### PR TITLE
Use command instead of which for apt-get existential check in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 export DEBIAN_FRONTEND=noninteractive
 export DOKKU_REPO=${DOKKU_REPO:-"https://github.com/progrium/dokku.git"}
 
-if ! which apt-get &>/dev/null
+if ! command -v apt-get &>/dev/null
 then
   echo "This installation script requires apt-get. For manual installation instructions, consult https://github.com/progrium/dokku ."
   exit 1


### PR DESCRIPTION
`command` is a better way to check if a command exists than `which`.  See [this StackOverflow post](http://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script).
