### PR TITLE
Fixed variable name.

### DIFF
--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -108,7 +108,7 @@ case "$1" in
     APP="$2"; APP_DIR="$DOKKU_ROOT/$APP"
     ENV_ADD=""
     ENV_TEMP=`cat "${ENV_FILE}"`
-    RESTART=false
+    RESTART_APP=false
     VARS="${*:3}"
 
     for var in $VARS; do


### PR DESCRIPTION
A `RESTART` variable is initialized to false, but the rest of the function uses a variable named `RESTART_APP`. This PR fixes this.
