### PR TITLE
Validate vhosts names more strictly

### DIFF
--- a/contrib/dokku-installer.rb
+++ b/contrib/dokku-installer.rb
@@ -104,7 +104,7 @@ __END__
 				});
 		}
 		function update() {
-			if ($("#vhost").is(":checked") && $("#hostname").val().match(/(\d{1,3}\.){3}\d{1,3}/)) {
+			if ($("#vhost").is(":checked") && $("#hostname").val().match(/^(\d{1,3}\.){3}\d{1,3}$/)) {
 				alert("In order to use virtualhost naming, the hostname must not be an IP but a valid domain name.")
 				$("#vhost").prop('checked', false);
 			}


### PR DESCRIPTION
There was a bug in the setup page where valid domains that start with a number would be captured by the validation check designed to detect IP addresses. This check detects IPs by comparing the host name to a regex, instead of simply detecting whether the first character is a number.
