### PR TITLE
Explicitly install man-db

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,7 +10,7 @@ then
 fi
 
 apt-get update
-apt-get install -y git make curl software-properties-common
+apt-get install -y git make curl software-properties-common man-db
 
 [[ `lsb_release -sr` == "12.04" ]] && apt-get install -y python-software-properties
 


### PR DESCRIPTION
Dokku requires mandb, but the man-db package is not part of the
minimal Ubuntu base. This causes bootstrap to fail. Attached PR explicitly installs man-db.
