### PR TITLE
make docker cp work on circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,8 @@
 machine:
+  pre:
+    - echo 'DOCKER_OPTS="-s btrfs -e lxc -D --userland-proxy=false"' | sudo tee -a /etc/default/docker
+    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.8.2-circleci-cp-workaround'
+    - sudo chmod 0755 /usr/bin/docker
   services:
     - docker
 dependencies:


### PR DESCRIPTION
installs patched docker version on ci to make docker cp work.

per https://discuss.circleci.com/t/unable-to-use-docker-cp-but-it-worked-2-days-ago/1137/8