### PR TITLE
Fix deprecated version constraint usage in debian control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.4.7
 Section: web
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, gcc, man-db, sshcommand, docker-engine-cs | docker-engine | lxc-docker (> 1.6.1) | docker.io (> 1.6.1) | tutum-agent, software-properties-common, python-software-properties
+Depends: locales, git, make, curl, gcc, man-db, sshcommand, docker-engine-cs | docker-engine | lxc-docker (>= 1.6.1) | docker.io (> 1.6.1) | tutum-agent, software-properties-common, python-software-properties
 Recommends: herokuish
 Pre-Depends: nginx (>= 1.4.6), dnsutils, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>


### PR DESCRIPTION
Fixes the following warning:

```
dpkg: warning: parsing file '/var/lib/dpkg/tmp.ci/control' near line 6 package 'dokku':
 `Depends' field, reference to `lxc-docker':
 `>' is obsolete, use `>=' or `>>' instead
```

Refs #1776