### PR TITLE
Create separate copy target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ PLUGINHOOK_URL = https://s3.amazonaws.com/progrium-pluginhook/pluginhook_0.1.0_a
 
 all: install
 
-install: gitreceive sshcommand pluginhook
+install: gitreceive sshcommand pluginhook copy
+
+copy:
 	cp dokku /usr/local/bin/dokku
 	cp receiver /home/git/receiver
 	mkdir -p /var/lib/dokku/plugins


### PR DESCRIPTION
I found it useful to have a separate copy target in the `Makefile` while developing.
