### PR TITLE
Simplify sq_dequote

### DIFF
--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -36,7 +36,7 @@ case "$1" in
     ;;
 
   git-*)
-    APP="$(echo $2 | perl -pe 's/(?<!\\)'\''//g' | sed 's/\\'\''/'\''/g')"
+    APP="$(echo $2 | xargs echo)"
     APP_PATH=$DOKKU_ROOT/$APP
 
     if [[ $1 == "git-receive-pack" && ! -d "$APP_PATH/refs" ]]; then


### PR DESCRIPTION
I mean, technically, the app name doesn't need to be dequoted at _all_, but this is a simpler way to dequote it.
