### PR TITLE
Suppress git "detached HEAD" notice output 

### DIFF
--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -8,6 +8,7 @@ git_archive_all() {
     unset GIT_DIR GIT_WORK_TREE
     git clone $DOKKU_ROOT/$APP $TMP_WORK_DIR > /dev/null
     pushd $TMP_WORK_DIR > /dev/null
+    git config advice.detachedHead false
     git checkout $REV > /dev/null
     git submodule update --init --recursive > /dev/null
     find -name .git -prune -exec rm -rf {} \; > /dev/null


### PR DESCRIPTION
Prevents "detached HEAD notification" <del>if `DOKKU_TRACE` is anything but 1</del>

Related to progrium/dokku#399

Be aware that this behavior is not covered by Travis tests !
