### PR TITLE
contrib: add dokku client shell script

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -1,0 +1,32 @@
+if [ -z "$DOKKU_CONTROLLER" ]
+then
+	function dokku {
+		appname=$(git remote -v 2>/dev/null | grep dokku | head -n 1 | cut -f1 -d' ' | cut -f2 -d':' 2>/dev/null)
+		if [ "$?" != "0" ]
+		then
+			donotshift="YES"
+		fi
+		if [ "$1" = "create" ]
+		then
+			appname=$(echo "print(elfs.GenName())" | lua -l elfs)
+			if git remote add dokku dokku@$DOKKU_CONTROLLER:$appname
+			then
+				echo "-----> Dokku remote added at $DOKKU_CONTROLLER"
+				echo "-----> Application name is $appname"
+			else
+				echo "!      Dokku remote not added! Do you already have a dokku remote?"
+				return
+			fi
+			git push dokku master
+		else
+			if [ -z "$donotshift" ]
+			then
+				ssh dokku@$DOKKU_CONTROLLER $*
+				exit
+			fi
+			verb=$1
+			shift
+			ssh dokku@$DOKKU_CONTROLLER "$verb" "$appname" $@
+		fi
+	}
+fi


### PR DESCRIPTION
This is adapted from the one I use in my shell profile scripts. This 
kinda-sorta-maybe acts like the `heroku` or `deis` commands and does some
clever reorganization of data before sending it to the server.

To use the app name generator, install the `elfs` rock from Moonrocks.
