### PR TITLE
Fix deploying when a container is not running.

### DIFF
--- a/dokku
+++ b/dokku
@@ -93,8 +93,8 @@ case "$1" in
     echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
 
     # kill the old container
-    if [[ -n "$oldid" ]]; then
-      docker inspect $oldid &> /dev/null && docker kill $oldid > /dev/null
+    if [[ -n "$oldid" ]] && docker inspect $oldid &> /dev/null; then
+      docker kill $oldid > /dev/null
     fi
 
     ;;


### PR DESCRIPTION
If a previous deploy failed to leave a container running, further
deploys will fail.  This is due to a check to ensure that a missing
container doesn't fail the build, however because the line fails due
to a missing container, everything breaks anyways.  Instead, properly
guard the condition.
