### PR TITLE
Fixed port when docker is start with --ip with an IP other than 0.0.0.0

### DIFF
--- a/dokku
+++ b/dokku
@@ -67,7 +67,7 @@ case "$1" in
     DOCKER_ARGS=$(: | pluginhook docker-args $APP)
     id=$(docker run -d -p 5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
     echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
-    port=$(docker port $id 5000 | sed 's/0.0.0.0://')
+    port=$(docker port $id 5000 | sed 's/[0-9.]*://')
     echo $port > "$DOKKU_ROOT/$APP/PORT"
     echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
 


### PR DESCRIPTION
If docker is started when --ip with an IP other than 0.0.0.0 (like --ip=127.0.0.1), the PORT contains something like 127.0.0.1:<port>, breaking the ngnix config.
