### PR TITLE
Add support for tutum-agent

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.4.6
 Section: web
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, gcc, man-db, sshcommand, docker-engine-cs | docker-engine | lxc-docker (> 1.6.1) | docker.io (> 1.6.1), software-properties-common, python-software-properties
+Depends: locales, git, make, curl, gcc, man-db, sshcommand, docker-engine-cs | docker-engine | lxc-docker (> 1.6.1) | docker.io (> 1.6.1) | tutum-agent, software-properties-common, python-software-properties
 Recommends: herokuish
 Pre-Depends: nginx (>= 1.4.6), dnsutils, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>


### PR DESCRIPTION
The agent embeds it's own docker, so installing both dokku and tutum-agent on the same instance is currently impossible.

[ci skip]