### PR TITLE
Import ssl certificates - nginx plugin enhancement

### DIFF
--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -2,8 +2,17 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 case "$1" in
+  nginx:import-ssl)
+    [[ ! $2 ]] && echo "Application name is required" && exit 1
+    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "Application $2 does not exist" && exit 1
+    [[ -t 0 ]] && echo "Tar archive containing ssl/server.crt and ssl/server.key expected on stdin" && exit 1
+    cd "$DOKKU_ROOT/$2"
+    tar xvf - <&0
+    ;;
   help)
-    cat
+    cat  && cat<<EOF
+    nginx:import-ssl <app>                          Extracts a tarbal from stdin into the app folder; should contain ssl/server.crt and ssl/server.key
+EOF
     ;;
 esac
 


### PR DESCRIPTION
This is just a simple addition to more readily expose the nginx plugin's excellent built in SSL support. I would imagine this is what was attempted through the `backup:import/export` capabilities and even though it would not work for me I don't see this as a replacement but merely a shorter path to a similar destination, why shouldn't we have both? 

Stream a tarbal archive consisting of the certificates `ssl/server.crt` and `ssl/server.key` to be consumed via `stdin` on receipt and extracted into the application folder to trigger and produce the appropriate ssl configuration.    

```
$ ssh <dokku-url> nginx:import-ssl <app-name> < archive-of-certs.tar
```
