### PR TITLE
Build image from Dockerfile instead of curling S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GITRECEIVE_URL ?= https://raw.github.com/progrium/gitreceive/master/gitreceive
 SSHCOMMAND_URL ?= https://raw.github.com/progrium/sshcommand/master/sshcommand
 PLUGINHOOK_URL ?= https://s3.amazonaws.com/progrium-pluginhook/pluginhook_0.1.0_amd64.deb
-STACK_URL ?= https://s3.amazonaws.com/progrium-dokku/progrium_buildstep.tgz
+STACK_URL ?= github.com/progrium/buildstep
 
 all: dependencies stack install plugins
 
@@ -40,7 +40,7 @@ aufs:
 	lsmod | grep aufs || modprobe aufs || apt-get install -y linux-image-extra-`uname -r`
 
 stack:
-	@docker images | grep progrium/buildstep || curl ${STACK_URL} | gunzip -cd | docker import - progrium/buildstep
+	@docker images | grep progrium/buildstep || docker build -t progrium/buildstep ${STACK_URL}
 
 count:
 	@echo "Core lines:"


### PR DESCRIPTION
Avoid the download from S3 by building the container in docker instead of importing it.
The final container is slightly lighter.

This PR has to be merged along with https://github.com/progrium/buildstep/pull/24
