### PR TITLE
Update Makefile: Do not try to install on "make" or "make all"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,12 @@ SSHCOMMAND_URL ?= https://raw.github.com/progrium/sshcommand/master/sshcommand
 PLUGINHOOK_URL ?= https://s3.amazonaws.com/progrium-pluginhook/pluginhook_0.1.0_amd64.deb
 STACK_URL ?= github.com/progrium/buildstep
 
-all: dependencies stack install plugins
+all:
+	# Type "make install" to install.
 
-install:
+install: dependencies stack copyfiles plugins
+
+copyfiles:
 	cp dokku /usr/local/bin/dokku
 	cp receiver /home/git/receiver
 	mkdir -p /var/lib/dokku/plugins

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ the repository and calling the install script. Example:
 
     $ git clone https://github.com/yourusername/dokku.git
     $ cd dokku
-    $ sudo make all
+    $ sudo make install
 
 The `Makefile` allows source URLs to be overridden to include customizations from your own
 repositories. The DOCKER_URL, GITRECEIVE_URL, PLUGINHOOK_URL, SSHCOMMAND_URL and STACK_URL
 environment variables may be set to override the defaults (see the `Makefile` for how these
 apply). Example:
 
-    $ sudo GITRECEIVE_URL=https://raw.github.com/yourusername/gitreceive/master/gitreceive make all
+    $ sudo GITRECEIVE_URL=https://raw.github.com/yourusername/gitreceive/master/gitreceive make install
 
 ## Advanced installation (bootstrap a server from your own repository)
 


### PR DESCRIPTION
To be consistent with usual makefile usage and to not surprise people too much, only do permanent changes to the system when explicitely prompted to do so via "make install" instead of on any "make" or "make all" invocation, which is usually used for _building_, not _installing_ things.
