### PR TITLE
Hint about build packs requiring config files.  Closes GH-141

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ That's it!
 
 ## Deploy an App
 
-Right now Buildstep supports buildpacks for Node.js, Ruby, Python, [and more](https://github.com/progrium/buildstep#supported-buildpacks). It's not hard to add more, [go add more](https://github.com/progrium/buildstep#adding-buildpacks)! Let's deploy
-the Heroku Node.js sample app. All you have to do is add a remote to name the app. It's created on-the-fly.
+Right now Buildstep supports buildpacks for Node.js, Ruby, Python, [and more](https://github.com/progrium/buildstep#supported-buildpacks). It's not hard to add more, [go add more](https://github.com/progrium/buildstep#adding-buildpacks)!
+Please check the documentation for your particular build pack as you may need to include configuration files (such as a Procfile) in your project root.
+Let's deploy the Heroku Node.js sample app. All you have to do is add a remote to name the app. It's created on-the-fly.
 
     $ cd node-js-sample
     $ git remote add progrium git@progriumapp.com:node-js-app


### PR DESCRIPTION
Add a hint to the README that buildpacks may require special configuration files (such as a Procfile) in order to deploy properly.
