### PR TITLE
Add X-Forwarded-For header to send client IP address to backend

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -21,6 +21,7 @@ server {
     proxy_set_header Upgrade \$http_upgrade;
     proxy_set_header Connection "upgrade"; 
     proxy_set_header Host \$http_host;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
   }
 }
 EOF


### PR DESCRIPTION
I realized my apps were not getting the real IP address so I made a small change to push the X-Forwarded-For header to the backend app to be handled as necessary. 

This is a simple change, and might also want to be applied to the SSL pull request that is pending as well.
