### PR TITLE
Keep .heroku and build on the existing image.

### DIFF
--- a/dokku
+++ b/dokku
@@ -23,7 +23,12 @@ case "$1" in
 
   build)
     IMAGE="$2"
-    id=$(cat | docker run -i -a stdin progrium/buildstep /bin/bash -c "mkdir -p /app && tar -xC /app")
+    if docker images | grep -q "$IMAGE "; then
+        starting_image=$IMAGE
+    else
+        starting_image='progrium/buildstep'
+    fi
+    id=$(cat | docker run -i -a stdin $starting_image /bin/bash -c "find /app -mindepth 1 -maxdepth 1 -not -name .heroku | xargs rm -rf 2>/dev/null && mkdir -p /app && tar -xC /app")
     test $(docker wait $id) -eq 0
     docker commit $id $IMAGE > /dev/null
     id=$(docker run -d $IMAGE /build/builder)


### PR DESCRIPTION
Closes issue #225

Basically runs the builder on the last version of the image with the everything in the app directory but .heroku deleted. This makes it so that if the environment already exists it simply builds on it (tested in python). If you want to force rebuild you simply delete the image in docker. 
