### PR TITLE
Fix dokku compatibility with systemd and sysv-init systems

### DIFF
--- a/contrib/dokku-installer.rbinit
+++ b/contrib/dokku-installer.rbinit
@@ -1,0 +1,68 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start dokku-installer at boot time
+# Description:       Enable dokku-installer service provided by daemon.
+### END INIT INFO
+
+DAEMON=/usr/local/share/dokku/contrib/dokku-installer.rb
+DIR=$(dirname "$DAEMON")
+NAME=dokku-installer
+DAEMONUSER=root
+PIDFILE="/var/run/${NAME}.pid"
+LOGFILE="/var/log/${NAME}.log"
+ERRFILE="/var/log/${NAME}.err"
+DESC="dokku"
+
+test -x $DAEMON || exit 0
+
+. /lib/lsb/init-functions
+
+case "$1" in
+    start)
+        if [ -e $PIDFILE ]; then
+          if $0 status > /dev/null ; then
+            log_success_msg "$DESC already started; not starting."
+            return
+          else
+            log_success_msg "Removing stale PID file $PIDFILE."
+            rm -f $PIDFILE
+          fi
+        fi
+        log_daemon_msg "Starting $DESC" "$NAME"
+        start-stop-daemon --start --quiet --pidfile "$PIDFILE" \
+        --user "$DAEMONUSER" --background --make-pidfile --exec "$DAEMON" --no-close >> "$LOGFILE" 2>&1
+        log_end_msg $?
+    ;;
+    stop)
+    if $0 status > /dev/null; then
+        log_daemon_msg "Stopping $DESC" "$NAME"
+        start-stop-daemon --stop --retry 5 --quiet --oknodo --pidfile "$PIDFILE" \
+        --user "$DAEMONUSER"
+        log_end_msg $?
+    else
+        log_daemon_msg "Not running"
+    fi
+    ;;
+    restart)
+    $0 stop
+    if $0 status >/dev/null  2>&1; then
+        log_daemon_msg "Unable to stop, will not attempt to start"
+        exit 1
+    fi
+    $0 start
+    ;;
+    status)
+    status_of_proc -p $PIDFILE $DAEMON $NAME && exit 0 || exit $?
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/deb.mk
+++ b/deb.mk
@@ -97,6 +97,7 @@ deb-dokku: deb-setup
 	$(MAKE) addman
 	cp /usr/local/share/man/man1/dokku.1 /tmp/build/usr/local/share/man/man1/dokku.1
 	cp contrib/dokku-installer.rb /tmp/build/usr/local/share/dokku/contrib
+	cp contrib/dokku-installer.rbinit /tmp/build/usr/local/share/dokku/contrib
 	git describe --tags > /tmp/build/var/lib/dokku/VERSION
 	cat /tmp/build/var/lib/dokku/VERSION | cut -d '-' -f 1 | cut -d 'v' -f 2 > /tmp/build/var/lib/dokku/STABLE_VERSION
 	git rev-parse HEAD > /tmp/build/var/lib/dokku/GIT_REV

--- a/debian/postinst
+++ b/debian/postinst
@@ -45,8 +45,8 @@ case "$1" in
 
     dokku plugin:install --core
 
-    rm -f /home/dokku/VERSION
-    cp /var/lib/dokku/STABLE_VERSION /home/dokku/VERSION
+    rm -f ${DOKKU_ROOT}/VERSION
+    cp /var/lib/dokku/STABLE_VERSION ${DOKKU_ROOT}/VERSION
 
     if [ -f /etc/init/dokku-installer.conf ] && service dokku-installer status 2> /dev/null | grep waiting; then
         sudo service dokku-installer start

--- a/debian/preinst
+++ b/debian/preinst
@@ -3,17 +3,25 @@ set -e
 
 . /usr/share/debconf/confmodule
 
+INIT_SYSTEM=$([ -h /sbin/init ] && echo systemd || echo sysvinit)
+
 case "$1" in
   install)
     db_get "dokku/web_config"
     if [ "$RET" = "true" ]; then
       INIT_CONF="/etc/init/dokku-installer.conf"
+      INIT_SCRIPT="/etc/init.d/dokku-installer"
       NGINX_CONF="/etc/nginx/conf.d/dokku-installer.conf"
 
-      rm -f $INIT_CONF
-      touch $INIT_CONF
-      echo 'start on runlevel [2345]' >> $INIT_CONF
-      echo 'exec /usr/local/share/dokku/contrib/dokku-installer.rb selfdestruct' >> $INIT_CONF
+      if [ ${INIT_SYSTEM} = "systemd" ]; then
+        rm -f $INIT_CONF
+        touch $INIT_CONF
+        echo 'start on runlevel [2345]' >> $INIT_CONF
+        echo 'exec /usr/local/share/dokku/contrib/dokku-installer.rb selfdestruct' >> $INIT_CONF
+      else
+        cp /usr/local/share/dokku/contrib/dokku-installer.rbinit ${INIT_SCRIPT}
+        update-rc.d -f dokku-installer defaults
+      fi
 
       rm -f $NGINX_CONF
       touch $NGINX_CONF


### PR DESCRIPTION
I added backward compatibility for dokku-installer with SysV init. I am going to prepare dokku works on debian (wheezy, jessie) and ubuntus versions (not only on LTS).