### PR TITLE
Fixed import-ssl server.crt/key check

### DIFF
--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -11,8 +11,8 @@ case "$1" in
     TEMP_DIR=`mktemp -d`
     cd $TEMP_DIR
     tar xvf - <&0
-    [[ -f "$TEMP_DIR/server.crt" ]] && echo "Tar archive missing server.crt" && exit 1
-    [[ -f "$TEMP_DIR/server.key" ]] && echo "Tar archive missing server.key" && exit 1
+    [[ ! -f "$TEMP_DIR/server.crt" ]] && echo "Tar archive missing server.crt" && exit 1
+    [[ ! -f "$TEMP_DIR/server.key" ]] && echo "Tar archive missing server.key" && exit 1
 
     mkdir -p "$DOKKU_ROOT/$APP/tls"
     mv "$TEMP_DIR/server.crt" "$DOKKU_ROOT/$APP/tls/server.crt"


### PR DESCRIPTION
`nginx:import-ssl` is currently always reporting missing files. File check needs to be inverted.
