### PR TITLE
post-deploy nginx template fix

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -10,7 +10,7 @@ server {
   listen      80;
   server_name $hostname;
   location    / {
-    proxy_pass  http://$APP;
+    proxy_pass  http://127.0.0.1:$PORT;
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade"; 


### PR DESCRIPTION
proxy_pass command in post-deploy file is now correct and will redirect traffic correctly.

Solving issues https://github.com/progrium/dokku/issues/48 and https://github.com/progrium/dokku/issues/82
