### PR TITLE
nginx vhost ipv6 compatibility

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -24,14 +24,14 @@ if [[ -f "$DOKKU_ROOT/VHOST" ]]; then
   cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf
 upstream $APP { server 127.0.0.1:$PORT; }
 server {
-  listen      [::]:80;
+  listen      [::]:80 ipv6only=on;
   listen      80;
   server_name $hostname;
   return 301 https://\$host\$request_uri;
 }
 
 server {
-  listen      [::]:443;
+  listen      [::]:443 ipv6only=on;
   listen      443;
   server_name $hostname;
 
@@ -62,7 +62,7 @@ else
   cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf
 upstream $APP { server 127.0.0.1:$PORT; }
 server {
-  listen      [::]:80;
+  listen      [::]:80 ipv6only=on;
   listen      80;
   server_name $hostname;
   location    / {


### PR DESCRIPTION
IPv6 Compatibility (Nginx Default Site is IPv6 compatible, resulting in not-working vhosts when AAAA DNS entry is set)
