### PR TITLE
[WIP] Add pre-deploy hook

### DIFF
--- a/dokku
+++ b/dokku
@@ -27,6 +27,7 @@ case "$1" in
   
   deploy)
     APP="$2"; IMAGE="$3"
+    pluginhook pre-deploy $APP $IMAGE
     if [[ ! -f "$HOME/$APP/PORT" ]]; then
       # First deploy
       id=$(docker run -d -p 5000 -e PORT=5000 $IMAGE /bin/bash -c "/start web")


### PR DESCRIPTION
Adds a pre-deploy hook passing the name of the app and the image. The
hook allows plugins to setup external resources (such as databases) and
modify the image (running pre-deployment script from the app) before the
application is deployed by dokku.

WIP because I'm not sure how to test it yet, since the semantics of the testcase would be different of what exists until now. My thoughts:
- create an extra dummy application
- add a test plugin that:
      - that creates a file in the container and persists the change
      - that creates a file outside the container to indicate the plugin has run

What do you think about the testing @progrium?

I also do not have the test setup running yet.
