### PR TITLE
Create an `apps` core plugin.

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -1,28 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
 case "$1" in
   delete)
-    if [[ -z $2 ]]; then
-        echo "Please specify an app to delete"
-        exit 1
-    fi
-    APP="$2"; IMAGE="dokku/$APP";
-    if [[ ! -d "$DOKKU_ROOT/$APP" ]]; then
-        echo "App does not exist"
-        exit 1
-    fi
-
-    pluginhook pre-delete $APP
-    if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
-      ID=$(< "$DOKKU_ROOT/$APP/CONTAINER")
-
-      docker stop $ID > /dev/null || true
-      docker rm $ID  > /dev/null || true
-    fi
-
-    docker images | grep $IMAGE | awk '{print $3}' | xargs docker rmi &> /dev/null &
-
-    pluginhook post-delete $APP
+    dokku apps:destroy $2
     ;;
 
   logs)
@@ -85,7 +66,6 @@ case "$1" in
 
   help)
     cat && cat<<EOF
-    delete <app>                                    Delete an application
     logs <app> [-t]                                 Show the last logs for an application (-t follows)
     run <app> <cmd>                                 Run a command in the environment of an application
     url <app>                                       Show the URL for an application

--- a/plugins/00_dokku-standard/pre-delete
+++ b/plugins/00_dokku-standard/pre-delete
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-
-APP="$1"; IMAGE="dokku/$APP"; CACHE_DIR="$DOKKU_ROOT/$APP/cache"
-
-docker run -v $CACHE_DIR:/cache $IMAGE find /cache -depth -mindepth 1 -maxdepth 1 -exec rm -Rf {} \;
-
-

--- a/plugins/apps/commands
+++ b/plugins/apps/commands
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+case "$1" in
+  apps)
+    echo "=== My Apps"
+    find $DOKKU_ROOT -maxdepth 1 -type d  \( ! -iname ".*" \) | sed 's|^\./||g' | sed 's|'$DOKKU_ROOT'\/||' | tail -n +2
+    ;;
+
+  apps:create)
+    if [[ -z $2 ]]; then
+      echo "Please specify an app to create"
+      exit 1
+    fi
+    APP="$2"
+    if [[ -d "$DOKKU_ROOT/$APP" ]]; then
+      echo " !    Name is already taken"
+      exit 1
+    fi
+
+    mkdir -p "$DOKKU_ROOT/$APP"
+    echo "Creating $APP... done"
+    ;;
+
+  apps:destroy)
+    if [[ -z $2 ]]; then
+      echo "Please specify an app to delete"
+      exit 1
+    fi
+    APP="$2"; IMAGE="dokku/$APP";
+    if [[ ! -d "$DOKKU_ROOT/$APP" ]]; then
+      echo "App $APP does not exist"
+      exit 1
+    fi
+
+    echo " !    WARNING: Potentially Destructive Action"
+    echo " !    This command will destroy $APP (including all add-ons)."
+    echo " !    To proceed, type \"$APP\""
+    echo ""
+
+    read -p "> " app_name
+    if [[ "$app_name" != "$APP" ]]; then
+      echo " !    Confirmation did not match $APP. Aborted."
+      exit 1
+    fi
+
+    echo "Destroying $APP (including all add-ons)"
+
+    pluginhook pre-delete $APP
+    if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
+      ID=$(< "$DOKKU_ROOT/$APP/CONTAINER")
+
+      docker stop $ID > /dev/null || true
+      docker rm $ID  > /dev/null || true
+    fi
+
+    docker images | grep $IMAGE | awk '{print $3}' | xargs docker rmi &> /dev/null &
+
+    pluginhook post-delete $APP
+    ;;
+
+  help)
+    cat && cat<<EOF
+    apps                                            List your apps
+    apps:create <app>                               Create a new app
+    apps:destroy <app>                              Permanently destroy an app
+EOF
+    ;;
+
+esac
+

--- a/plugins/apps/post-delete
+++ b/plugins/apps/post-delete
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
 [[ -n $1 ]] && rm -r "$DOKKU_ROOT/$1" > /dev/null

--- a/plugins/apps/pre-delete
+++ b/plugins/apps/pre-delete
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+APP="$1"; IMAGE="dokku/$APP"; CACHE_DIR="$DOKKU_ROOT/$APP/cache"
+if [[ -d $CACHE_DIR ]]; then
+  docker run -v "$CACHE_DIR:/cache" "$IMAGE" find /cache -depth -mindepth 1 -maxdepth 1 -exec rm -Rf {} \;
+fi

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -53,12 +53,14 @@ config_styled_hash () {
 config_restart_app() {
   APP="$1";
 
-  echo "-----> Releasing $APP ..."
-  dokku release $APP
-  echo "-----> Release complete!"
-  echo "-----> Deploying $APP ..."
-  dokku deploy $APP
-  echo "-----> Deploy complete!"
+  if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
+    echo "-----> Releasing $APP ..."
+    dokku release $APP
+    echo "-----> Release complete!"
+    echo "-----> Deploying $APP ..."
+    dokku deploy $APP
+    echo "-----> Deploy complete!"
+  fi
 }
 
 config_write() {


### PR DESCRIPTION
This creates the following commands:
- apps
- apps:create <app>
- apps:destroy <app>

It also:
- makes `delete` an alias for `apps:destroy`
- adds confirmation to `apps:destroy`
- allows a developer to remove apps that have been created via apps:create but have not been deployed

Refs #87
Refs #543
Refs #586
Closes #599
Refs #655
Refs #656
Refs #685
Closes #757
