### PR TITLE
Update Vagrant box to trusty because of raring server issues

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-BOX_NAME = ENV["BOX_NAME"] || "raring"
-BOX_URI = ENV["BOX_URI"] || "https://cloud-images.ubuntu.com/vagrant/raring/current/raring-server-cloudimg-amd64-vagrant-disk1.box"
+BOX_NAME = ENV["BOX_NAME"] || "trusty"
+BOX_URI = ENV["BOX_URI"] || "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 BOX_MEMORY = ENV["BOX_MEMORY"] || "512"
 DOKKU_DOMAIN = ENV["DOKKU_DOMAIN"] || "dokku.me"
 DOKKU_IP = ENV["DOKKU_IP"] || "10.0.0.2"


### PR DESCRIPTION
13.04 is end of life.  Servers are probably down (from http://archive.ubuntu.com/ IP: 91.189.91.15 80), it could be permanent or maintenance. Updated to 14.04 box.

Details - http://askubuntu.com/questions/498464/failed-to-fetch-packages-from-http-archive-ubuntu-com-ip-91-189-91-15-80
