### PR TITLE
Add CNAME option

### DIFF
--- a/dokku
+++ b/dokku
@@ -63,6 +63,12 @@ case "$1" in
       docker inspect $oldid &> /dev/null && docker kill $oldid > /dev/null
     fi
 
+    # CNAME
+    CNAME=$(docker run -i $IMAGE /bin/bash -c "if [[ -f /app/CNAME ]];then cat /app/CNAME; fi")
+    if [[ -n "$CNAME" ]]; then
+      echo "$CNAME" > "$DOKKU_ROOT/$APP/CNAME"
+    fi
+
     # start the app
     DOCKER_ARGS=$(: | pluginhook docker-args $APP)
     id=$(docker run -d -p 5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")

--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -25,6 +25,10 @@ EOF
     SSL_DIRECTIVES=""
   fi
 
+  if [[ -f "$DOKKU_ROOT/$APP/CNAME" ]]; then
+    hostname=$(< "$DOKKU_ROOT/$APP/CNAME" )
+  fi
+
   # ssl based nginx.conf
   if [[ -n "$SSL_INUSE" ]]; then
   cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf


### PR DESCRIPTION
When a repo have a CNAME file, it will use the URL from it to map the server_name on ngnix.

@progrium let me know your thoughts about this. The implementation is really simple, and IMO gives a lot, so we can add a custom domain to an app without using the VHOST.

I have about 5 apps running in the same host machine, every container has a completely different domain, So thats how I make it work. Just need to add a file called `CNAME` to the root of my repo, and ngnix will use that url. (see https://github.com/arthurnn/octostalker/commit/138ab8bbe94263e17c4b07408f35b54e592f8203 for example)
