### PR TITLE
For #313: Do not specify both `$APP` and `$IMAGE` for base commands.

### DIFF
--- a/dokku
+++ b/dokku
@@ -18,44 +18,44 @@ case "$1" in
     echo "-----> Cleaning up ..."
     dokku cleanup
     echo "-----> Building $APP ..."
-    cat | dokku build $APP $IMAGE
+    cat | dokku build $APP
     echo "-----> Releasing $APP ..."
-    dokku release $APP $IMAGE
+    dokku release $APP
     echo "-----> Deploying $APP ..."
-    dokku deploy $APP $IMAGE
+    dokku deploy $APP
     echo "=====> Application deployed:"
     echo "       $(dokku url $APP)"
     echo
     ;;
 
   build)
-    APP="$2"; IMAGE="$3"; CACHE_DIR="$DOKKU_ROOT/$APP/cache"
+    APP="$2"; IMAGE="app/$APP"; CACHE_DIR="$DOKKU_ROOT/$APP/cache"
     id=$(cat | docker run -i -a stdin progrium/buildstep /bin/bash -c "mkdir -p /app && tar -xC /app")
     test $(docker wait $id) -eq 0
     docker commit $id $IMAGE > /dev/null
     [[ -d $CACHE_DIR ]] || mkdir $CACHE_DIR
-    pluginhook pre-build $APP $IMAGE
+    pluginhook pre-build $APP
     id=$(docker run -d -v $CACHE_DIR:/cache $IMAGE /build/builder)
     docker attach $id
     test $(docker wait $id) -eq 0
     docker commit $id $IMAGE > /dev/null
-    pluginhook post-build $APP $IMAGE
+    pluginhook post-build $APP
     ;;
 
   release)
-    APP="$2"; IMAGE="$3"
-    pluginhook pre-release $APP $IMAGE
+    APP="$2"; IMAGE="app/$APP"
+    pluginhook pre-release $APP
     if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
       id=$(cat "$DOKKU_ROOT/$APP/ENV" | docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/app-env.sh")
       test $(docker wait $id) -eq 0
       docker commit $id $IMAGE > /dev/null
     fi
-    pluginhook post-release $APP $IMAGE
+    pluginhook post-release $APP
     ;;
 
   deploy)
-    APP="$2"; IMAGE="$3"
-    pluginhook pre-deploy $APP $IMAGE
+    APP="$2"; IMAGE="app/$APP"
+    pluginhook pre-deploy $APP
 
     # kill the app when running
     if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
@@ -93,8 +93,7 @@ case "$1" in
   deploy:all)
     for app in $(ls -d $DOKKU_ROOT/*/); do
       APP=$(basename $app);
-      IMAGE="app/$APP"
-      dokku deploy $APP $IMAGE
+      dokku deploy $APP
     done
     ;;
 

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -49,13 +49,13 @@ config_styled_hash () {
 }
 
 config_restart_app() {
-  APP="$1"; IMAGE="app/$APP"
+  APP="$1";
 
   echo "-----> Releasing $APP ..."
-  dokku release $APP $IMAGE
+  dokku release $APP
   echo "-----> Release complete!"
   echo "-----> Deploying $APP ..."
-  dokku deploy $APP $IMAGE
+  dokku deploy $APP
   echo "-----> Deploy complete!"
 }
 


### PR DESCRIPTION
As discussed in #313, dokku base commands such as build, release, and deploy require specifying both `$APP` and `$IMAGE` as arguments where `IMAGE="app/$APP"`. Thus, the `$IMAGE` parameter is currently redudant.

This patch removes the need to specify `$IMAGE` for these base commands and is backwards compatible. If, in the future, the base commands expect an `$IMAGE` different than `app/$APP`, then the `$IMAGE` parameter will be re-added for those specific commands.

All tests currently pass.
