### PR TITLE
Fix bootstrap script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,7 +4,7 @@ DOKKU_STACK=${DOKKU_STACK:-"https://s3.amazonaws.com/progrium-dokku/progrium_bui
 apt-get install -y linux-image-extra-`uname -r`
 apt-get install -y python-software-properties
 add-apt-repository -y ppa:dotcloud/lxc-docker
-apt-get update && apt-get install -y lxc-docker git ruby nginx make dnsutils
+apt-get update && apt-get install -y lxc-docker git ruby nginx make curl dnsutils
 
 cd ~ && git clone ${DOKKU_REPO}
 cd dokku && make install


### PR DESCRIPTION
This PR makes three changes:

1 splits the kernel installation and the requirements for add-apt-repository into two steps
Installing the kernel can fail in vagrant. In my case, it failed to find that kernel.
2 replaces software-properties-common with python-software-properties
$ apt-file search add-apt-repository
python-software-properties: /usr/bin/add-apt-repository
3 adds curl to the list of packages to be installed as dependencies
This was missing in my vagrant VM.
