### PR TITLE
I want to add env variables to new instances

### DIFF
--- a/dokku
+++ b/dokku
@@ -34,11 +34,13 @@ case "$1" in
 
   release)
     APP="$2"; IMAGE="$3"
+    pluginhook pre-release $APP $IMAGE
     if [[ -f "$HOME/$APP/ENV" ]]; then
       id=$(cat "$HOME/$APP/ENV" | docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/app-env.sh")
       test $(docker wait $id) -eq 0
       docker commit $id $IMAGE > /dev/null
     fi
+    pluginhook post-release $APP $IMAGE
     ;;
 
   deploy)


### PR DESCRIPTION
I want all my deployments to have access to postgres, thus I'm creating a plugin which sets up a new user with access to a new database (on a postgres server in a different container). I want to expose the database access with an env variable, just like heroku does. To me it looks like release is the best place to put this hook.
