### PR TITLE
support for fully qualified domain names not just subdomains

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -3,7 +3,13 @@ set -e
 APP="$1"; PORT="$2"
 
 if [[ -f "$HOME/VHOST" ]]; then
-  [[ "$APP" == *.* ]] && hostname="${APP/\//-}" || hostname="${APP/\//-}.$(< "$HOME/VHOST")"
+  VHOST=$(< "$HOME/VHOST")
+  SUBDOMAIN=${APP/%\.${VHOST}/}
+  if [[ "$APP" == *.* ]] && [[ "$SUBDOMAIN" == "$APP" ]]; then
+    hostname="${APP/\//-}"
+  else
+    hostname="${APP/\//-}.$VHOST"
+  fi
   cat<<EOF > $HOME/$APP/nginx.conf
 upstream $APP { server 127.0.0.1:$PORT; }
 server { 


### PR DESCRIPTION
Currently dokku is limited to subdomains of the `$HOME/VHOST`. This PR adds support for fully qualified domain names.

If the `$APP` contains a `.` character in it, then it will be treated as a full domain name, if not it will retain the old behaviour which is to be a subdomain of the `$HOME/VHOST`.

For example:

```
# pushes to blah.eugeneware.com
$ git remote add dokkufull git@myserver.com:blah.eugeneware.com
$ git push dokkufull master
```

or:

```
# pushes to blah.myserver.com (as myserver.com is the VHOST)
$ git remote add dokkusubdomain git@myserver.com:blah
$ git push dokkusubdomain master
```
