### PR TITLE
Redeploy apps on reboot, fixes #82

### DIFF
--- a/dokku
+++ b/dokku
@@ -77,6 +77,15 @@ case "$1" in
     pluginhook install
     ;;
 
+  # temporary hack for https://github.com/progrium/dokku/issues/82
+  deploy:all)
+    for app in $(ls -d $HOME/*/); do
+      APP=$(basename $app);
+      IMAGE="app/$APP"
+      dokku deploy $APP $IMAGE
+    done
+    ;;
+
   help)
     cat<<EOF | pluginhook commands help | sort
     help            Print the list of commands

--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -3,3 +3,18 @@
 sed -i 's/docker -d$/docker -d -r=true/' /etc/init/docker.conf
 
 echo $HOSTNAME > /home/git/HOSTNAME
+
+
+# temporary hack for https://github.com/progrium/dokku/issues/82
+# redeploys all apps after a reboot
+cat<<EOF > /etc/init/dokku-redeploy.conf
+description "Dokku app redeploy service"
+
+start on (started docker)
+
+script
+  sleep 2 # give docker some time
+  sudo -i -u git /usr/local/bin/dokku deploy:all
+end script
+EOF
+


### PR DESCRIPTION
It's a different approach from https://github.com/progrium/dokku/pull/88 and https://github.com/progrium/dokku/pull/94, but it's shorter, and we hope to remove it in the future (see https://github.com/progrium/dokku/issues/82#issuecomment-22781098). A possible + of this approach is that other plugins also get to run the pre- and post-deploy steps.
