### PR TITLE
Disable pseudo-TTY allocation for getting the URL in `test_deploy`.

### DIFF
--- a/tests/test_deploy
+++ b/tests/test_deploy
@@ -13,7 +13,11 @@ git commit -m 'initial commit'
 REPO="test-$(basename $APP)-$RANDOM"
 git remote add target dokku@$TARGET:$REPO
 git push target master
-URL=$(ssh dokku@$TARGET url $REPO)$FORWARDED_PORT
+# Disable Pseudo-TTY allocation or else $FORWARDED_PORT cannot be appended to
+# the url correctly.
+# e.g. (with RequestTTY): :8080//test-nodejs-express-10694.dokku.me
+#      (disable PTY): http://test-nodejs-express-10694.dokku.me:8080
+URL="$(ssh -T dokku@$TARGET url $REPO)$FORWARDED_PORT"
 sleep 2
 ./check_deploy $URL && echo "-----> Deploy success!" || {
   sleep 4


### PR DESCRIPTION
Added `ssh -T` flag when getting url from dokku command over ssh since
without it, the returned string cannot be appended to correctly. For
example:
- (with PTY): :8080//test-nodejs-express-10694.dokku.me
- (disable PTY): http://test-nodejs-express-10694.dokku.me:8080

EDIT: This applies when user has `RequestTTY yes` in their `~/.ssh/config` or when running vagrant tests.
