### PR TITLE
Fixing logs so you can detach from console

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -40,7 +40,7 @@ case "$1" in
       CONTAINER=$(<$DOKKU_ROOT/$APP/CONTAINER)
       docker logs $CONTAINER | tail -n 100
       if [[ $3 == "-t" ]]; then
-        docker attach $CONTAINER
+        docker attach -sig-proxy=false $CONTAINER
       fi
     else
       echo "Application's container not found"


### PR DESCRIPTION
When running `dokku logs ruby-sample -t` it won't allow you to exit.  Passing `-sig-proxy=false` allows you to exit by killing the client.
