### PR TITLE
Support NO_VHOST to prevent nginx vhost

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -8,11 +8,11 @@ set +e
 NO_VHOST=$(dokku config:get $APP NO_VHOST)
 set -e
 
-if [[ -z "$NO_VHOST" ]]; then
+if [[ ! -z "$NO_VHOST" ]]; then
   echo "------> NO_VHOST config detected"
 fi
 
-if [[ -f "$DOKKU_ROOT/VHOST" && ! -z "$NO_VHOST" ]]; then
+if [[ -f "$DOKKU_ROOT/VHOST" && -z "$NO_VHOST" ]]; then
   VHOST=$(< "$DOKKU_ROOT/VHOST")
   SUBDOMAIN=${APP/%\.${VHOST}/}
   if [[ "$APP" == *.* ]] && [[ "$SUBDOMAIN" == "$APP" ]]; then


### PR DESCRIPTION
This change allows you to use "dokku config:set [app] NO_VHOST=true" which will then prevent creation (and deletion if it already exists) of the nginx.conf and URL files.

Makes it more practical to deploy internal applications (ex: a Java back-end which is called by a Node front end), which are better linked using named container links (using the dokku-name and dokku-link plugins)
