### PR TITLE
Make ENV file readable only from dokku user.

### DIFF
--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -137,6 +137,7 @@ case "$1" in
       config_styled_hash "$ENV_ADD"
 
       echo -e "$ENV_TEMP" | sed '/^$/d' | sort > $ENV_FILE
+      chmod 600 $ENV_FILE
       config_restart_app $APP
     fi
   ;;


### PR DESCRIPTION
The ENV file may contain user password, secret key and so on.
As it is insecure that the other users than dokku can see the content of ENV file, this PR changes the permission.
