### PR TITLE
Remove shebang from config/functions

### DIFF
--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 


### PR DESCRIPTION
In order to be one step closer to lintian compliance, lets remove the shebang
from this file so it doesn;t have to be executable

See #1641