### PR TITLE
Add deletion command in standard plugin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@
 #
 Alexander <iam.asm89@gmail.com>
 Alexander Beletsky <alexander.beletsky@gmail.com>
+Alexis Gavoty <kload@kload.fr>
 Felipe Coury <felipe.coury@gmail.com>
 Jeff Lindsay <progrium@gmail.com>
 Leo Unbekandt <leo@unbekandt.eu>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ like this from your local machine:
 
     $ cat ~/.ssh/id_rsa.pub | ssh progriumapp.com "sudo gitreceive upload-key progrium"
 
+In addition, if you want to be able to remotely execute dokku commands:
+
+    $ cat ~/.ssh/id_rsa.pub | ssh progriumapp.com "sshcommand acl-add dokku progrium"
+
 That's it!
 
 ## Deploy an App
@@ -67,18 +71,13 @@ https://github.com/progrium/dokku/wiki/Plugins
 
 ## Removing a deployed app
 
-Currently this is a manual process.
+From client side:
 
-To remove an app, ssh to the server, then run:
+    $ ssh dokku@progriumapp.com delete myapp
 
-    $ sudo docker ps
-    # Then from the list, take repository name of your app and run:
-    $ sudo docker stop app/node-js-sample
-    # To find the ids of images to delete, run:
-    $ sudo docker images
-    # Then from that list, take the IDs corresponding to your app, and
-    # those corresponding to no tag at all, and for each run:
-    $ sudo docker rmi 123456789
+Or ssh to the server, then execute:
+
+    $ dokku delete myapp
 
 ## Environment setup
 

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -19,10 +19,35 @@ set -e; case "$1" in
     docker run $IMAGE /exec "$@"
     ;;
 
+  delete)
+    # Check if an app is specified
+    if [[ -z $2 ]]; then
+        echo "Please specify an app to delete"
+        exit 1
+    fi
+    APP="$2"; IMAGE="app/$APP"
+    APP_DIR="/home/git/$APP"
+    # Check if the app directory exists
+    if [[ ! -d $APP_DIR ]]; then
+        echo "App does not exist"
+        exit 1
+    fi
+    pluginhook pre-delete $APP
+    ID=$(< "$APP_DIR/CONTAINER")
+    # Shutdown the app
+    docker stop $ID > /dev/null
+    # Delete image
+    docker images | grep $IMAGE | awk '{print $3}' | xargs docker rmi &> /dev/null &
+    # Delete app repository
+    rm -r "$APP_DIR" > /dev/null
+    pluginhook post-delete $APP
+    ;;
+
   help)
     cat && cat<<EOF
     logs <app>      Show the last logs for an application
     run <app> <cmd> Run a command in the environment of an application
+    delete <app>    Delete an application
 EOF
     ;;
 

--- a/plugins/nginx-vhosts/post-delete
+++ b/plugins/nginx-vhosts/post-delete
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+nc -U $HOME/reload-nginx


### PR DESCRIPTION
Simple command to delete app.

Usage:

```
dokku delete <app>
```

It will:
- Stop app in docker
- Delete docker images and container
- Delete app repo ( /home/git/app )
- Reload nginx

Ref. #124
