### PR TITLE
Set X-Forwarded-Proto Header

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -48,6 +48,8 @@ server {
     proxy_set_header Host \$http_host;
     proxy_set_header X-Forwarded-Proto \$scheme;
     proxy_set_header X-Forwarded-For \$remote_addr;
+    proxy_set_header X-Forwarded-Port \$server_port;
+    proxy_set_header X-Request-Start \$msec;
   }
 }
 EOF
@@ -66,6 +68,8 @@ server {
     proxy_set_header Host \$http_host;
     proxy_set_header X-Forwarded-Proto \$scheme;
     proxy_set_header X-Forwarded-For \$remote_addr;
+    proxy_set_header X-Forwarded-Port \$server_port;
+    proxy_set_header X-Request-Start \$msec;
   }
 }
 EOF


### PR DESCRIPTION
Heroku passes the [X-Forwarded-Proto header](https://devcenter.heroku.com/articles/http-routing#heroku-headers) to indicate the protocol of
the incoming request. Ruby's rack [relies on this header](https://github.com/rack/rack/blob/master/lib/rack/request.rb#L77) to
determine if a request is HTTPS.

Also, the X-Scheme header was removed to eliminate redundant passing of
the scheme.
