### PR TITLE
Deprecated statement in installation guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ This may take around 5 minutes. Certainly better than the several hours it takes
 
 Set up a domain and a wildcard domain pointing to that host. Make sure `/home/dokku/VHOST` is set to this domain. By default it's set to whatever the hostname the host has. This file only created if the hostname can be resolved by dig (`dig +short $HOSTNAME`). Otherwise you have to create the file manually and set it to your prefered domain. If this file still not present when you push your app, dokku will publish the app with a port number (i.e. `http://example.com:49154` - note the missing subdomain).
 
-You'll have to add a public key associated with a username as it says at the end of the bootstrapper. You'll do something
-like this from your local machine:
+You'll have to add a public key associated with a username by doing something like this from your local machine:
 
     $ cat ~/.ssh/id_rsa.pub | ssh progriumapp.com "sudo sshcommand acl-add dokku progrium"
 


### PR DESCRIPTION
"..as it says at the end of the bootstrapper" is deprecated.

Instead it says:
"Almost done! For next steps on configuration:
  https://github.com/progrium/dokku#configuring"
after bootstrapping..
