### PR TITLE
Keep vhost

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -16,6 +16,7 @@ if [[ -f "$HOME/VHOST" ]]; then
         hostname="${APP/\//-}.$VHOST"
       fi
   fi
+  
   if [[ -f "$SSL/server.crt" ]] && [[ -f "$SSL/server.key" ]]; then
     SSL_INUSE="$SSL"
   elif  [[ -f "$WILDCARD_SSL/server.crt" ]] && [[ -f "$WILDCARD_SSL/server.key" ]]; then


### PR DESCRIPTION
Made it so that existing VHOST files will be kept/honored. This keeps a definitive state for the hostname and allows adding custom hostnames. i.e. <app>.herokuapps.com <app>.com in the VHOST file to use every time the app builds. 
