### PR TITLE
Run plugins-install hooks in series

### DIFF
--- a/dokku
+++ b/dokku
@@ -85,7 +85,9 @@ case "$1" in
     ;;
 
   plugins-install)
-    pluginhook install
+    for script in $(ls -d /var/lib/dokku/plugins/*/install); do
+      $script "$@"
+    done
     ;;
 
   # temporary hack for https://github.com/progrium/dokku/issues/82


### PR DESCRIPTION
If several plugins install new packages with `apt-get`, `dokku plugins-install` breaks because `pluginhook` runs scripts in parallel, and `apt-get`cannot run in parallel (`dpkg` locks `/var/lib/apt/lists/lock`).
This happens as soon as we add a plugin using `apt-get` (like dokku-mongodb-plugin) since `nginx-vhosts` already calls `apt-get`.
This PR fixes it by running hooks in series (progrium/pluginhook#1 would be a nicer fix).
