### PR TITLE
Display correctly ENV values containing spaces

### DIFF
--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -26,6 +26,8 @@ fi
 config_styled_hash () {
   vars=`echo -e "$1"`
 
+  OLDIFS=$IFS
+  IFS=$'\n'
   longest=""
   for word in $vars; do
     KEY=`echo $word | cut -d"=" -f1`
@@ -46,6 +48,7 @@ config_styled_hash () {
     done
     echo "$KEY:$zeros$VALUE"
   done
+  IFS=$OLDIFS
 }
 
 config_restart_app() {
@@ -69,7 +72,7 @@ case "$1" in
       exit 1
     fi
 
-    VARS=`cat $ENV_FILE | grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" | cut -d" " -f2`
+    VARS=`cat $ENV_FILE | grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" | cut -d" " -f2-`
 
     for var in "$@"; do
       if [[ "$var" == "--shell" ]]; then
@@ -95,7 +98,7 @@ case "$1" in
 
     KEY="$3"
 
-    cat $ENV_FILE | grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" | cut -d" " -f2 | grep "^$KEY=" | cut -d"=" -f2-
+    cat $ENV_FILE | grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" | cut -d" " -f2- | grep "^$KEY=" | cut -d"=" -f2-
   ;;
 
   config:set)


### PR DESCRIPTION
Command `dokku config <app>` doesn't return entire env values (only to the first space) e.g.:

```
$ cat ENV
export ALLOWED_HOSTS='domain.com test.domain.com dev.domain.com'
export NEXT_VARIABLE=value

$ dokku config <app>
ALLOWED_HOSTS:    "domain.com
NEXT_VARIABLE:    value
```
