### PR TITLE
Official user-env-compile plugin

### DIFF
--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -3,12 +3,13 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
 
+[[ -f "$DOKKU_ROOT/BUILD_ENV" ]] && cat "$DOKKU_ROOT/BUILD_ENV" >> "$DOKKU_ROOT/ENV" && rm "$DOKKU_ROOT/BUILD_ENV"
+
+[[ ! $(grep CURL_CONNECT_TIMEOUT "$DOKKU_ROOT/ENV") ]] && echo "export CURL_CONNECT_TIMEOUT=5" >> "$DOKKU_ROOT/ENV"
+[[ ! $(grep CURL_TIMEOUT "$DOKKU_ROOT/ENV") ]] && echo "export CURL_TIMEOUT=30" >> "$DOKKU_ROOT/ENV"
+
 if [[ -f "$DOKKU_ROOT/ENV" ]]; then
   BUILD_ENV+=$(< "$DOKKU_ROOT/ENV")
-fi
-if [[ -f "$DOKKU_ROOT/BUILD_ENV" ]]; then
-  BUILD_ENV+=" "
-  BUILD_ENV+=$(< "$DOKKU_ROOT/BUILD_ENV")
 fi
 if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
   BUILD_ENV+=" "


### PR DESCRIPTION
- Uses ENV and APP/ENV files
- Supports old BUILD_ENV files (which are likely in wide-use)
- Allows user's to override globals with app-specific configuration

TODO:
- [x] Migrate `$DOKKU_ROOT/BUILD_ENV` to `$DOKKU_ROOT/ENV` if the former exists and the latter does not
- [x] Drop `BUILD_ENV` support in favor of just `ENV`
- [x] ~~Allow configuring of global `ENV` file~~ We'll do this if there is a need.
- [x] Add default `ENV` with `CURL_TIMEOUT` and `CURL_CONNECT_TIMEOUT`

Closes #284
Closes #683
Closes #763

Refs #503
Refs #678
