### PR TITLE
fix apps plugin issues in 0.3.6

### DIFF
--- a/plugins/apps/commands
+++ b/plugins/apps/commands
@@ -4,7 +4,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 case "$1" in
   apps)
     echo "=== My Apps"
-    find $DOKKU_ROOT -maxdepth 1 -type d  \( ! -iname ".*" \)  -not -path $DOKKU_ROOT/tls | sed 's|^\./||g' | sed 's|'$DOKKU_ROOT'\/||' | tail -n +2 | sort
+    find $DOKKU_ROOT -follow -maxdepth 1 -type d  \( ! -iname ".*" \)  -not -path $DOKKU_ROOT/tls | sed 's|^\./||g' | sed 's|'$DOKKU_ROOT'\/||' | tail -n +2 | sort
     ;;
 
   apps:create)


### PR DESCRIPTION
1) `dokku apps:create` would always fail because it was searching for an empty app and thus `$DOKKU_ROOT/$APP` always exists.

2) I happen to have `/home/dokku` mounted to an external folder using a symlink and `find` requires the `-follow` to make this properly list the contents.
