### PR TITLE
Fix edge case: app directory is created before first app push

### DIFF
--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -23,7 +23,7 @@ case "$1" in
     APP="$(echo $2 | perl -pe 's/(?<!\\)'\''//g' | sed 's/\\'\''/'\''/g')"
     APP_PATH=$DOKKU_ROOT/$APP
 
-    if [[ $1 == "git-receive-pack" && ! -d $APP_PATH ]]; then
+    if [[ $1 == "git-receive-pack" && ! -d "$APP_PATH/refs" ]]; then
         git init --bare $APP_PATH > /dev/null
         PRERECEIVE_HOOK="$APP_PATH/hooks/pre-receive"
         cat > $PRERECEIVE_HOOK <<EOF


### PR DESCRIPTION
When an app directory (i.e. `/home/dokku/myapp`) is created before the app is pushed for the first time (which may occur if config files such as `ENV` are added before the initial push), then the app directory will not be initialized to a bare git repo nor will the pre-receive hook be installed because `plugins/git/commands` assumes that if `$APP_PATH` exists, then the directory must also be git initialized too. This fix checks for `$APP_PATH/refs` instead.

This issue appeared in https://github.com/fgrehm/chef-dokku/issues/11.
