### PR TITLE
receiver: fix shebang for non-standard bash locations

### DIFF
--- a/dokku
+++ b/dokku
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 export PLUGIN_PATH=${PLUGIN_PATH:="/var/lib/dokku/plugins"}

--- a/receiver
+++ b/receiver
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e; set -o pipefail; cat | dokku receive $1 | sed -u "s/^/"$'\e[1G'"/"


### PR DESCRIPTION
BTW, why are we using bash for this instead of the standard sh, anyway?
