### PR TITLE
bootstrap.sh: Add shebang, Error out when apt-get is not found

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,14 @@
+#!/usr/bin/env sh
+
 set -e
 export DEBIAN_FRONTEND=noninteractive
 export DOKKU_REPO=${DOKKU_REPO:-"https://github.com/progrium/dokku.git"}
+
+if ! which apt-get &>/dev/null
+then
+	echo "This installation script requres apt-get. For manual installation instructions, consult https://github.com/progrium/dokku ."
+	exit 1
+fi
 
 apt-get update
 apt-get install -y git make curl software-properties-common


### PR DESCRIPTION
...to fail more gracefully on systems without apt.
