### PR TITLE
docker-compose support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PREBUILT_STACK_URL ?= gliderlabs/herokuish:latest
 DOKKU_LIB_ROOT ?= /var/lib/dokku
 PLUGINS_PATH ?= ${DOKKU_LIB_ROOT}/plugins
 CORE_PLUGINS_PATH ?= ${DOKKU_LIB_ROOT}/core-plugins
+DOCKER_COMPOSE_VERSION ?= 1.5.0rc1
 
 # If the first argument is "vagrant-dokku"...
 ifeq (vagrant-dokku,$(firstword $(MAKECMDGOALS)))
@@ -22,7 +23,7 @@ else
 	BUILD_STACK_TARGETS = build-in-docker
 endif
 
-.PHONY: all apt-update install version copyfiles man-db plugins dependencies sshcommand plugn docker aufs stack count dokku-installer vagrant-acl-add vagrant-dokku
+.PHONY: all apt-update install version copyfiles man-db plugins dependencies sshcommand plugn docker aufs stack count dokku-installer vagrant-acl-add vagrant-dokku docker-compose shyaml
 
 include tests.mk
 include deb.mk
@@ -77,11 +78,18 @@ plugin-dependencies: plugn
 plugins: plugn docker
 	dokku plugin:install --core
 
-dependencies: apt-update sshcommand plugn docker help2man man-db
+dependencies: apt-update sshcommand plugn docker help2man man-db docker-compose shyaml
 	$(MAKE) -e stack
 
 apt-update:
 	apt-get update
+
+shyaml:
+	apt-get install -qq -y python-yaml
+	curl -L https://raw.githubusercontent.com/0k/shyaml/master/shyaml > /usr/local/bin/shyaml; chmod +x /usr/local/bin/shyaml
+
+docker-compose:
+	curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
 
 help2man:
 	apt-get install -qq -y help2man

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PREBUILT_STACK_URL ?= gliderlabs/herokuish:latest
 DOKKU_LIB_ROOT ?= /var/lib/dokku
 PLUGINS_PATH ?= ${DOKKU_LIB_ROOT}/plugins
 CORE_PLUGINS_PATH ?= ${DOKKU_LIB_ROOT}/core-plugins
-DOCKER_COMPOSE_VERSION ?= 1.5.0rc1
+DOCKER_COMPOSE_VERSION ?= 1.5.0rc2
 
 # If the first argument is "vagrant-dokku"...
 ifeq (vagrant-dokku,$(firstword $(MAKECMDGOALS)))
@@ -86,10 +86,12 @@ apt-update:
 
 shyaml:
 	apt-get install -qq -y python-yaml
-	curl -L https://raw.githubusercontent.com/0k/shyaml/master/shyaml > /usr/local/bin/shyaml; chmod +x /usr/local/bin/shyaml
+	curl -L https://raw.githubusercontent.com/0k/shyaml/master/shyaml > /usr/local/bin/shyaml
+	chmod +x /usr/local/bin/shyaml
 
 docker-compose:
 	curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+	chmod +x /usr/local/bin/docker-compose
 
 help2man:
 	apt-get install -qq -y help2man

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: amd64
 Depends: locales, git, make, curl, software-properties-common, docker-engine | docker-engine-cs | lxc-docker, gcc, python-software-properties, man-db, herokuish, sshcommand
-Pre-Depends: nginx, dnsutils, ruby, ruby-dev, rubygem-rack, rubygem-rack-protection, rubygem-sinatra, rubygem-tilt, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo
+Pre-Depends: nginx, dnsutils, ruby, ruby-dev, rubygem-rack, rubygem-rack-protection, rubygem-sinatra, rubygem-tilt, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo, python-yaml
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 Description: Docker powered mini-Heroku in around 100 lines of Bash

--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -192,4 +192,4 @@ See the [zero-downtime deploy documentation](/dokku/checks-examples/).
 
 ## Image tagging
 
-See the [image tagging documentation](/dokku/deployment/images).
+See the [image tagging documentation](/dokku/deployment/images/).

--- a/docs/deployment/docker-compose.md
+++ b/docs/deployment/docker-compose.md
@@ -1,0 +1,53 @@
+# Dockerfile Deployment
+
+> New as of 0.4.3
+
+As an extension of Dockerfile-based deployment, you can also deploy an application that uses `docker-compose`. This is useful as an alternative to running a process manager inside of a `Dockerfile`-based container, and should be considered the canonical way to deploy multiple processes when using a `Dockerfile` directly.
+
+To deploy an application via `docker-compose`, your repository will need the following files:
+
+- `Dockerfile`
+- `docker-compose.yml`
+
+To use `docker-compose` for deployment, commit a valid `Dockerfile` **and** `docker-compose.yml` to the root of your repository and push the repository to your Dokku installation. If these files are detected, Dokku will default to using it to construct containers **except** in the following two cases:
+
+- The application has a `BUILDPACK_URL` environment variable set via the `dokku config:set` command or in a committed `.env` file. In this case, Dokku will use your specified buildpack.
+- The application has a `.buildpacks` file in the root of the repository. In this case, Dokku will use your specified buildpack(s).
+
+At this time, you cannot fallback to using `Dockerfile` only deployments.
+
+## Web processes
+
+At this time, you may only have **one** web process proxied by nginx. Having any other processes will require manual configuration of your nginx configuration.
+
+The web process is noted as either the `app` or `web` stanza in your `docker-compose.yml` file, with the `web` stanza having precedence.
+
+Your application *must* have either an `app` or `web` stanza or the `docker-compose` deployment will fail.
+
+## Exposed ports
+
+By default, Dokku will extract the first `EXPOSE` tcp port and use said port with nginx to proxy your app to that port. For applications that have multiple ports exposed, you may override this port via the following command:
+
+```shell
+# replace APP with the name of your application
+dokku config:set APP DOKKU_DOCKERFILE_PORT=8000
+```
+
+Dokku will not expose other ports on your application without a [custom docker-option](/dokku/configuration/docker-options/).
+
+If you do not have a port explicitly exposed, Dokku will automatically expose port `5000` for your application.
+
+## Dependent images
+
+Dokku will automatically use the images specified for each process-type specified in a `docker-compose.yml` file, and will fall back to the image created by either the `app` or `web` process-type. Non-primary process types will be scaled to 0 by default.
+
+## Limitations
+
+`docker-compose` support has a few known limitations. The below is not considered exhaustive, and may change over time.
+
+- Container `links` do not work. When Dokku starts containers, the containers are named pseudo-randomly, and due to how zero-downtime deployments work, we cannot guarantee that any started links will start properly. Docker also cannot link already started containers, and thus this functionality is currently unused. For datastores, please use the [official datastore plugins](/dokku/plugins/#official-plugins-beta).
+- Dokku uses a special `Procfile.compose` file to maintain a mapping of the process type to docker image. Please avoid using this file for other purposes.
+
+## Process scaling
+
+Process scaling works the same as it does for `buildpack` deployments. See the [process management documentation](/dokku/process-management/).

--- a/docs/process-management.md
+++ b/docs/process-management.md
@@ -17,7 +17,7 @@ ps:stop <app>                                    Stop app container(s)
 
 ## Scaling
 
-Dokku allows you to run multiple process types at different container counts. For example, if you had an app that contained 1 web app listener and 1 background job processor, dokku can, spin up 1 container for each process type defined in the Procfile. *By default, dokku will only start a single web process (if defined.)* However, if you wanted, for example, 2 job processors running simultaneously, you can modify this behavior in one of the following ways.
+Dokku allows you to run multiple process types at different container counts. For example, if you had an app that contained 1 web app listener and 1 background job processor, dokku can, spin up 1 container for each process type defined in the `Procfile` or `docker-compose.yml` file. *By default, dokku will only start a single web process (if defined.)* However, if you wanted, for example, 2 job processors running simultaneously, you can modify this behavior in one of the following ways.
 
 ### DOKKU_SCALE file
 

--- a/docs/template.html
+++ b/docs/template.html
@@ -70,6 +70,7 @@
 
             <a href="/dokku/application-deployment/" class="list-group-item">Deploying an Application</a>
             <a href="/dokku/deployment/dockerfiles/" class="list-group-item">Dockerfile Deployment</a>
+            <a href="/dokku/deployment/docker-compose/" class="list-group-item">Docker Compose Deployment</a>
             <a href="/dokku/deployment/images/" class="list-group-item">Image Tagging</a>
             <a href="/dokku/remote-commands/" class="list-group-item">Remote Commands</a>
             <a href="/dokku/deployment/one-off-processes/" class="list-group-item">One Off Processes</a>

--- a/dokku
+++ b/dokku
@@ -111,7 +111,6 @@ case "$1" in
            [[ "$line" == $PROC_TYPE* ]] && PROC_IMAGE=$(echo $line | cut -d' ' -f2) && break
         done < "$COMPOSE_PROCFILE"
       fi
-      echo $PROC_IMAGE
 
       while [[ $CONTAINER_INDEX -le $PROC_COUNT ]]; do
         id=""; port=""; ipaddr=""

--- a/dokku
+++ b/dokku
@@ -105,7 +105,7 @@ case "$1" in
       COMPOSE_PROCFILE="$COMPOSE_PROCFILE_DIR/Procfile.compose"
 
       mkdir -p "$COMPOSE_PROCFILE_DIR"
-      copy_from_image "$IMAGE" "/opt/Procfile.compose" "$COMPOSE_PROCFILE_DIR" 2>/dev/null || true
+      copy_from_image "$IMAGE" "/tmp/Procfile.compose" "$COMPOSE_PROCFILE_DIR" 2>/dev/null || true
       if [[ -f "$COMPOSE_PROCFILE" ]]; then
         while read line || [[ -n "$line" ]]; do
            [[ "$line" == $PROC_TYPE* ]] && PROC_IMAGE=$(echo $line | cut -d' ' -f2) && break

--- a/dokku
+++ b/dokku
@@ -100,6 +100,7 @@ case "$1" in
       PROC_TYPE=${TRIM%%=*}
       PROC_COUNT=${TRIM#*=}
       CONTAINER_INDEX=1
+      PROC_IMAGE=$IMAGE
 
       while [[ $CONTAINER_INDEX -le $PROC_COUNT ]]; do
         id=""; port=""; ipaddr=""
@@ -123,15 +124,15 @@ case "$1" in
         if [[ "$PROC_TYPE" == "web" ]]; then
           port=${DOKKU_DOCKERFILE_PORT:=5000}
           if [[ "$BIND_EXTERNAL" = "true" ]]; then
-            id=$(docker run -d -p $port -e PORT=$port $DOCKER_ARGS $IMAGE $START_CMD)
+            id=$(docker run -d -p $port -e PORT=$port $DOCKER_ARGS $PROC_IMAGE $START_CMD)
             port=$(docker port $id $port | sed 's/[0-9.]*://')
             ipaddr=127.0.0.1
           else
-            id=$(docker run -d -e PORT=$port $DOCKER_ARGS $IMAGE $START_CMD)
+            id=$(docker run -d -e PORT=$port $DOCKER_ARGS $PROC_IMAGE $START_CMD)
             ipaddr=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $id)
           fi
         else
-          id=$(docker run -d $DOCKER_ARGS $IMAGE $START_CMD)
+          id=$(docker run -d $DOCKER_ARGS $PROC_IMAGE $START_CMD)
         fi
 
         # if we can't post-deploy successfully, kill new container

--- a/dokku
+++ b/dokku
@@ -101,6 +101,17 @@ case "$1" in
       PROC_COUNT=${TRIM#*=}
       CONTAINER_INDEX=1
       PROC_IMAGE=$IMAGE
+      COMPOSE_PROCFILE_DIR="/tmp/$APP"
+      COMPOSE_PROCFILE="$COMPOSE_PROCFILE_DIR/Procfile.compose"
+
+      mkdir -p "$COMPOSE_PROCFILE_DIR"
+      copy_from_image "$IMAGE" "/opt/Procfile.compose" "$COMPOSE_PROCFILE_DIR" 2>/dev/null || true
+      if [[ -f "$COMPOSE_PROCFILE" ]]; then
+        while read line || [[ -n "$line" ]]; do
+           [[ "$line" == $PROC_TYPE* ]] && PROC_IMAGE=$(echo $line | cut -d' ' -f2) && break
+        done < "$COMPOSE_PROCFILE"
+      fi
+      echo $PROC_IMAGE
 
       while [[ $CONTAINER_INDEX -le $PROC_COUNT ]]; do
         id=""; port=""; ipaddr=""

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -83,7 +83,7 @@ case "$1" in
         done
 
         # add a compose procfile
-        id=$(docker run -i -a stdin $IMAGE /bin/bash -c "cat > /opt/$process_file" < "$process_file")
+        id=$(docker run -i -a stdin $IMAGE /bin/bash -c "cat > /tmp/$process_file" < "$process_file")
         test "$(docker wait $id)" -eq 0
         docker commit $id $IMAGE > /dev/null
         docker stop $id > /dev/null 2>&1 || true

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -62,12 +62,12 @@ case "$1" in
         dokku_log_verbose_quiet "Pulling service images, it may take some time ..."
         cd $TMP_WORK_DIR && docker-compose $COMPOSE_ARGS pull > /dev/null
 
-        app_stanza_type=$(shyaml get-type app < docker-compose.yml 2> /dev/null || true)
         web_stanza_type=$(shyaml get-type web < docker-compose.yml 2> /dev/null || true)
-        if [[ $app_stanza_type == "struct" ]]; then
-          docker tag -f "$APP"_app "$IMAGE"
-        elif [[ $web_stanza_type == "struct" ]]; then
+        app_stanza_type=$(shyaml get-type app < docker-compose.yml 2> /dev/null || true)
+        if [[ $web_stanza_type == "struct" ]]; then
           docker tag -f "$APP"_web "$IMAGE"
+        elif [[ $app_stanza_type == "struct" ]]; then
+          docker tag -f "$APP"_app "$IMAGE"
         else
           dokku_log_fail "Could not detect app or web stanza in docker-compose.yml"
         fi

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -8,6 +8,7 @@ source "$PLUGIN_AVAILABLE_PATH/nginx-vhosts/functions"
 case "$1" in
   build)
     APP="$2"; IMAGE_SOURCE_TYPE="$3"; TMP_WORK_DIR="$4"; IMAGE=$(get_app_image_name $APP)
+    APP_DIR="$DOKKU_ROOT/$APP/app"
     verify_app_name "$APP"
 
     CACHE_DIR="$DOKKU_ROOT/$APP/cache"
@@ -46,6 +47,34 @@ case "$1" in
         plugn trigger post-build-dockerfile "$APP"
         ;;
 
+      compose)
+        # extract first port from docker-compose.yml
+        COMPOSE_PORT=$(cat docker-compose.yml | shyaml get-value app.ports.0 2> /dev/null || true)
+        [[ ! -n "$COMPOSE_PORT" ]] && COMPOSE_PORT=$(cat docker-compose.yml | shyaml get-value web.ports.0 2> /dev/null || true)
+        [[ -n "$COMPOSE_PORT" ]] && config_set --no-restart $APP DOKKU_COMPOSE_PORT=$COMPOSE_PORT
+        plugn trigger pre-build-compose "$APP"
+
+        FIG_ARGS=$(: | plugn trigger compose-args-build $APP)
+        dokku_log_verbose_quiet "Building docker images, it may take some time ..."
+        cd $TMP_WORK_DIR && docker-compose $FIG_ARGS build > /dev/null
+
+        FIG_ARGS=$(: | plugn trigger compose-args-pull $APP)
+        dokku_log_verbose_quiet "Pulling service images, it may take some time ..."
+        cd $TMP_WORK_DIR && docker-compose $FIG_ARGS pull > /dev/null
+
+        app_stanza_type=$(cat docker-compose.yml | shyaml get-type app 2> /dev/null || true)
+        web_stanza_type=$(cat docker-compose.yml | shyaml get-type web 2> /dev/null || true)
+        if [[ $app_stanza_type == "struct" ]]; then
+          docker tag -f "$APP"_app "$IMAGE"
+        elif [[ $web_stanza_type == "struct" ]]; then
+          docker tag -f "$APP"_web "$IMAGE"
+        else
+          dokku_log_fail "Could not detect app or web stanza in docker-compose.yml"
+        fi
+
+        plugn trigger post-build-compose "$APP"
+        ;;
+
       *)
         dokku_log_fail "Building image source type $IMAGE_SOURCE_TYPE not supported!"
         ;;
@@ -76,6 +105,12 @@ case "$1" in
         # buildstep plugins don't necessarily make sense for dockerfiles. call the new breed!!!
         plugn trigger pre-release-dockerfile "$APP" "$IMAGE_TAG"
         plugn trigger post-release-dockerfile "$APP" "$IMAGE_TAG"
+        ;;
+
+      compose)
+        # buildstep plugins don't necessarily make sense for docker-compose. call the new breed!!!
+        plugn trigger pre-release-compose "$APP" "$IMAGE_TAG"
+        plugn trigger post-release-compose "$APP" "$IMAGE_TAG"
         ;;
 
       *)

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -72,6 +72,22 @@ case "$1" in
           dokku_log_fail "Could not detect app or web stanza in docker-compose.yml"
         fi
 
+        # keep track of all the images
+        process_file="Procfile.compose"
+        touch "$process_file"
+        for key in $(cat docker-compose.yml | shyaml keys); do
+          image_name=$(cat docker-compose.yml | shyaml get-value $key.image 2> /dev/null || echo "$APP"_"$key");
+          image_tag="$IMAGE"-"$key"
+          docker tag -f "$image_name" "$image_tag"
+          echo "$key: $image_tag" >> "$process_file"
+        done
+
+        # add a compose procfile
+        id=$(cat $process_file | docker run -i -a stdin $IMAGE /bin/bash -c "cat > /opt/$process_file")
+        test $(docker wait $id) -eq 0
+        docker commit $id $IMAGE > /dev/null
+        docker stop $id && docker kill $id
+
         plugn trigger post-build-compose "$APP"
         ;;
 

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -86,7 +86,7 @@ case "$1" in
         id=$(cat $process_file | docker run -i -a stdin $IMAGE /bin/bash -c "cat > /opt/$process_file")
         test $(docker wait $id) -eq 0
         docker commit $id $IMAGE > /dev/null
-        docker stop $id && docker kill $id
+        docker stop $id > /dev/null && docker kill $id > /dev/null || true
 
         plugn trigger post-build-compose "$APP"
         ;;

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -86,7 +86,8 @@ case "$1" in
         id=$(cat $process_file | docker run -i -a stdin $IMAGE /bin/bash -c "cat > /opt/$process_file")
         test $(docker wait $id) -eq 0
         docker commit $id $IMAGE > /dev/null
-        docker stop $id > /dev/null && docker kill $id > /dev/null || true
+        docker stop $id > /dev/null 2>&1 || true
+        docker kill $id > /dev/null 2>&1 || true
 
         plugn trigger post-build-compose "$APP"
         ;;

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -54,13 +54,13 @@ case "$1" in
         [[ -n "$COMPOSE_PORT" ]] && config_set --no-restart $APP DOKKU_COMPOSE_PORT=$COMPOSE_PORT
         plugn trigger pre-build-compose "$APP"
 
-        FIG_ARGS=$(: | plugn trigger compose-args-build $APP)
+        COMPOSE_ARGS=$(: | plugn trigger compose-args-build $APP)
         dokku_log_verbose_quiet "Building docker images, it may take some time ..."
-        cd $TMP_WORK_DIR && docker-compose $FIG_ARGS build > /dev/null
+        cd $TMP_WORK_DIR && docker-compose $COMPOSE_ARGS build > /dev/null
 
-        FIG_ARGS=$(: | plugn trigger compose-args-pull $APP)
+        COMPOSE_ARGS=$(: | plugn trigger compose-args-pull $APP)
         dokku_log_verbose_quiet "Pulling service images, it may take some time ..."
-        cd $TMP_WORK_DIR && docker-compose $FIG_ARGS pull > /dev/null
+        cd $TMP_WORK_DIR && docker-compose $COMPOSE_ARGS pull > /dev/null
 
         app_stanza_type=$(cat docker-compose.yml | shyaml get-type app 2> /dev/null || true)
         web_stanza_type=$(cat docker-compose.yml | shyaml get-type web 2> /dev/null || true)

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -56,11 +56,11 @@ case "$1" in
 
         COMPOSE_ARGS=$(: | plugn trigger docker-compose-args-build $APP)
         dokku_log_verbose_quiet "Building docker images, it may take some time ..."
-        cd $TMP_WORK_DIR && docker-compose $COMPOSE_ARGS build > /dev/null
+        cd $TMP_WORK_DIR && docker-compose $COMPOSE_ARGS --project-name "$APP" build > /dev/null
 
         COMPOSE_ARGS=$(: | plugn trigger docker-compose-args-pull $APP)
         dokku_log_verbose_quiet "Pulling service images, it may take some time ..."
-        cd $TMP_WORK_DIR && docker-compose $COMPOSE_ARGS pull > /dev/null
+        cd $TMP_WORK_DIR && docker-compose $COMPOSE_ARGS --project-name "$APP" pull > /dev/null
 
         web_stanza_type=$(shyaml get-type web < docker-compose.yml 2> /dev/null || true)
         app_stanza_type=$(shyaml get-type app < docker-compose.yml 2> /dev/null || true)

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -49,8 +49,8 @@ case "$1" in
 
       compose)
         # extract first port from docker-compose.yml
-        COMPOSE_PORT=$(cat docker-compose.yml | shyaml get-value app.ports.0 2> /dev/null || true)
-        [[ ! -n "$COMPOSE_PORT" ]] && COMPOSE_PORT=$(cat docker-compose.yml | shyaml get-value web.ports.0 2> /dev/null || true)
+        COMPOSE_PORT=$(shyaml get-value app.ports.0 < docker-compose.yml 2> /dev/null || true)
+        [[ ! -n "$COMPOSE_PORT" ]] && COMPOSE_PORT=$(shyaml get-value web.ports.0 < docker-compose.yml 2> /dev/null || true)
         [[ -n "$COMPOSE_PORT" ]] && config_set --no-restart $APP DOKKU_COMPOSE_PORT=$COMPOSE_PORT
         plugn trigger pre-build-compose "$APP"
 
@@ -62,8 +62,8 @@ case "$1" in
         dokku_log_verbose_quiet "Pulling service images, it may take some time ..."
         cd $TMP_WORK_DIR && docker-compose $COMPOSE_ARGS pull > /dev/null
 
-        app_stanza_type=$(cat docker-compose.yml | shyaml get-type app 2> /dev/null || true)
-        web_stanza_type=$(cat docker-compose.yml | shyaml get-type web 2> /dev/null || true)
+        app_stanza_type=$(shyaml get-type app < docker-compose.yml 2> /dev/null || true)
+        web_stanza_type=$(shyaml get-type web < docker-compose.yml 2> /dev/null || true)
         if [[ $app_stanza_type == "struct" ]]; then
           docker tag -f "$APP"_app "$IMAGE"
         elif [[ $web_stanza_type == "struct" ]]; then
@@ -75,16 +75,16 @@ case "$1" in
         # keep track of all the images
         process_file="Procfile.compose"
         touch "$process_file"
-        for key in $(cat docker-compose.yml | shyaml keys); do
-          image_name=$(cat docker-compose.yml | shyaml get-value $key.image 2> /dev/null || echo "$APP"_"$key");
-          image_tag="$IMAGE"-"$key"
+        for key in $(shyaml keys < docker-compose.yml); do
+          image_name=$(shyaml get-value $key.image < docker-compose.yml 2> /dev/null || echo "${APP}_${key}");
+          image_tag="$IMAGE-$key"
           docker tag -f "$image_name" "$image_tag"
           echo "$key: $image_tag" >> "$process_file"
         done
 
         # add a compose procfile
-        id=$(cat $process_file | docker run -i -a stdin $IMAGE /bin/bash -c "cat > /opt/$process_file")
-        test $(docker wait $id) -eq 0
+        id=$(docker run -i -a stdin $IMAGE /bin/bash -c "cat > /opt/$process_file" < "$process_file")
+        test "$(docker wait $id)" -eq 0
         docker commit $id $IMAGE > /dev/null
         docker stop $id > /dev/null 2>&1 || true
         docker kill $id > /dev/null 2>&1 || true

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -47,18 +47,18 @@ case "$1" in
         plugn trigger post-build-dockerfile "$APP"
         ;;
 
-      compose)
+      docker-compose)
         # extract first port from docker-compose.yml
         COMPOSE_PORT=$(shyaml get-value app.ports.0 < docker-compose.yml 2> /dev/null || true)
         [[ ! -n "$COMPOSE_PORT" ]] && COMPOSE_PORT=$(shyaml get-value web.ports.0 < docker-compose.yml 2> /dev/null || true)
         [[ -n "$COMPOSE_PORT" ]] && config_set --no-restart $APP DOKKU_COMPOSE_PORT=$COMPOSE_PORT
-        plugn trigger pre-build-compose "$APP"
+        plugn trigger pre-build-docker-compose "$APP"
 
-        COMPOSE_ARGS=$(: | plugn trigger compose-args-build $APP)
+        COMPOSE_ARGS=$(: | plugn trigger docker-compose-args-build $APP)
         dokku_log_verbose_quiet "Building docker images, it may take some time ..."
         cd $TMP_WORK_DIR && docker-compose $COMPOSE_ARGS build > /dev/null
 
-        COMPOSE_ARGS=$(: | plugn trigger compose-args-pull $APP)
+        COMPOSE_ARGS=$(: | plugn trigger docker-compose-args-pull $APP)
         dokku_log_verbose_quiet "Pulling service images, it may take some time ..."
         cd $TMP_WORK_DIR && docker-compose $COMPOSE_ARGS pull > /dev/null
 
@@ -89,7 +89,7 @@ case "$1" in
         docker stop $id > /dev/null 2>&1 || true
         docker kill $id > /dev/null 2>&1 || true
 
-        plugn trigger post-build-compose "$APP"
+        plugn trigger post-build-docker-compose "$APP"
         ;;
 
       *)
@@ -124,10 +124,10 @@ case "$1" in
         plugn trigger post-release-dockerfile "$APP" "$IMAGE_TAG"
         ;;
 
-      compose)
+      docker-compose)
         # buildstep plugins don't necessarily make sense for docker-compose. call the new breed!!!
-        plugn trigger pre-release-compose "$APP" "$IMAGE_TAG"
-        plugn trigger post-release-compose "$APP" "$IMAGE_TAG"
+        plugn trigger pre-release-docker-compose "$APP" "$IMAGE_TAG"
+        plugn trigger post-release-docker-compose "$APP" "$IMAGE_TAG"
         ;;
 
       *)

--- a/plugins/00_dokku-standard/compose-args-build
+++ b/plugins/00_dokku-standard/compose-args-build
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+STDIN=$(cat)
+APP="$1"
+
+echo "$STDIN -p $APP"

--- a/plugins/00_dokku-standard/compose-args-run
+++ b/plugins/00_dokku-standard/compose-args-run
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+STDIN=$(cat)
+APP="$1"
+
+echo "$STDIN -p $APP"

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -20,13 +20,14 @@ git_build_app_repo() {
   git submodule update --init --recursive &> /dev/null
   find -name .git -prune -exec rm -rf {} \; > /dev/null
 
-  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]]; then
-    plugn trigger pre-receive-app "$APP" "dockerfile" "$TMP_WORK_DIR"
-    dokku receive "$APP" "dockerfile" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
-  else
-    plugn trigger pre-receive-app "$APP" "herokuish" "$TMP_WORK_DIR"
-    dokku receive "$APP" "herokuish" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
+  local IMAGE_SOURCE_TYPE="herokuish"
+  if [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]]; then
+    [[ -f Dockerfile ]] && IMAGE_SOURCE_TYPE="dockerfile"
+    [[ -f Dockerfile ]] && [[ -f docker-compose.yml ]] && IMAGE_SOURCE_TYPE="compose"
   fi
+
+  plugn trigger pre-receive-app "$APP" "$IMAGE_SOURCE_TYPE" "$TMP_WORK_DIR"
+  dokku receive "$APP" "$IMAGE_SOURCE_TYPE" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
 }
 
 case "$1" in

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -23,7 +23,7 @@ git_build_app_repo() {
   local IMAGE_SOURCE_TYPE="herokuish"
   if [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]]; then
     [[ -f Dockerfile ]] && IMAGE_SOURCE_TYPE="dockerfile"
-    [[ -f Dockerfile ]] && [[ -f docker-compose.yml ]] && IMAGE_SOURCE_TYPE="compose"
+    [[ -f Dockerfile ]] && [[ -f docker-compose.yml ]] && IMAGE_SOURCE_TYPE="docker-compose"
   fi
 
   plugn trigger pre-receive-app "$APP" "$IMAGE_SOURCE_TYPE" "$TMP_WORK_DIR"

--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -21,7 +21,7 @@ generate_scale_file() {
     trap 'rm -rf "$TMP_WORK_DIR" > /dev/null' RETURN
 
     copy_from_image "$IMAGE" "/app/Procfile" "$TMP_WORK_DIR" 2>/dev/null || true
-    copy_from_image "$IMAGE" "/opt/Procfile.compose" "$TMP_WORK_DIR" 2>/dev/null || true
+    copy_from_image "$IMAGE" "/tmp/Procfile.compose" "$TMP_WORK_DIR" 2>/dev/null || true
     local PROCFILE="$TMP_WORK_DIR/Procfile"
     local COMPOSE_PROCFILE="$TMP_WORK_DIR/Procfile.compose"
     if [[ ! -e "$PROCFILE" ]] && [[ ! -e "$COMPOSE_PROCFILE" ]]; then

--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -34,7 +34,6 @@ generate_scale_file() {
         NAME=${line%%:*}
         NUM_PROCS=0
         [[ "$NAME" == "web" ]] && NUM_PROCS=1
-        [[ -e "$COMPOSE_PROCFILE" ]] && NUM_PROCS=1
         echo "$NAME=$NUM_PROCS" >> $DOKKU_SCALE_FILE
       done < "$DOKKU_PROCFILE"
     fi

--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -21,17 +21,22 @@ generate_scale_file() {
     trap 'rm -rf "$TMP_WORK_DIR" > /dev/null' RETURN
 
     copy_from_image "$IMAGE" "/app/Procfile" "$TMP_WORK_DIR" 2>/dev/null || true
+    copy_from_image "$IMAGE" "/opt/Procfile.compose" "$TMP_WORK_DIR" 2>/dev/null || true
     local PROCFILE="$TMP_WORK_DIR/Procfile"
-    if [[ ! -e "$PROCFILE" ]]; then
+    local COMPOSE_PROCFILE="$TMP_WORK_DIR/Procfile.compose"
+    if [[ ! -e "$PROCFILE" ]] && [[ ! -e "$COMPOSE_PROCFILE" ]]; then
       echo "web=1" >> $DOKKU_SCALE_FILE
     else
+      COMPOSE_PROCFILE="$PROCFILE"
+      [[ -e "$COMPOSE_PROCFILE" ]] && DOKKU_PROCFILE="$COMPOSE_PROCFILE"
       while read line || [[ -n "$line" ]]; do
         [[ -z "$line" ]] && continue
         NAME=${line%%:*}
         NUM_PROCS=0
         [[ "$NAME" == "web" ]] && NUM_PROCS=1
+        [[ -e "$COMPOSE_PROCFILE" ]] && NUM_PROCS=1
         echo "$NAME=$NUM_PROCS" >> $DOKKU_SCALE_FILE
-      done < "$PROCFILE"
+      done < "$DOKKU_PROCFILE"
     fi
     dokku_log_info1_quiet "New DOKKU_SCALE file generated"
   else

--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -27,7 +27,7 @@ generate_scale_file() {
     if [[ ! -e "$PROCFILE" ]] && [[ ! -e "$COMPOSE_PROCFILE" ]]; then
       echo "web=1" >> $DOKKU_SCALE_FILE
     else
-      COMPOSE_PROCFILE="$PROCFILE"
+      DOKKU_PROCFILE="$PROCFILE"
       [[ -e "$COMPOSE_PROCFILE" ]] && DOKKU_PROCFILE="$COMPOSE_PROCFILE"
       while read line || [[ -n "$line" ]]; do
         [[ -z "$line" ]] && continue


### PR DESCRIPTION
This PR implements preliminary docker-compose support. It's pretty untested, but building containers and deploying them the dokku way appears to work. A few notes:

- `links` do not work. This is because containers have random names when we start them, and the links depend upon those names being applied to running containers. There isn't a straightforward way to do this since you cannot re-link running containers. I'm sure other compose features are similarly broken.
- We require using a `Procfile.compose` to track the required image for a given process type. It's pretty hacky and I'm not proud of it.
- It goes without saying, but you need both a `Dockerfile` and a `docker-compose.yml` file. Unfortunately there is currently no way to disable `docker-compose` support.
- Tests don't pass, mostly because github is broken atm and I didn't run them locally. We probably want a `docker-compose` test as well. I have a small app that should work.
- You still need to run the following (as root) to get this to work:

 ```shell
curl -L https://raw.githubusercontent.com/0k/shyaml/master/shyaml > /usr/local/bin/shyaml; chmod +x /usr/local/bin/shyaml
curl -L https://github.com/docker/compose/releases/download/1.5.0rc1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
apt-get install python-yaml
```

Todo:

- [ ] Add a test
- [ ] Display warning if links are specified in `docker-compose.yml`.
- [ ] Create a package for shyaml
- [ ] Create a package for docker-compose (and a PR upstream would be nice as well)
- [ ] Do another pass on documentation

Refs #1564
Refs #1594