### PR TITLE
Setup dokku-installer within Vagrant VM on first provision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifeq (vagrant-dokku,$(firstword $(MAKECMDGOALS)))
   $(eval $(RUN_ARGS):;@:)
 endif
 
-.PHONY: all install copyfiles version plugins dependencies sshcommand pluginhook docker aufs stack count vagrant-acl-add vagrant-dokku
+.PHONY: all install copyfiles version plugins dependencies sshcommand pluginhook docker aufs stack count dokku-installer vagrant-acl-add vagrant-dokku
 
 all:
 	# Type "make install" to install.
@@ -83,6 +83,16 @@ count:
 	@find plugins -type f | xargs cat | wc -l
 	@echo "Test lines:"
 	@find tests -type f | xargs cat | wc -l
+
+dokku-installer:
+	test -f /var/lib/dokku/.dokku-installer-created || gem install rack -v 1.5.2 --no-rdoc --no-ri
+	test -f /var/lib/dokku/.dokku-installer-created || gem install rack-protection -v 1.5.3 --no-rdoc --no-ri
+	test -f /var/lib/dokku/.dokku-installer-created || gem install sinatra -v 1.4.5 --no-rdoc --no-ri
+	test -f /var/lib/dokku/.dokku-installer-created || gem install tilt -v 1.4.1 --no-rdoc --no-ri
+	test -f /var/lib/dokku/.dokku-installer-created || ruby /root/dokku/contrib/dokku-installer.rb onboot
+	test -f /var/lib/dokku/.dokku-installer-created || service dokku-installer start
+	test -f /var/lib/dokku/.dokku-installer-created || service nginx reload
+	test -f /var/lib/dokku/.dokku-installer-created || touch /var/lib/dokku/.dokku-installer-created
 
 vagrant-acl-add:
 	vagrant ssh -- sudo sshcommand acl-add dokku $(USER)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,4 +30,5 @@ Vagrant::configure("2") do |config|
   end
 
   config.vm.provision :shell, :inline => "apt-get -qq -y install git > /dev/null && cd /root/dokku && #{make_cmd}"
+  config.vm.provision :shell, :inline => "cd /root/dokku && make dokku-installer"
 end

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,11 +113,7 @@ sudo BUILD_STACK=true make install
     vagrant up
     ```
 
-- Add SSH key to Dokku using `sshcommand`:
-
-    ```bash
-    cat ~/.ssh/id_rsa.pub | make vagrant-acl-add
-    ```
+- Copy your SSH key via `cat ~/.ssh/id_rsa.pub | pbcopy` and paste it into the dokku-installer at http://dokku.me . Change the `Hostname` field on the Dokku Setup screen to your domain and then check the box that says `Use virtualhost naming`. Then click *Finish Setup* to install your key. You'll be directed to application deployment instructions from here.
 
 You are now ready to deploy an app or install plugins.
 


### PR DESCRIPTION
Should unify our setup with what is used on digital ocean.
