### PR TITLE
Revert "Add CNAME option"

### DIFF
--- a/dokku
+++ b/dokku
@@ -61,12 +61,6 @@ case "$1" in
       oldid=$(< "$DOKKU_ROOT/$APP/CONTAINER")
     fi
 
-    # CNAME
-    CNAME=$(docker run -i $IMAGE /bin/bash -c "if [[ -f /app/CNAME ]];then cat /app/CNAME; fi")
-    if [[ -n "$CNAME" ]]; then
-      echo "$CNAME" > "$DOKKU_ROOT/$APP/CNAME"
-    fi
-
     # start the app
     DOCKER_ARGS=$(: | pluginhook docker-args $APP)
     id=$(docker run -d -p 5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")

--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -25,10 +25,6 @@ EOF
     SSL_DIRECTIVES=""
   fi
 
-  if [[ -f "$DOKKU_ROOT/$APP/CNAME" ]]; then
-    hostname=$(< "$DOKKU_ROOT/$APP/CNAME" )
-  fi
-
   # ssl based nginx.conf
   if [[ -n "$SSL_INUSE" ]]; then
   cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf


### PR DESCRIPTION
Reverts progrium/dokku#657

There appeared to be a few issues with this merge, and there is a plugin that handles domain configuration quite nicely. Handling CNAMEs in a way that doesn't follow other platforms - heroku being the main one - means that it is less likely that we can manipulate this option via a third-party tool - ruling out any dashboard-like software - and thus I think the merge was ill-advised.

A proper implementation would not depend upon a file in the repository, as that would tie that repository to a single host, and thus not allow it to be deployed by multiple users.
