### PR TITLE
fix version constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.4.6
 Section: web
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, gcc, man-db, sshcommand, docker-engine-cs | docker-engine | lxc-docker (>= 1.6.2) | docker.io (>= 1.6.2), software-properties-common, python-software-properties
+Depends: locales, git, make, curl, gcc, man-db, sshcommand, docker-engine-cs | docker-engine | lxc-docker (> 1.6.1) | docker.io (> 1.6.1), software-properties-common, python-software-properties
 Recommends: herokuish
 Pre-Depends: nginx (>= 1.4.6), dnsutils, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo, ruby, ruby-dev, rubygem-rack , rubygem-rack-protection, rubygem-sinatra, rubygem-tilt
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>


### PR DESCRIPTION
The version of docker.io in jessie-backports is 1.6.2~dfsg1-1~bpo8+1.
This is regarded as lower than 1.6.2 by dpkg because `~` has a special meaning
in regards to version sort in dpkg.

This leads to:
```
The following packages have unmet dependencies:
 dokku : Depends: docker-engine-cs but it is not installable or
                  docker-engine but it is not installable or
                  lxc-docker (>= 1.6.2) but it is not installable or
                  docker.io (>= 1.6.2) but 1.6.2~dfsg1-1~bpo8+1 is to be installed
         Recommends: herokuish but it is not going to be installed
```

By changing the contraints the version in backports will be accepted by dpkg.