### PR TITLE
Preserve public port across deployments

### DIFF
--- a/dokku
+++ b/dokku
@@ -54,18 +54,19 @@ case "$1" in
     ;;
 
   deploy)
-    APP="$2"; IMAGE="app/$APP"
+    APP="$2"; IMAGE="app/$APP"; PORT="5000"
     pluginhook pre-deploy $APP
 
     # kill the app when running
     if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
+      PORT="$(cat "$DOKKU_ROOT/$APP/PORT"):5000"
       oldid=$(< "$DOKKU_ROOT/$APP/CONTAINER")
       docker kill $oldid > /dev/null 2>&1 || true
     fi
 
     # start the app
     DOCKER_ARGS=$(: | pluginhook docker-args $APP)
-    id=$(docker run -d -p 5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
+    id=$(docker run -d -p $PORT -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
     echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
     port=$(docker port $id 5000 | sed 's/0.0.0.0://')
     echo $port > "$DOKKU_ROOT/$APP/PORT"


### PR DESCRIPTION
I'm running my load balancer separately from the Dokku instance and would like to avoid having to propagate a new port on every `git push`.  This change preserves the public port on a new deployment.
