### PR TITLE
Only update dokku.conf when it does not exist

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -15,7 +15,7 @@ if ! grep -q dokku-nginx-reload "/etc/sudoers"; then
 fi
 
 # if dokku.conf has not been created, create it
-if [ ! -f /etc/nginx/conf.d/dokku.conf ]; then
+if [[ ! -f /etc/nginx/conf.d/dokku.conf ]]; then
   cat<<EOF > /etc/nginx/conf.d/dokku.conf
 include $DOKKU_ROOT/*/nginx.conf;
 


### PR DESCRIPTION
Only create dokku.conf if it hasn't been created. This way if you have ssl enabled, running `sudo dokku plugins-install` doesn't rewrite the dokku.conf.
