### PR TITLE
Handle pipe failures

### DIFF
--- a/dokku
+++ b/dokku
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -o pipefail
 export PLUGIN_PATH=${PLUGIN_PATH:="/var/lib/dokku/plugins"}
 case "$1" in
   receive)

--- a/receiver
+++ b/receiver
@@ -1,2 +1,2 @@
 #!/bin/bash
-set -e; cat | dokku receive $1 | sed -u "s/^/"$'\e[1G'"/"
+set -e; set -o pipefail; cat | dokku receive $1 | sed -u "s/^/"$'\e[1G'"/"


### PR DESCRIPTION
Sometimes when dokku hook fails it doesn't exit with not zero status code. This pull request fixed this on my side.
