### PR TITLE
add missing git dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ plugins: pluginhook docker
 dependencies: gitreceive sshcommand pluginhook docker stack
 
 gitreceive:
+	apt-get -y install git
 	wget -qO /usr/local/bin/gitreceive ${GITRECEIVE_URL}
 	chmod +x /usr/local/bin/gitreceive
 	test -f /home/git/receiver || gitreceive init


### PR DESCRIPTION
dokku was not working properly with vagrant because git was not installed via apt-get
