### PR TITLE
Match www apex domain for root deployments

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -8,7 +8,7 @@ if [[ -f "$DOKKU_ROOT/VHOST" ]]; then
   VHOST=$(< "$DOKKU_ROOT/VHOST")
   SUBDOMAIN=${APP/%\.${VHOST}/}
   if [[ "$APP" == *.* ]] && [[ "$SUBDOMAIN" == "$APP" ]]; then
-    hostname="${APP/\//-}"
+    hostname=".${APP/\//-}"
   else
     hostname="${APP/\//-}.$VHOST"
   fi


### PR DESCRIPTION
Does anybody have thoughts on the pull request below?  This would by default cause root domain deployments to match http://example.com and http://www.example.com.  

From the nginx docs: http://nginx.org/en/docs/http/server_names.html:

```
A special wildcard name in the form “.example.org” can be used to match both the exact name “example.org” and the wildcard name “*.example.org”.
```

Perhaps there is a simpler way I could accomplish this with an nginx configuration.  I would appreciate the help if that is the case.

Thank you!
