### PR TITLE
Make plugin hooks send out more information

### DIFF
--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -75,7 +75,7 @@ case "$1" in
     for DOMAIN in "$@"; do
       echo "$DOMAIN" >> "$DOKKU_ROOT/$APP/VHOST"
     done
-    plugn trigger post-domains-update $APP
+    plugn trigger post-domains-update $APP "add" "$@"
     for DOMAIN in "$@"; do
       dokku_log_info1 "Added $DOMAIN to $APP"
     done
@@ -89,7 +89,7 @@ case "$1" in
 
     rm -f "$DOKKU_ROOT/$APP/VHOST"
     dokku domains:setup $APP
-    plugn trigger post-domains-update $APP
+    plugn trigger post-domains-update $APP "clear"
     dokku_log_info1 "Cleared domains in $APP"
 
     ;;
@@ -110,7 +110,7 @@ case "$1" in
     for DOMAIN in "$@"; do
       sed -i "/^$DOMAIN$/d" "$DOKKU_ROOT/$APP/VHOST"
     done
-    plugn trigger post-domains-update $APP
+    plugn trigger post-domains-update $APP "remove" "$@"
     for DOMAIN in "$@"; do
       dokku_log_info1 "Removed $DOMAIN from $APP"
     done


### PR DESCRIPTION
At this point you only get information that "something" happend on the given
hook. By adding more information to the hook, plugin creators can do more
interesting stuff.

* The first params remains the `$APP` name (to maintain backwards compatability)
* The second params sends in the action that happend, for domain this can be:
  `add`, `clear` or `remove`
* The third param sends in the argument that was passed to the original
  function, for domain that would be a list of all the domains that was given.

One reason this addition would be great for plugin owners, is that when you have
a web tool over Dokku, and someone creates a domain over the CLI, we a plugin
can send back information about the event to the webapp over an API. That way
the webapp is always up-to-date with the Dokku installation.