### PR TITLE
issue #138: added wildcard support

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -15,7 +15,7 @@ if [[ -f "$HOME/VHOST" ]]; then
 
   if [[ -f "$SSL/server.crt" ]] && [[ -f "$SSL/server.key" ]]; then
     SSL_INUSE="$SSL"
-  elif  [[ -f "$WILDCARD_SSL/server.crt" ]] && [[ -f "$WILDCARD_SSL/server.key" ]]; then
+  elif  [[ -f "$WILDCARD_SSL/server.crt" ]] && [[ -f "$WILDCARD_SSL/server.key" ]] && [[ $hostname = `openssl x509 -in $WILDCARD_SSL/server.crt -noout -subject | tr '/' '\n' | grep CN= | cut -c4-` ]]; then
     SSL_INUSE="$WILDCARD_SSL"
   fi
 


### PR DESCRIPTION
So, it should be good enought - it tries to find `local` certificates, use ones if they exist; it fallbacks for `wildcard` certificates, use ones if exists; otherwise just `no_ssl` config;
