### PR TITLE
Fix for nginx not reloading.

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -12,7 +12,7 @@ start on runlevel [2345]
 stop on runlevel [!2345]
 
 script
-  rm -rf /home/git/reload-nginx
+  [[ -f /home/git/reload-nginx ]] && rm -rf /home/git/reload-nginx
   echo | sudo -u git nc -l -U /home/git/reload-nginx && /etc/init.d/nginx reload
 end script
 respawn


### PR DESCRIPTION
This PR remove socket file before listening for reloads.

What is happening is that if there is an old socket file then reloads fails and the `reload-nginx` service fails.

This happens regularly upon a reboot of the server, for instance.
