### PR TITLE
Actually suppress the output from `git_archive_all`

### DIFF
--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -6,11 +6,11 @@ git_archive_all() {
     TMP_WORK_DIR=$(mktemp -d)
     chmod 755 $TMP_WORK_DIR
     unset GIT_DIR GIT_WORK_TREE
-    git clone $DOKKU_ROOT/$APP $TMP_WORK_DIR > /dev/null
+    git clone $DOKKU_ROOT/$APP $TMP_WORK_DIR &> /dev/null
     pushd $TMP_WORK_DIR > /dev/null
     git config advice.detachedHead false
-    git checkout $REV > /dev/null
-    git submodule update --init --recursive > /dev/null
+    git checkout $REV &> /dev/null
+    git submodule update --init --recursive &> /dev/null
     find -name .git -prune -exec rm -rf {} \; > /dev/null
     tar c .
     popd > /dev/null


### PR DESCRIPTION
This suppresses the ugly `remote: ...` stuff for the archiving of the repo at the start of a deploy.

I felt like got in the way of the actual output of the deploy.
