### PR TITLE
fix missing semicolon in nginx config

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -32,7 +32,7 @@ ssl_prefer_server_ciphers on;
 EOF
 fi
 
-echo 'server_names_hash_bucket_size 64' >| /etc/nginx/conf.d/server_names_hash_bucket_size.conf
+echo 'server_names_hash_bucket_size 64;' >| /etc/nginx/conf.d/server_names_hash_bucket_size.conf
 
 if [[ ! -f  "$DOKKU_ROOT/VHOST" ]]; then
   [[ $(dig +short $(< "$DOKKU_ROOT/HOSTNAME")) ]] && cp "$DOKKU_ROOT/HOSTNAME" "$DOKKU_ROOT/VHOST"


### PR DESCRIPTION
There is a missing semicolon which causes nginx to not reload after dokku install
