### PR TITLE
setup port forwards to only listen locally

### DIFF
--- a/dokku
+++ b/dokku
@@ -65,7 +65,7 @@ case "$1" in
 
     # start the app
     DOCKER_ARGS=$(: | pluginhook docker-args $APP)
-    id=$(docker run -d -p 5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
+    id=$(docker run -d -p 127.0.0.1::5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
     echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
     port=$(docker port $id 5000 | sed 's/0.0.0.0://')
     echo $port > "$DOKKU_ROOT/$APP/PORT"

--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-APP="$1"; PORT="$2"
+APP="$1"; HOSTPORT="$2"
 WILDCARD_SSL="$DOKKU_ROOT/tls"
 SSL="$DOKKU_ROOT/$APP/tls"
 
@@ -28,7 +28,7 @@ EOF
   # ssl based nginx.conf
   if [[ -n "$SSL_INUSE" ]]; then
   cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf
-upstream $APP { server 127.0.0.1:$PORT; }
+upstream $APP { server $HOSTPORT; }
 server {
   listen      [::]:80;
   listen      80;
@@ -63,7 +63,7 @@ EOF
 else
 # default nginx.conf
   cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf
-upstream $APP { server 127.0.0.1:$PORT; }
+upstream $APP { server $HOSTPORT; }
 server {
   listen      [::]:80;
   listen      80;


### PR DESCRIPTION
I had to make these changes while running on a Linode.  I was having trouble closing down the ports with UFW/shorewall so I wanted my containers to only listen on the localhost.

I renamed the variable PORT in the nginx conf plugin to HOSTPORT and this variable now contains "127.0.0.1:5000"
