### PR TITLE
check if aufs is loaded before running modprobe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ docker: aufs
 	sleep 2 # give docker a moment i guess
 
 aufs:
-	modprobe aufs || apt-get install -y linux-image-extra-`uname -r`
+	lsmod | grep aufs || modprobe aufs || apt-get install -y linux-image-extra-`uname -r`
 
 stack:
 	@docker images | grep progrium/buildstep || curl ${STACK_URL} | gunzip -cd | docker import - progrium/buildstep


### PR DESCRIPTION
This PR changes dokku's aufs Makefile target so that we try to check if the AUFS module is loaded.
Some virtualized environments will fail when running `modprobe`, but we should always be able to run `lsmod` to check if the module is loaded.

This PR doesn't add extra error checking and handling, but it prevents the Makefile from throwing an error when AUFS is loaded and modprobe can't attempt to load it.
