### PR TITLE
If VHOST exists, don't use the raw URL with port

### DIFF
--- a/dokku
+++ b/dokku
@@ -90,7 +90,9 @@ case "$1" in
     # now using the new container
     echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
     echo $port > "$DOKKU_ROOT/$APP/PORT"
-    echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
+    if [[ ! -f "$DOKKU_ROOT/VHOST" ]]; then
+        echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
+    fi
 
     # kill the old container
     if [[ -n "$oldid" ]]; then


### PR DESCRIPTION
If the VHOST file exists, don't overwrite the $APP/URL file, such that, when the app is building the VHOST'd URL is output in the terminal, instead of the $HOSTNAME/:$port version.

Most documentation references the idea of apps being released as subdomains (Heroku type subdomains), this would alleviate some of the confusion of seeing a port based URL.
