### PR TITLE
Update README with "new timing"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ best to use a fresh VM. The bootstrapper will install everything it needs.
 
     $ wget -qO- https://raw.github.com/progrium/dokku/master/bootstrap.sh | sudo bash
 
-This may take around 5 minutes. Certainly better than the several hours it takes to bootstrap Cloud Foundry.
+This may take from 30 minutes to 1 hours to complete, certainly better than the several hours it takes to bootstrap Cloud Foundry.
 
 ## Configuring
 


### PR DESCRIPTION
After the changes introduced on https://github.com/progrium/dokku/pull/168 it no longer takes 5 minutes to bootstrap the machine.

Down here on a 35mb connection it took around 48 minutes to install the dependencies and build the base image, I'm guessing something around 30 minutes to 1 hour depending on users internet connection, maybe less but I'm pretty sure it won't be just 5 minutes :D
