### PR TITLE
Fix bootstrap on clean install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 export DOKKU_REPO=${DOKKU_REPO:-"https://github.com/progrium/dokku.git"}
 
 apt-get update
-apt-get install -y git make curl
+apt-get install -y git make curl software-properties-common
 
 cd ~ && test -d dokku || git clone $DOKKU_REPO
 cd dokku && test $DOKKU_BRANCH && git checkout origin/$DOKKU_BRANCH || true


### PR DESCRIPTION
On a clean Ubuntu 13.04 install, the bootstrap script fails with:
make: apt-add-repository: Command not found
make: **\* [docker] Error 127

This happens because 'software-properties-common' needs to be installed.

This fixes #157
