### PR TITLE
Don't overwrite $APP/URL modified by plugins in post-deploy hook

### DIFF
--- a/dokku
+++ b/dokku
@@ -77,14 +77,15 @@ case "$1" in
     trap kill_new INT TERM EXIT
     echo "-----> Running pre-flight checks"
     pluginhook check-deploy $id $APP $port
-    echo "-----> Running post-deploy"
-    pluginhook post-deploy  $APP $port
-    trap -        INT TERM EXIT
 
     # now using the new container
     echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
     echo $port > "$DOKKU_ROOT/$APP/PORT"
     echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
+
+    echo "-----> Running post-deploy"
+    pluginhook post-deploy  $APP $port
+    trap -        INT TERM EXIT
 
     # kill the old container
     if [[ -n "$oldid" ]]; then


### PR DESCRIPTION
Changes made by a plugin (e.g. nginx-vhost) in $APP/URL will be overwritten during deploy.
Now the file will be generated before running post-deploy hooks.
