### PR TITLE
Allow double quotes in config values

### DIFF
--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -126,7 +126,7 @@ case "$1" in
       if [[ $KEY == [a-zA-Z_][a-zA-Z0-9_]* ]]; then
         RESTART_APP=true
         ENV_TEMP=$(echo -e "${ENV_TEMP}" | sed "/^export $KEY=/ d")
-        ENV_TEMP="${ENV_TEMP}\nexport ${var}"
+        ENV_TEMP="${ENV_TEMP}\nexport $KEY='$VALUE'"
         ENV_ADD=$(echo -e "${ENV_ADD}" | sed "/^$KEY=/ d")
         ENV_ADD="${ENV_ADD}\n${var}"
       fi


### PR DESCRIPTION
For example, if one wanted to store JSON in a config value (granted, not a great idea in general).

Setting `{"foo":"bar"}` via `ssh -t ... config:set <app> TEST='{"foo":"bar"}'` would result in the following (broken) line in ENV:

```
export TEST={"foo":"bar"}
```

With this pull request the value is strong quoted

```
export TEST='{"foo":"bar"}'
```

For comparison, double quotes in config values do work on Heroku.

/cc @mdpye, thanks for the digging!
