### PR TITLE
Display help when invoking dokku with no parameter

### DIFF
--- a/dokku
+++ b/dokku
@@ -116,7 +116,7 @@ case "$1" in
     done
     ;;
 
-  help)
+  help|'')
     cat<<EOF | pluginhook commands help | sort
     help            Print the list of commands
     plugins         Print active plugins


### PR DESCRIPTION
Currently, invoking `dokku` with no parameter gives no feedback. This PR shows the help when `dokku` is invoked with no parameter.
