### PR TITLE
Added temping and chepointing

### DIFF
--- a/dokku
+++ b/dokku
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 set -o pipefail
+TEMP_PREFIX='DOKKU_TEMP'
 export PLUGIN_PATH=${PLUGIN_PATH:="/var/lib/dokku/plugins"}
 case "$1" in
   receive)


### PR DESCRIPTION
Does basically two things:

1) Uses temp image names during the build/release phase (where things often go wrong) to protect the current image from being committed by a corrupt build

2) Added checkpointing: Alternative PR for #229 and closes #225, see discussion on on #229. Basically checkpoint saves the first build as its own image checkpoint/:<app_name> and all subsequent builds use said checkpoint if it is available. This has a couple benefits
    - Reduces build times **dramatically**, only changed dependencies install (at least in python)
    - Avoids the 42 layer AUFS limit
    - You can destroy the image at any time to build from new, you'd really only have to do this when your current build gets really far from dependency wise from the checkpoint

Note: I didn't get a chance to test this, so please do (too busy ATM) however it is partially from my fork which I know works. 
