### PR TITLE
Don't redirect to from HTTP to HTTPS

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -26,7 +26,18 @@ upstream $APP { server 127.0.0.1:$PORT; }
 server {
   listen      80;
   server_name $hostname;
-  return 301 https://\$host\$request_uri;
+
+  location    / {
+    proxy_pass  http://$APP;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host \$http_host;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_set_header X-Forwarded-For \$remote_addr;
+    proxy_set_header X-Forwarded-Port \$server_port;
+    proxy_set_header X-Request-Start \$msec;
+  }
 }
 
 server {


### PR DESCRIPTION
Let applications redirect basing on `X-Forwarded-Proto` header.

Example of a usecase where this would be better than redirecting by
default: dokku running at `apps.<root-domain>`, with a wildcard
certificate for `*.<root-domain>` set up. Applications which require SSL
could be deployed as `<subdomain>.<root-domain>` (by setting DNS up to
point to dokku host and using custom domain). Regular applications could
be deployed as usual.
