### PR TITLE
Escape variable in nginx post-deploy script

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -12,7 +12,7 @@ server {
   location    / {
     proxy_pass  http://$APP;
     proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade"; 
   }
 }


### PR DESCRIPTION
`$http_upgrade` is supposed to be a variable set by nginx. It was now substituted by nothing.
