### PR TITLE
Let the user know it's on the `stack` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ aufs:
 	lsmod | grep aufs || modprobe aufs || apt-get install -qq -y linux-image-extra-`uname -r` > /dev/null
 
 stack:
+@echo "Start building buildstep"
 ifdef BUILD_STACK
 	@docker images | grep progrium/buildstep || (git clone ${STACK_URL} /tmp/buildstep && docker build -t progrium/buildstep /tmp/buildstep && rm -rf /tmp/buildstep)
 else


### PR DESCRIPTION
Since curl is running quietly it may give the impression that the installation hanged with the last message on the terminal being: "sleep 2 # give docker a moment i guess". In my case I thought it gave it a huge moment and not 2 seconds. It wasn't until the third time that I actually checked the processes on the machine and saw there it was curl downloading stuff quietly.
