### PR TITLE
Make `help` command output more consistent

### DIFF
--- a/dokku
+++ b/dokku
@@ -118,9 +118,9 @@ case "$1" in
 
   help)
     cat<<EOF | pluginhook commands help | sort
-    help            Print the list of commands
-    plugins         Print active plugins
-    plugins-install Install active plugins
+    help                                            Print the list of commands
+    plugins                                         Print active plugins
+    plugins-install                                 Install active plugins
 EOF
     ;;
 

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -163,10 +163,10 @@ case "$1" in
 
   help)
     cat && cat<<EOF
-    config <app>                                    display the config vars for an app
-    config:get <app> KEY                            display a config value for an app
-    config:set <app> KEY1=VALUE1 [KEY2=VALUE2 ...]  set one or more config vars
-    config:unset <app> KEY1 [KEY2 ...]              unset one or more config vars
+    config <app>                                    Display the config vars for an app
+    config:get <app> KEY                            Display a config value for an app
+    config:set <app> KEY1=VALUE1 [KEY2=VALUE2 ...]  Set one or more config vars
+    config:unset <app> KEY1 [KEY2 ...]              Unset one or more config vars
 EOF
   ;;
 


### PR DESCRIPTION
Formats the help output a bit more consistently.
