### PR TITLE
Rewrite nginx.conf files based on latest Docker dynamic port mappings on server reboot

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -23,13 +23,13 @@ script
     if /bin/nc -z 127.0.0.1 4243; then
      echo "Docker service successfully detected"
       for i in /home/git/*; do
-        if [ -f $i/CONTAINER ] && [ -f $i/nginx.conf ]; then
-          echo "Processing dokkup app: $i"
-          CONTAINER=`cat $i/CONTAINER`
-          PORT=`/usr/bin/docker inspect $CONTAINER | /usr/bin/tr '\n' ' ' | /bin/grep -oP "PortMapping.*?}" | /usr/bin/cut -d'"' -f5`
-          if [ "$PORT" -gt 0 ] 2>/dev/null; then
-            /bin/sed -i.bak -r "s/server 127.0.0.1\:[0-9]+/server 127.0.0.1:${PORT}/" $i/nginx.conf
-            echo "Rewritten $i/nginx.conf using PORT=$PORT"
+        if [ -f \$i/CONTAINER ] && [ -f \$i/nginx.conf ]; then
+          echo "Processing dokkup app: \$i"
+          CONTAINER=\`cat \$i/CONTAINER\`
+          PORT=\`/usr/bin/docker inspect \$CONTAINER | /usr/bin/tr '\n' ' ' | /bin/grep -oP "PortMapping.*?}" | /usr/bin/cut -d'"' -f5\`
+          if [ "\$PORT" -gt 0 ] 2>/dev/null; then
+            /bin/sed -i.bak -r "s/server 127.0.0.1\:[0-9]+/server 127.0.0.1:\${PORT}/" \$i/nginx.conf
+            echo "Rewritten \$i/nginx.conf using PORT=\$PORT"
           fi
         fi
       done
@@ -50,3 +50,4 @@ sed -i 's/# server_names_hash_bucket_size/server_names_hash_bucket_size/' /etc/n
 
 /etc/init.d/nginx start
 start nginx-reloader || true
+start dokku || true


### PR DESCRIPTION
When a server reboots all the dynamic port mappings from Docker get reset leading to `502 bad gateway` errors in Nginx, or even worse: the wrong servers displaying for different host names.

This PR addresses the issue in https://github.com/progrium/dokku/issues/82

It creates a new upstart service called `dokku.conf` which is run after `docker` that will iterate through the dokku apps, find the `CONTAINER` IDs, find the port mapping, rewrite the nginx.conf files and then reload nginx.
