### PR TITLE
Make targets in the Makefile part of PHONY.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ PLUGINHOOK_URL ?= https://s3.amazonaws.com/progrium-pluginhook/pluginhook_0.1.0_
 STACK_URL ?= github.com/progrium/buildstep
 PREBUILT_STACK_URL ?= https://s3.amazonaws.com/progrium-dokku/progrium_buildstep_c30652f59a.tgz
 
+.PHONY: all install copyfiles plugins dependencies sshcommand pluginhook docker aufs stack count
+
 all:
 	# Type "make install" to install.
 


### PR DESCRIPTION
One line PR :)
Just makes the target in the Makefile "PHONY".
I had a was hacking on pluginhook, and had it's sources in my dokku tree. This caused `make install` to not install the deb.
