### PR TITLE
Add link to new zero-downtime Let's Encrypt Plugin to docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -116,6 +116,7 @@ Note: The following plugins have been supplied by our community and may not have
 [alexkruegger]: https://github.com/alexkruegger
 [dokku]: https://github.com/dokku
 [sgulseth]: https://github.com/sgulseth
+[sseemayer]: https://github.com/sseemayer
 
 ### Datastores
 
@@ -182,6 +183,7 @@ Note: The following plugins have been supplied by our community and may not have
 | [Graduate (Environment Management)](https://github.com/glassechidna/dokku-graduate)               | [Benjamin-Dobell][]   | 0.3.14+                 |
 | [HTTP Auth Secure Apps](https://github.com/matto1990/dokku-secure-apps)                           | [matto1990][]         | 0.4.0+                |
 | [Hostname](https://github.com/michaelshobbs/dokku-hostname)                                       | [michaelshobbs][]     | 0.4.0+                |
+| [Lets Encrypt (Zero-Downtime)](https://github.com/sseemayer/dokku-letsencrypt)                    | [sseemayer][]         | 0.4.0+                |
 | [Lets Encrypt](https://github.com/sgulseth/dokku-letsencrypt)                                     | [sgulseth][]          | 0.4.0+                |
 | [Multi-Buildpack](https://github.com/pauldub/dokku-multi-buildpack)                               | [pauldub][]           |                       |
 | [Nuke Containers](https://github.com/heichblatt/dokku-nuke)                                       | [heichblatt][]        |                       |


### PR DESCRIPTION
I've created a new plugin for dokku that allows securing dokku apps using the now public-beta free certificate authority Let's Encrypt by one simple `dokku letsencrypt <myapp>`.

As opposed to the existing [sgulseth/dokku-letsencrypt](https://github.com/sgulseth/dokku-letsencrypt) plugin, no stopping of the dokku nginx server is required during the host verification process and it won't mess up permissions of a pre-existing systemwide let's encrypt installation's data in `/etc/letsencrypt` because it only works in its own isolated Let's Encrypt working directory.