### PR TITLE
Cannot download docker deb file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GITRECEIVE_URL ?= https://raw.github.com/progrium/gitreceive/master/gitreceive
 SSHCOMMAND_URL ?= https://raw.github.com/progrium/sshcommand/master/sshcommand
 PLUGINHOOK_URL ?= https://s3.amazonaws.com/progrium-pluginhook/pluginhook_0.1.0_amd64.deb
-DOCKER_URL ?= https://launchpad.net/~dotcloud/+archive/lxc-docker/+files/lxc-docker_0.4.8-1_amd64.deb
+DOCKER_URL ?= https://launchpad.net/~dotcloud/+archive/lxc-docker/+files/lxc-docker_0.5.0-1_amd64.deb
 DOCKER_BIN ?= https://s3.amazonaws.com/get.docker.io/builds/Linux/x86_64/docker-1004d57b85fc3714b089da4c457228690f254504
 STACK_URL ?= https://s3.amazonaws.com/progrium-dokku/progrium_buildstep.tgz
 
@@ -33,8 +33,8 @@ pluginhook:
 	dpkg -i /tmp/pluginhook_0.1.0_amd64.deb
 
 docker: aufs
-	wget -qO /tmp/lxc-docker_0.4.8-1_amd64.deb ${DOCKER_URL}
-	dpkg --force-depends -i /tmp/lxc-docker_0.4.8-1_amd64.deb && apt-get install -f -y
+	wget -qO /tmp/lxc-docker_0.5.0-1_amd64.deb ${DOCKER_URL}
+	dpkg --force-depends -i /tmp/lxc-docker_0.5.0-1_amd64.deb && apt-get install -f -y
 	# newer docker 0.4.8 binary
 	stop docker
 	wget -qO /usr/bin/docker ${DOCKER_BIN}


### PR DESCRIPTION
I can't download docker deb file.
`https://launchpad.net/~dotcloud/+archive/lxc-docker/+files/lxc-docker_0.4.8-1_amd64.deb`
So, I updated docker version.
