### PR TITLE
Set Ubuntu Raring cloud box `--ostype=Ubuntu_64` to fix virtualbox boot

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,9 @@ Vagrant::configure("2") do |config|
 
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    # Ubuntu's Raring 64-bit cloud image is set to a 32-bit Ubuntu OS type by
+    # default in Virtualbox and thus will not boot. Manually override that.
+    vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
   end
 
   config.vm.provision :shell, :inline => "apt-get -y install git && cd /root/dokku && #{make_cmd}"


### PR DESCRIPTION
For Mac OS 10.6 using Virtualbox 4.2.18 and Vagrant 1.3.5, booting the current Ubuntu 13.04 (Raring) cloud image fails because the box is set to 32-bit Ubuntu by default. Thus, we manually specify the OS type to Ubuntu 64-bit for the Virtualbox provider. This bug may be specific to my platform, but the fix is innocent enough to generalize to all platforms.
