### PR TITLE
Named rebuild fix clean for issue #489

### DIFF
--- a/dokku
+++ b/dokku
@@ -64,6 +64,7 @@ case "$1" in
     fi
     
     dokku cleanup
+    sleep 2
 
     # start the app
     DOCKER_ARGS=$(: | pluginhook docker-args $APP)


### PR DESCRIPTION
on deploy phase, issue dokku cleanup to remove shut down containers and sleep 2 for docker to reliably apply the changes.  without these changes, every other rebuild of a named container will fail
