### PR TITLE
Avoid docker-args collisions for unique arguments

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -60,7 +60,7 @@ case "$1" in
     fi
     shift 2
 
-    DOCKER_ARGS=$(: | pluginhook docker-args $APP)
+    DOCKER_ARGS=$(: | pluginhook docker-run-args $APP)
     docker run -i -t $DOCKER_ARGS $IMAGE /exec "$@"
     ;;
 


### PR DESCRIPTION
Changed the `run` command plugin hook from `docker-args` to `docker-run-args` to avoid collisions.

For example with the `dokku-name` plugin that sets a name for the deployed container, so that name is already in use when trying to run a command via `dokku run APP [...]`.
