### PR TITLE
Add nginx configure hook

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -69,6 +69,7 @@ server {
 }
 EOF
   fi
+  pluginhook nginx-pre-reload $APP
   nc -U $HOME/reload-nginx
   echo "$hostname" > "$HOME/$APP/VHOST"
 fi


### PR DESCRIPTION
This adds a pluginhook for nginx-configure to be called after the main nginx configuration is called and before nginx is reloaded. This will allow other plugins to modify the nginx configuration
