### PR TITLE
Added pre and post deployall hooks

### DIFF
--- a/dokku
+++ b/dokku
@@ -93,9 +93,9 @@ case "$1" in
   deploy:all)
     for app in $(ls -d $DOKKU_ROOT/*/); do
       APP=$(basename $app);
-      pluginhook pre-deployall
+      pluginhook pre-deployall $app
       dokku deploy $APP
-      pluginhook post-deployall
+      pluginhook post-deployall $app
     done
     ;;
 


### PR DESCRIPTION
Since there are some issues with ports and mappings being messed-up after deployment, i think it will be a good idea for plugins to be able to hook in to the deploy:all action. Some plugins (the dokku-pg plugin for example) needs to perform some actions after the server rebooted. This way we can plugin to the reboot sequence.

Hope it can be accepted
