### PR TITLE
Allow client requests to be bigger

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -63,6 +63,7 @@ http {
 EOF
 
 echo 'server_names_hash_bucket_size 512;' >| /etc/nginx/conf.d/server_names_hash_bucket_size.conf
+echo 'client_max_body_size 100m;' > | /etc/nginx/conf.d/client_max_body_size.conf
 
 case "$DOKKU_DISTRO" in
   ubuntu)


### PR DESCRIPTION
With certain applications, we always run into the problem of not being able to post enough data with a single request. Some its images, sometimes it database backups or just data, that has to be processed and returned back.
