### PR TITLE
Using logs --follow instead of attaching to instance

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -38,9 +38,10 @@ case "$1" in
 
     if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
       CONTAINER=$(<$DOKKU_ROOT/$APP/CONTAINER)
-      docker logs $CONTAINER | tail -n 100
       if [[ $3 == "-t" ]]; then
         docker logs --follow $CONTAINER
+      else
+        docker logs $CONTAINER | tail -n 100
       fi
     else
       echo "Application's container not found"


### PR DESCRIPTION
`docker logs app-name -t` doesn't allow you to detach from the attached console.  Using a new method that allows you to detach from the `logs` command.
