### PR TITLE
auto remove the cache dir cleanup container

### DIFF
--- a/plugins/apps/pre-delete
+++ b/plugins/apps/pre-delete
@@ -3,5 +3,5 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"; IMAGE="dokku/$APP"; CACHE_DIR="$DOKKU_ROOT/$APP/cache"
 if [[ -d $CACHE_DIR ]]; then
-  docker run -v "$CACHE_DIR:/cache" "$IMAGE" find /cache -depth -mindepth 1 -maxdepth 1 -exec rm -Rf {} \;
+  docker run --rm -v "$CACHE_DIR:/cache" "$IMAGE" find /cache -depth -mindepth 1 -maxdepth 1 -exec rm -Rf {} \;
 fi


### PR DESCRIPTION
This was preventing the app image from being removed upon `apps:destroy`
