### PR TITLE
For #304: Add $DOCKER_ARGS and docker-args pluginhook to dokku deploy and command run.

### DIFF
--- a/dokku
+++ b/dokku
@@ -63,7 +63,7 @@ case "$1" in
     fi
 
     # start the app
-    DOCKER_ARGS=$(pluginhook docker-args $APP)
+    DOCKER_ARGS=$(: | pluginhook docker-args $APP)
     id=$(docker run -d -p 5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
     echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
     port=$(docker port $id 5000 | sed 's/0.0.0.0://')

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -59,7 +59,7 @@ case "$1" in
     fi
     shift 2
 
-    DOCKER_ARGS=$(pluginhook docker-args $APP)
+    DOCKER_ARGS=$(: | pluginhook docker-args $APP)
     docker run -i -t $DOCKER_ARGS $IMAGE /exec "$@"
     ;;
 


### PR DESCRIPTION
Solves https://github.com/progrium/dokku/issues/304 .

Without much code I think it opens up some more advanced options, however the default stays heroku-ish in keeping with the theme of dokku.

Should probably have some documentation somewhere with a pluginhook example so people know they need to read from stdin, append or do whatever they want (with access to $APP as $1), and then echo to stdout so all hooks can manipulate the string in a chain.

I noticed the new docs section so I will add some to there once this is finalised/if it's merged.
