### PR TITLE
Add apps rename

### DIFF
--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -100,6 +100,16 @@ This will prompt you to verify the application's name before destroying it. You 
 dokku --force apps:destroy APP
 ```
 
+### Renaming a deployed app
+
+You can rename a deployed app using the `apps:rename` CLI tool:
+
+```shell
+dokku apps:rename OLD_NAME NEW_NAME
+```
+
+This will copy all of your app's contents into a new app directory with the name of your choice, delete your old app, then rebuild the new version of the app and deploy it. All of your config variables, including database urls, will be preserved.
+
 ### Adding deploy users
 
 While it is possible to use password-based authorization to push to Dokku, it is preferable to use key-based authentication for security. You can add your public key to the dokku user's `authorized_keys` file with the following command:

--- a/plugins/apps/commands
+++ b/plugins/apps/commands
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-[[ " apps apps:create apps:destroy help apps:help " == *" $1 "* ]] || exit $DOKKU_NOT_IMPLEMENTED_EXIT
+[[ " apps apps:create apps:rename apps:destroy help apps:help " == *" $1 "* ]] || exit $DOKKU_NOT_IMPLEMENTED_EXIT
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/apps/functions"
@@ -13,7 +13,25 @@ case "$1" in
   apps:create)
     apps_create $2
     ;;
+  
+  apps:rename)
+    [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
+    [[ -d "$DOKKU_ROOT/$3" ]] && dokku_log_fail "Name is already taken"
+    OLD_APP="$2"
+    NEW_APP="$3"
 
+    mkdir -p "$DOKKU_ROOT/$NEW_APP"
+    docker run --rm -v "$DOKKU_ROOT/$OLD_APP/cache:/cache" "dokku/$OLD_APP" chmod 777 -R /cache
+    rm -rf "$DOKKU_ROOT/$OLD_APP/cache"
+    cp -a "$DOKKU_ROOT/$OLD_APP/." "$DOKKU_ROOT/$NEW_APP"
+    dokku apps:destroy $OLD_APP --force
+    sed -i -e "s/$OLD_APP/$NEW_APP/g" "$DOKKU_ROOT/$NEW_APP/URLS"
+    sed -i -e "s/$OLD_APP/$NEW_APP/g" "$DOKKU_ROOT/$NEW_APP/VHOST"
+    dokku ps:rebuild $NEW_APP
+    plugn trigger post-app-rename $OLD_APP $NEW_APP
+    echo "Renaming $OLD_APP to $NEW_APP... done"
+    ;;
+ 
   apps:destroy)
     [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
     [[ "$2" == "tls" ]] && dokku_log_fail "Unable to destroy tls directory"
@@ -52,6 +70,7 @@ case "$1" in
     apps, List your apps
     apps:create <app>, Create a new app
     apps:destroy <app>, Permanently destroy an app
+    apps:rename <old-app> <new-app>, Rename an app
 EOF
     ;;
 

--- a/tests/unit/apps.bats
+++ b/tests/unit/apps.bats
@@ -26,3 +26,23 @@ load test_helper
   echo "status: "$status
   assert_success
 }
+
+@test "(apps) apps:rename" {
+  deploy_app
+  run bash -c "dokku apps:rename $TEST_APP great-test-name"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  run bash -c "dokku apps | grep $TEST_APP"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output ""
+  run bash -c "curl --silent --write-out '%{http_code}\n' `dokku url great-test-name` | grep 404"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output ""
+  run bash -c "dokku --force apps:destroy great-test-name"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+}


### PR DESCRIPTION
This adds the

`dokku apps:rename <old-app> <new-app>`

function to dokku.

I honestly wasn't sure how to run the tests but I'm reasonable confident mine works although I'm sure we could also test that the new name is there :)