### PR TITLE
Added man page plugin command warning

### DIFF
--- a/dokku.1
+++ b/dokku.1
@@ -1,4 +1,4 @@
-.TH DOKKU 1 2014-03-08
+.TH DOKKU 1 2014-05-10
 .\"Make sure to change that date when you commit a change!
 .\"
 .SH NAME


### PR DESCRIPTION
As of now, the man page does not update when plugins are installed. Until then, the user should know that the man page does not list the full set of plugins available to them. Maybe in the future we can parse the `dokku help` output into the man page to update it.

The new warning under `NOTES`:

![The new warning](https://cloud.githubusercontent.com/assets/2830107/2937036/cd2c8284-d882-11e3-857a-5cc4773bb183.png)
