### PR TITLE
Attach stdin when running `dokku run`.

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -51,7 +51,7 @@ case "$1" in
         exit 1
     fi
     shift 2
-    docker run -i -t -a stdout -a stderr $IMAGE /exec "$@"
+    docker run -i -t -a stdin -a stdout -a stderr $IMAGE /exec "$@"
     ;;
 
   url)


### PR DESCRIPTION
I can no longer interact with the process when running `dokku run`. Is this expected behaviour? If so how is it possible to run commands which need an input?

Seems to have been a regression with f92e7a59d906e6c4dfc5406e7928c3b29647a1d5 ?
