### PR TITLE
Redirect to the app deployment docs on success.

### DIFF
--- a/contrib/dokku-installer.rb
+++ b/contrib/dokku-installer.rb
@@ -96,7 +96,7 @@ __END__
 			$.post('/setup', data)
 				.done(function() {
 					$("#result").html("Success!")
-					window.location.href = "https://github.com/progrium/dokku#deploy-an-app";
+					window.location.href = "http://progrium.viewdocs.io/dokku/application-deployment";
 				})
 				.fail(function(data) {
 					$("#result").html("Something went wrong...")


### PR DESCRIPTION
The app deployment docs have moved off of the GitHub repo's front page so it isn't useful to redirect there anymore. Redirect to the new documentation.
