### PR TITLE
Fix for JSON with docker inspect

### DIFF
--- a/deploystep
+++ b/deploystep
@@ -5,7 +5,7 @@ if [[ ! -f "$HOME/$APP/PORT" ]]; then
   # First deploy
   ID=$(docker run -d -p 5000 -e PORT=5000 $CONTAINER /bin/bash -c "/start web")
   echo $ID > "$HOME/$APP/CONTAINER"
-  PORT=$(docker inspect $ID | ruby -e 'require"json";puts JSON.parse(STDIN.read)["NetworkSettings"]["PortMapping"]["5000"]')
+  PORT=$(docker inspect $ID | ruby -e 'require"json";puts JSON.parse(STDIN.read)[0]["NetworkSettings"]["PortMapping"]["5000"]')
   echo $PORT > "$HOME/$APP/PORT"
   if [[ -f "$HOME/DOMAIN" ]]; then
     HOSTNAME="${APP/\//-}.$(< "$HOME/DOMAIN")"


### PR DESCRIPTION
`docker inspect` now puts an array around the JSON instead of making it a hash.

This pull request fixes it by getting the first element in the JSON.
