### PR TITLE
Output error message when a command is not found. Closes #778

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -28,6 +28,49 @@ If you create your own plugin:
 3. edit this page and add a link to it below!
 4. subscribe to the [dokku development blog](http://progrium.com) to be notified about API changes and releases
 
+### Sample plugin
+
+The below plugin is a dummy `dokku hello` plugin. If your plugin exposes commands, this is a good template for your `commands` file:
+
+```bash
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+case "$1" in
+  hello)
+    [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
+    [[ ! -d "$DOKKU_ROOT/$APP" ]] && echo "App $APP does not exist" && exit 1
+    APP="$2";
+
+    echo "Hello $APP"
+    ;;
+
+  hello:world)
+    echo "Hello world"
+    ;;
+
+  help)
+    cat && cat<<EOF
+    hello <app>                                     Says "Hello <app>"
+    hello:world                                     Says "Hello world"
+EOF
+    ;;
+
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+    ;;
+
+esac
+```
+
+A few notes:
+
+- You should always support `DOKKU_TRACE` as specified on the 2nd line of the plugin.
+- If your command requires that an application exists, ensure you check for it's existence in the manner prescribed above.
+- A `help` command is required, though it is allowed to be empty.
+- Commands *should* be namespaced.
+- As of 0.3.3, a catch-all should be implemented which exits with a `DOKKU_NOT_IMPLEMENTED_EXIT` code. This allows dokku to output a `command not found` message.
+
 ## Community plugins
 
 Note: The following plugins have been supplied by our community and may not have been tested by dokku maintainers.

--- a/dokku
+++ b/dokku
@@ -6,6 +6,8 @@ export DOKKU_IMAGE=${DOKKU_IMAGE:="progrium/buildstep"}
 export DOKKU_ROOT=${DOKKU_ROOT:="/home/dokku"}
 
 export PLUGIN_PATH=${PLUGIN_PATH:="/var/lib/dokku/plugins"}
+export DOKKU_NOT_IMPLEMENTED_EXIT=10
+export DOKKU_VALID_EXIT=0
 
 [[ -f $DOKKU_ROOT/dokkurc ]] && source $DOKKU_ROOT/dokkurc
 
@@ -143,6 +145,9 @@ case "$1" in
     ;;
 
   help|'')
+    echo "Usage: dokku COMMAND <app> [command-specific-options]"
+    echo ""
+
     cat<<EOF | pluginhook commands help | sort
     help                                            Print the list of commands
     plugins                                         Print active plugins
@@ -151,9 +156,24 @@ EOF
     ;;
 
   *)
+    implemented=0
     for script in $(ls -d $PLUGIN_PATH/*/commands); do
-      $script "$@"
+      set +e; $script "$@" ; exit_code=$? ; set -e
+      if [ "$exit_code" -eq "$DOKKU_NOT_IMPLEMENTED_EXIT" ]; then
+        continue
+      fi
+
+      implemented=1
+      if [ "$exit_code" -ne "$DOKKU_VALID_EXIT" ]; then
+        exit $exit_code
+      fi
     done
+
+    if [ "$implemented" -eq 0 ]; then
+      echo " !    \`$@\` is not a dokku command."
+      echo " !    See \`dokku help\` for a list of available commands."
+      exit 1
+    fi
     ;;
 
 esac

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -73,4 +73,8 @@ case "$1" in
 EOF
     ;;
 
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+    ;;
+
 esac

--- a/plugins/apps/commands
+++ b/plugins/apps/commands
@@ -72,4 +72,8 @@ case "$1" in
 EOF
     ;;
 
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+    ;;
+
 esac

--- a/plugins/backup/commands
+++ b/plugins/backup/commands
@@ -92,4 +92,8 @@ case "$1" in
 EOF
     ;;
 
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+    ;;
+
 esac

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -184,4 +184,8 @@ ${var}"
 EOF
     ;;
 
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+    ;;
+
 esac

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -58,4 +58,8 @@ EOF
     cat
     ;;
 
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+    ;;
+
 esac

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -41,4 +41,8 @@ case "$1" in
 EOF
     ;;
 
+  *)
+    exit $DOKKU_NOT_IMPLEMENTED_EXIT
+    ;;
+
 esac


### PR DESCRIPTION
Plugins with commands will need to implement a catch-all command that exits with the `DOKKU_NOT_IMPLEMENTED_EXIT`` code (10). This signals to dokku that a given plugin has indeed not executed anything for a plugin (which may not always be the case).

Using plugins that do not implement this pattern will result in those plugins silencing the error message.
