### PR TITLE
Drop root privileges if necessary.

### DIFF
--- a/dokku
+++ b/dokku
@@ -7,6 +7,11 @@ export PLUGIN_PATH=${PLUGIN_PATH:="/var/lib/dokku/plugins"}
 
 [[ $DOKKU_TRACE ]] && set -x
 
+if [[ $(id -un) != "dokku" && $1 != "plugins-install" ]]; then
+  sudo -u dokku -H $0 "$@"
+  exit
+fi
+
 case "$1" in
   receive)
     APP="$2"; IMAGE="app/$APP"


### PR DESCRIPTION
This makes it possible to safely call dokku commands as root.
`plugins-install` is an exception, as it requires root privileges.

Unfortunately, this means that plugins cannot create commands that require root privileges. They must call `sudo` on an individual basis.
