### PR TITLE
Global and local env configuration

### DIFF
--- a/dokku
+++ b/dokku
@@ -33,13 +33,18 @@ case "$1" in
     ;;
 
   release)
-    APP="$2"; IMAGE="$3"
+    APP="$2"; IMAGE="$3"; ENV="";
     pluginhook pre-release $APP $IMAGE
-    if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
-      id=$(cat "$DOKKU_ROOT/$APP/ENV" | docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/app-env.sh")
-      test $(docker wait $id) -eq 0
-      docker commit $id $IMAGE > /dev/null
+    if [[ -f "$DOKKU_ROOT/ENV" ]]; then
+      ENV+=$(< "$DOKKU_ROOT/ENV")
     fi
+    if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
+      ENV+=$(< "$DOKKU_ROOT/$APP/ENV")
+    fi
+    id=$(echo $ENV | docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/app-env.sh")
+    test $(docker wait $id) -eq 0
+    docker commit $id $IMAGE > /dev/null
+
     pluginhook post-release $APP $IMAGE
     ;;
 


### PR DESCRIPTION
The applications I deploy with dokku are almost identical with their ENV setup. Changing common things, like DB connection strings thought all application is a bit painful thing.

This PR introduce global and local ENV configuration.

`/home/dokku/ENV` - global one, shared among all applications.
`/home/dokku/$APP/ENV` - local one, contains app specific ENV variables + able to override global ones.
