### PR TITLE
Allow custom server name with DOKKU_SERVER_NAME app env var

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -7,7 +7,12 @@ SSL="$DOKKU_ROOT/$APP/tls"
 if [[ -f "$DOKKU_ROOT/VHOST" ]]; then
   VHOST=$(< "$DOKKU_ROOT/VHOST")
   SUBDOMAIN=${APP/%\.${VHOST}/}
-  if [[ "$APP" == *.* ]] && [[ "$SUBDOMAIN" == "$APP" ]]; then
+
+  # source in app env to get DOKKU_SERVER_NAME
+  [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source $DOKKU_ROOT/$APP/ENV
+  if [[ -n "$DOKKU_SERVER_NAME" ]]; then
+    hostname="$DOKKU_SERVER_NAME"
+  elif [[ "$APP" == *.* ]] && [[ "$SUBDOMAIN" == "$APP" ]]; then
     hostname="${APP/\//-}"
   else
     hostname="${APP/\//-}.$VHOST"


### PR DESCRIPTION
This allows to set a custom server name by setting the `DOKKU_SERVER_NAME` config var. It provides the functionality of 0cd1839ce857ffe83d369238968f48f2e6a99ded but outside the repo.
I used the same config name style as `DOKKU_CHECKS_WAIT` from the checks plugin.
