### PR TITLE
create build env for both dokku and new style buildpacks

### DIFF
--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -17,7 +17,8 @@ fi
 
 if [[ ! -z "$BUILD_ENV" ]]; then
   echo "-----> Adding BUILD_ENV to build environment..."
-  # create build env files for use in buildpacks like this: https://github.com/niteoweb/heroku-buildpack-buildout/blob/master/bin/compile#L34
+  # create build env files for use in buildpacks like this:
+  # https://github.com/niteoweb/heroku-buildpack-buildout/blob/5879fa3418f7d8e079f1aa5816ba1adde73f4948/bin/compile#L34
   id=$(echo $BUILD_ENV |sed 's@export @@g'| docker run -i -a stdin $IMAGE /bin/bash -c "for ENV_VAR in `cat`; do echo \$ENV_VAR |sed 's@^\([^=]*\)=\(.*\)\$@echo \2 >/tmp/env/\1@g' >>/tmp/set_env.sh; done && mkdir -p /tmp/env && /bin/bash /tmp/set_env.sh")
   test $(docker wait $id) -eq 0
   docker commit $id $IMAGE > /dev/null


### PR DESCRIPTION
This functionally works in that we get both a useful `/app/.env` and per-variable file in `/tmp/env`

ref: #787
