### PR TITLE
Load app-specific env vars after default env vars. Fix #503

### DIFF
--- a/dokku
+++ b/dokku
@@ -46,7 +46,7 @@ case "$1" in
     APP="$2"; IMAGE="dokku/$APP"
     pluginhook pre-release $APP
     if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
-      id=$(cat "$DOKKU_ROOT/$APP/ENV" | docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/app-env.sh")
+      id=$(cat "$DOKKU_ROOT/$APP/ENV" | docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/config_vars_app")
       test $(docker wait $id) -eq 0
       docker commit $id $IMAGE > /dev/null
     fi


### PR DESCRIPTION
Currently env vars are stored in `/app/.profile.d/*` folder and they are
loaded by `/start` script:

```
# https://github.com/progrium/buildstep/blob/master/stack/builder#L83
for file in $app_root/.profile.d/*; do source \$file; done
```

App-specific env vars are stored in `app-env.sh` and default env vars are
stored in `config_vars` file, and the latter overwrites the first one.

To load app-specific vars after default config I suggest to rename
`app-env.sh` file to `config_vars_app`.

PS: Yeah, that seems hacky because it depends on bash's for-loop behaviour
    which may be different for different versions of OSs.
