### PR TITLE
Document what bootstrap.sh is doing.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# A script to bootstrap dokku.
+# It expects to be run on Ubuntu 12.04 or 14.04 via 'sudo'
+# It checks out the dokku source code from Github into ~/dokku and then runs 'make install' from dokku source.
+
 set -eo pipefail
 export DEBIAN_FRONTEND=noninteractive
 export DOKKU_REPO=${DOKKU_REPO:-"https://github.com/progrium/dokku.git"}


### PR DESCRIPTION
Some folks are rightly interested in what shell scripts are doing
before they pipe code from the internet to `sudo`.

This patch provides a bit of documentation to the script to make it faster to grok.
