### PR TITLE
Make it possible to skip a deploy

### DIFF
--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -116,6 +116,14 @@ Dokku only supports deploying from its master branch, so if you'd like to deploy
 
 You can also support pushing multiple branches using the [receive-branch](/dokku/development/plugin-triggers/#receive-branch) plugin trigger in a custom plugin.
 
+### Skipping deployment
+
+If you only want to rebuild and tag a container, you can skip the deployment phase by setting `$DOKKU_SKIP_DEPLOY` to `true` by running:
+
+``` shell
+dokku config:set ruby-rails-sample DOKKU_SKIP_DEPLOY=true
+```
+
 ### Deploying with private git submodules
 
 Dokku uses git locally (i.e. not a docker image) to build its own copy of your app repo, including submodules. This is done as the `dokku` user. Therefore, in order to deploy private git submodules, you'll need to drop your deploy key in `/home/dokku/.ssh/` and potentially add github.com (or your VCS host key) into `/home/dokku/.ssh/known_hosts`. The following test should help confirm you've done it correctly.

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -316,12 +316,23 @@ release_and_deploy() {
       IMAGE_SOURCE_TYPE="dockerfile"
     fi
 
+    DOKKU_APP_SKIP_DEPLOY="$(dokku config:get $APP DOKKU_SKIP_DEPLOY || true)"
+    DOKKU_GLOBAL_SKIP_DEPLOY="$(dokku config:get --global DOKKU_SKIP_DEPLOY || true)"
+
+    DOKKU_SKIP_DEPLOY=${DOKKU_APP_SKIP_DEPLOY:="$DOKKU_GLOBAL_SKIP_DEPLOY"}
+
     dokku_log_info1 "Releasing $APP ($IMAGE)..."
     dokku release "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG"
-    dokku_log_info1 "Deploying $APP ($IMAGE)..."
-    dokku deploy "$APP" "$IMAGE_TAG"
-    dokku_log_info2 "Application deployed:"
-    dokku urls $APP | sed "s/^/       /"
+
+    if [[ "$DOKKU_SKIP_DEPLOY" != "true" ]]; then
+      dokku_log_info1 "Deploying $APP ($IMAGE)..."
+      dokku deploy "$APP" "$IMAGE_TAG"
+      dokku_log_info2 "Application deployed:"
+      dokku urls $APP | sed "s/^/       /"
+    else
+      dokku_log_info1 "Skipping deployment"
+    fi
+
     echo
   fi
 }


### PR DESCRIPTION
The rationale here is to make it possible to `git push dokku master` a base image that is used by other applications that are effectively being deployed.

Used in this manner, Dokku becomes a lightweight alternative to a private Docker registry.