### PR TITLE
do not output message when creating ENV file

### DIFF
--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -93,8 +93,7 @@ case "$1" in
       exit 1
     fi
 
-    config_create
-    if [[ ! -s $ENV_FILE ]] ; then
+    if [[ ! -f $ENV_FILE ]] ; then
       exit 0
     fi
 


### PR DESCRIPTION
This fixes a bug introduced when deploying apps where the
nginx-vhosts plugin runs `dokku config:get $APP NO_VHOST`. The initial
run of this actually was creating the `ENV` file and dumping to
stdout the value "NO_VHOST=-----> Creating /home/dokku/foo/ENV". This
was obviously no good because nginx-vhosts was considering this to be a
value of true.

I've modified this to simply not return anything when the value does not
exist. A better update may be to output the messages to stderr instead
of stdout.

To be clear, deploying apps is completely broken for me in v0.3.6 due to
this, as the vhost is never configured.
