### PR TITLE
use DOKKU_IMAGE (i.e. progrium/buildstep)

### DIFF
--- a/dokku
+++ b/dokku
@@ -42,7 +42,7 @@ case "$1" in
 
   build)
     APP="$2"; IMAGE="dokku/$APP"; CACHE_DIR="$DOKKU_ROOT/$APP/cache"
-    id=$(cat | docker run -i -a stdin $DOKKU_DISTRO /bin/bash -c "mkdir -p /app && tar -xC /app")
+    id=$(cat | docker run -i -a stdin $DOKKU_IMAGE /bin/bash -c "mkdir -p /app && tar -xC /app")
     test $(docker wait $id) -eq 0
     docker commit $id $IMAGE > /dev/null
     [[ -d $CACHE_DIR ]] || mkdir $CACHE_DIR


### PR DESCRIPTION
As I commented in the original PR (albeit late), I think we want to be using $DOKKU_IMAGE here. Feel free to tell me I'm on crack if I missed something.
