### PR TITLE
notify when docker fails to kill container, and suggest how to resolve

### DIFF
--- a/dokku
+++ b/dokku
@@ -59,7 +59,7 @@ case "$1" in
     # kill the app when running
     if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
       oldid=$(< "$DOKKU_ROOT/$APP/CONTAINER")
-      docker kill $oldid > /dev/null
+      docker kill $oldid > /dev/null 2>&1 || true
     fi
 
     # start the app

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -16,8 +16,8 @@ case "$1" in
     if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
       ID=$(< "$DOKKU_ROOT/$APP/CONTAINER")
 
-      docker stop $ID > /dev/null
-      docker rm $ID  > /dev/null
+      docker stop $ID > /dev/null || true
+      docker rm $ID  > /dev/null || true
     fi
 
     docker images | grep $IMAGE | awk '{print $3}' | xargs docker rmi &> /dev/null &


### PR DESCRIPTION
doesn't automatically fix the issue, but informs on the likely solution.  if you would prefer it could remove the file automatically and continue deploying.
