### PR TITLE
CHANGED use namespace dokku for docker 0.10 compatibility

### DIFF
--- a/dokku
+++ b/dokku
@@ -14,7 +14,7 @@ fi
 
 case "$1" in
   receive)
-    APP="$2"; IMAGE="app/$APP"
+    APP="$2"; IMAGE="dokku/$APP"
     echo "-----> Cleaning up ..."
     dokku cleanup
     echo "-----> Building $APP ..."
@@ -29,7 +29,7 @@ case "$1" in
     ;;
 
   build)
-    APP="$2"; IMAGE="app/$APP"; CACHE_DIR="$DOKKU_ROOT/$APP/cache"
+    APP="$2"; IMAGE="dokku/$APP"; CACHE_DIR="$DOKKU_ROOT/$APP/cache"
     id=$(cat | docker run -i -a stdin progrium/buildstep /bin/bash -c "mkdir -p /app && tar -xC /app")
     test $(docker wait $id) -eq 0
     docker commit $id $IMAGE > /dev/null
@@ -43,7 +43,7 @@ case "$1" in
     ;;
 
   release)
-    APP="$2"; IMAGE="app/$APP"
+    APP="$2"; IMAGE="dokku/$APP"
     pluginhook pre-release $APP
     if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
       id=$(cat "$DOKKU_ROOT/$APP/ENV" | docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/app-env.sh")
@@ -54,7 +54,7 @@ case "$1" in
     ;;
 
   deploy)
-    APP="$2"; IMAGE="app/$APP"
+    APP="$2"; IMAGE="dokku/$APP"
     pluginhook pre-deploy $APP
 
     # kill the app when running

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -6,7 +6,7 @@ case "$1" in
         echo "Please specify an app to delete"
         exit 1
     fi
-    APP="$2"; IMAGE="app/$APP";
+    APP="$2"; IMAGE="dokku/$APP";
     if [[ ! -d "$DOKKU_ROOT/$APP" ]]; then
         echo "App does not exist"
         exit 1
@@ -53,7 +53,7 @@ case "$1" in
         echo "Please specify an app to run the command on"
         exit 1
     fi
-    APP="$2"; IMAGE="app/$APP"
+    APP="$2"; IMAGE="dokku/$APP"
     if [[ ! -d "$DOKKU_ROOT/$APP" ]]; then
         echo "App $APP does not exist"
         exit 1

--- a/plugins/00_dokku-standard/pre-delete
+++ b/plugins/00_dokku-standard/pre-delete
@@ -2,7 +2,7 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
-IMAGE=app/"$1"
+IMAGE=dokku/"$1"
 CACHE_DIR="$DOKKU_ROOT/$APP/cache"
 
 docker run -v $CACHE_DIR:/cache $IMAGE find /cache -depth -mindepth 1 -maxdepth 1 -exec rm -Rf {} \;


### PR DESCRIPTION
Changed `dokku` executable and plugins to use the namespace `dokku` instead of `app`.

Docker 0.10 requires namespaces to have 4 characters or longer.
