### PR TITLE
Update vagrant installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,7 +88,7 @@ sudo BUILD_STACK=true make install
 - Clone Dokku
 
     ```
-    git clone git@github.com:progrium/dokku.git
+    git clone https://github.com/progrium/dokku.git
     ```
 
 - Setup SSH hosts in your `/etc/hosts`


### PR DESCRIPTION
Avoids 

```
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
```

that can occur on certain Vagrant images. Since we need readonly anyway, might as well use HTTPS instead of SSH.
