### PR TITLE
Explicitly install dnsutils during installation

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@ DOKKU_STACK=${DOKKU_STACK:-"http://s3.amazonaws.com/progrium-dokku/progrium_buil
 
 apt-get install -y linux-image-extra-`uname -r` software-properties-common
 add-apt-repository -y ppa:dotcloud/lxc-docker
-apt-get update && apt-get install -y lxc-docker git ruby nginx make
+apt-get update && apt-get install -y lxc-docker git ruby nginx make dnsutils
 
 cd ~ && git clone ${DOKKU_REPO}
 cd dokku && make install


### PR DESCRIPTION
The dig command at line 19 requires dnsutils.  It's part of ubuntu-standard, but my VM host doesn't install that by default.  Explicitly depending upon it fixes the installation.

I'm not sure what's up with the newline at the end of the file; I've not actually touched that, and no matter how many times I re-do this commit that still seems to happen.
