### PR TITLE
Please increase the server_names_hash_bucket_size

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -62,7 +62,7 @@ http {
 
 EOF
 
-echo 'server_names_hash_bucket_size 64;' >| /etc/nginx/conf.d/server_names_hash_bucket_size.conf
+echo 'server_names_hash_bucket_size 512;' >| /etc/nginx/conf.d/server_names_hash_bucket_size.conf
 
 if [[ ! -f  "$DOKKU_ROOT/VHOST" ]]; then
   [[ $(dig +short $(< "$DOKKU_ROOT/HOSTNAME")) ]] && cp "$DOKKU_ROOT/HOSTNAME" "$DOKKU_ROOT/VHOST"


### PR DESCRIPTION
I use Dokku in a private environment with very long hostname.... 64 was always a lot to short.
