### PR TITLE
Debian packaging updates

### DIFF
--- a/contrib/dokku-installer.py
+++ b/contrib/dokku-installer.py
@@ -38,6 +38,10 @@ def check_boot():
     systemd_dir = os.getenv('SYSTEMD_DIR', '/etc/systemd/system')
     nginx_dir = os.getenv('NGINX_DIR', '/etc/nginx/conf.d')
 
+    if os.path.exists(init_dir):
+        with open('{0}/dokku-installer.conf'.format(init_dir), 'w') as f:
+            f.write("start on runlevel [2345]\n")
+            f.write("exec {0} selfdestruct\n".format(os.path.abspath(__file__)))
     if os.path.exists(systemd_dir):
         with open('{0}/dokku-installer.service'.format(systemd_dir), 'w') as f:
             f.write("[Unit]\n")
@@ -49,10 +53,6 @@ def check_boot():
             f.write("[Install]\n")
             f.write("WantedBy=multi-user.target\n")
             f.write("WantedBy=graphical.target\n")
-    elif os.path.exists(init_dir):
-        with open('{0}/dokku-installer.conf'.format(init_dir), 'w') as f:
-            f.write("start on runlevel [2345]\n")
-            f.write("exec {0} selfdestruct\n".format(os.path.abspath(__file__)))
     if os.path.exists(nginx_dir):
         with open('{0}/dokku-installer.conf'.format(nginx_dir), 'w') as f:
             f.write("upstream dokku-installer { server 127.0.0.1:2000; }\n")

--- a/contrib/dokku-installer.py
+++ b/contrib/dokku-installer.py
@@ -38,10 +38,6 @@ def check_boot():
     systemd_dir = os.getenv('SYSTEMD_DIR', '/etc/systemd/system')
     nginx_dir = os.getenv('NGINX_DIR', '/etc/nginx/conf.d')
 
-    if os.path.exists(init_dir):
-        with open('{0}/dokku-installer.conf'.format(init_dir), 'w') as f:
-            f.write("start on runlevel [2345]\n")
-            f.write("exec {0} selfdestruct\n".format(os.path.abspath(__file__)))
     if os.path.exists(systemd_dir):
         with open('{0}/dokku-installer.service'.format(systemd_dir), 'w') as f:
             f.write("[Unit]\n")
@@ -53,6 +49,10 @@ def check_boot():
             f.write("[Install]\n")
             f.write("WantedBy=multi-user.target\n")
             f.write("WantedBy=graphical.target\n")
+    elif os.path.exists(init_dir):
+        with open('{0}/dokku-installer.conf'.format(init_dir), 'w') as f:
+            f.write("start on runlevel [2345]\n")
+            f.write("exec {0} selfdestruct\n".format(os.path.abspath(__file__)))
     if os.path.exists(nginx_dir):
         with open('{0}/dokku-installer.conf'.format(nginx_dir), 'w') as f:
             f.write("upstream dokku-installer { server 127.0.0.1:2000; }\n")

--- a/deb.mk
+++ b/deb.mk
@@ -83,13 +83,13 @@ deb-dokku: deb-setup
 	mkdir -p /tmp/tmp /tmp/build
 
 	cp -r debian /tmp/build/DEBIAN
-	mkdir -p /tmp/build/usr/bin
+	mkdir -p /tmp/build/usr/local/bin
 	mkdir -p /tmp/build/var/lib/dokku/core-plugins/available
 	mkdir -p /tmp/build/usr/share/man/man1
 	mkdir -p /tmp/build/usr/share/dokku/contrib
 	mkdir -p /tmp/build/usr/share/doc/dokku
 
-	cp dokku /tmp/build/usr/bin
+	cp dokku /tmp/build/usr/local/bin
 	cp LICENSE /tmp/build/usr/share/doc/dokku/copyright
 	cp -r plugins/* /tmp/build/var/lib/dokku/core-plugins/available
 	find plugins/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read plugin; do touch /tmp/build/var/lib/dokku/core-plugins/available/$$plugin/.core; done

--- a/deb.mk
+++ b/deb.mk
@@ -87,8 +87,10 @@ deb-dokku: deb-setup
 	mkdir -p /tmp/build/var/lib/dokku/core-plugins/available
 	mkdir -p /tmp/build/usr/share/man/man1
 	mkdir -p /tmp/build/usr/share/dokku/contrib
+	mkdir -p /tmp/build/usr/share/doc/dokku
 
 	cp dokku /tmp/build/usr/bin
+	cp LICENSE /tmp/build/usr/share/doc/dokku/copyright
 	cp -r plugins/* /tmp/build/var/lib/dokku/core-plugins/available
 	find plugins/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read plugin; do touch /tmp/build/var/lib/dokku/core-plugins/available/$$plugin/.core; done
 	$(MAKE) help2man

--- a/deb.mk
+++ b/deb.mk
@@ -85,7 +85,7 @@ deb-dokku: deb-setup
 	cp -r debian /tmp/build/DEBIAN
 	mkdir -p /tmp/build/usr/bin
 	mkdir -p /tmp/build/var/lib/dokku/core-plugins/available
-	mkdir -p /tmp/build/usr/local/share/man/man1
+	mkdir -p /tmp/build/usr/share/man/man1
 	mkdir -p /tmp/build/usr/local/share/dokku/contrib
 
 	cp dokku /tmp/build/usr/bin
@@ -93,7 +93,7 @@ deb-dokku: deb-setup
 	find plugins/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read plugin; do touch /tmp/build/var/lib/dokku/core-plugins/available/$$plugin/.core; done
 	$(MAKE) help2man
 	$(MAKE) addman
-	cp /usr/local/share/man/man1/dokku.1 /tmp/build/usr/local/share/man/man1/dokku.1
+	cp /usr/local/share/man/man1/dokku.1 /tmp/build/usr/share/man/man1/dokku.1
 	cp contrib/dokku-installer.py /tmp/build/usr/local/share/dokku/contrib
 	git describe --tags > /tmp/build/var/lib/dokku/VERSION
 	cat /tmp/build/var/lib/dokku/VERSION | cut -d '-' -f 1 | cut -d 'v' -f 2 > /tmp/build/var/lib/dokku/STABLE_VERSION

--- a/deb.mk
+++ b/deb.mk
@@ -83,12 +83,12 @@ deb-dokku: deb-setup
 	mkdir -p /tmp/tmp /tmp/build
 
 	cp -r debian /tmp/build/DEBIAN
-	mkdir -p /tmp/build/usr/local/bin
+	mkdir -p /tmp/build/usr/bin
 	mkdir -p /tmp/build/var/lib/dokku/core-plugins/available
 	mkdir -p /tmp/build/usr/local/share/man/man1
 	mkdir -p /tmp/build/usr/local/share/dokku/contrib
 
-	cp dokku /tmp/build/usr/local/bin
+	cp dokku /tmp/build/usr/bin
 	cp -r plugins/* /tmp/build/var/lib/dokku/core-plugins/available
 	find plugins/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read plugin; do touch /tmp/build/var/lib/dokku/core-plugins/available/$$plugin/.core; done
 	$(MAKE) help2man

--- a/deb.mk
+++ b/deb.mk
@@ -86,7 +86,7 @@ deb-dokku: deb-setup
 	mkdir -p /tmp/build/usr/bin
 	mkdir -p /tmp/build/var/lib/dokku/core-plugins/available
 	mkdir -p /tmp/build/usr/share/man/man1
-	mkdir -p /tmp/build/usr/local/share/dokku/contrib
+	mkdir -p /tmp/build/usr/share/dokku/contrib
 
 	cp dokku /tmp/build/usr/bin
 	cp -r plugins/* /tmp/build/var/lib/dokku/core-plugins/available
@@ -94,7 +94,7 @@ deb-dokku: deb-setup
 	$(MAKE) help2man
 	$(MAKE) addman
 	cp /usr/local/share/man/man1/dokku.1 /tmp/build/usr/share/man/man1/dokku.1
-	cp contrib/dokku-installer.py /tmp/build/usr/local/share/dokku/contrib
+	cp contrib/dokku-installer.py /tmp/build/usr/share/dokku/contrib
 	git describe --tags > /tmp/build/var/lib/dokku/VERSION
 	cat /tmp/build/var/lib/dokku/VERSION | cut -d '-' -f 1 | cut -d 'v' -f 2 > /tmp/build/var/lib/dokku/STABLE_VERSION
 	git rev-parse HEAD > /tmp/build/var/lib/dokku/GIT_REV

--- a/deb.mk
+++ b/deb.mk
@@ -94,6 +94,7 @@ deb-dokku: deb-setup
 	$(MAKE) help2man
 	$(MAKE) addman
 	cp /usr/local/share/man/man1/dokku.1 /tmp/build/usr/share/man/man1/dokku.1
+	gzip -9 /tmp/build/usr/share/man/man1/dokku.1
 	cp contrib/dokku-installer.py /tmp/build/usr/share/dokku/contrib
 	git describe --tags > /tmp/build/var/lib/dokku/VERSION
 	cat /tmp/build/var/lib/dokku/VERSION | cut -d '-' -f 1 | cut -d 'v' -f 2 > /tmp/build/var/lib/dokku/STABLE_VERSION

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 Architecture: amd64
 Depends: locales, git, make, curl, gcc, man-db, sshcommand, docker-engine-cs | docker-engine | lxc-docker (>= 1.6.1) | docker.io (>= 1.6.1) | tutum-agent, software-properties-common, python-software-properties
 Recommends: herokuish
-Pre-Depends: nginx (>= 1.4.6), dnsutils, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo
+Pre-Depends: nginx (>= 1.4.6), dnsutils, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo, python2.7
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 Description: Docker-powered PaaS that helps build and manage the lifecycle of applications
 

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 Architecture: amd64
 Depends: locales, git, make, curl, gcc, man-db, sshcommand, docker-engine-cs | docker-engine | lxc-docker (>= 1.6.1) | docker.io (>= 1.6.1) | tutum-agent, software-properties-common, python-software-properties
 Recommends: herokuish
-Pre-Depends: nginx (>= 1.4.6), dnsutils, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo, python2.7
+Pre-Depends: nginx (>= 1.4.6), dnsutils, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo, python2.7, debconf
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 Description: Docker-powered PaaS that helps build and manage the lifecycle of applications
 

--- a/debian/control
+++ b/debian/control
@@ -7,5 +7,5 @@ Depends: locales, git, make, curl, gcc, man-db, sshcommand, docker-engine-cs | d
 Recommends: herokuish
 Pre-Depends: nginx (>= 1.4.6), dnsutils, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
-Description: A docker-powered PaaS that helps you build and manage the lifecycle of applications
+Description: Docker-powered PaaS that helps build and manage the lifecycle of applications
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -51,9 +51,13 @@ case "$1" in
     rm -f ${DOKKU_ROOT}/VERSION
     cp ${DOKKU_LIB_ROOT}/STABLE_VERSION ${DOKKU_ROOT}/VERSION
 
-    echo "starting dokku-installer if necessary"
-    if [ -f /etc/init/dokku-installer.conf ] && service dokku-installer status 2> /dev/null | grep waiting; then
-        sudo service dokku-installer start
+    if [[ -f /etc/nginx/conf.d/dokku-installer.conf ]]; then
+      echo "Setting up dokku-installer"
+      /usr/local/share/dokku/contrib/dokku-installer.py onboot
+
+      echo "Starting dokku-installer"
+      [[ -f /etc/systemd/system ]] && systemctl daemon-reload
+      service dokku-installer start
     fi
 
     db_get "dokku/web_config"

--- a/debian/postinst
+++ b/debian/postinst
@@ -18,13 +18,13 @@ case "$1" in
     egrep -i "^docker" /etc/group || groupadd docker
     usermod -aG docker dokku
 
-    echo "setup plugin directories"
+    echo "Setting up plugin directories"
     # should be replaced by `plugn init`
     mkdir -p ${DOKKU_LIB_ROOT}/core-plugins/available ${DOKKU_LIB_ROOT}/plugins/available
     mkdir -p ${DOKKU_LIB_ROOT}/core-plugins/enabled ${DOKKU_LIB_ROOT}/plugins/enabled
     touch ${DOKKU_LIB_ROOT}/core-plugins/config.toml ${DOKKU_LIB_ROOT}/plugins/config.toml
 
-    echo "migrate old plugins"
+    echo "Migrating old plugins"
     find ${DOKKU_LIB_ROOT}/plugins/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
       if [ "$plugin" = "available" ] || [ "$plugin" = "enabled" ]; then
         continue
@@ -35,7 +35,7 @@ case "$1" in
       fi
     done
 
-    echo "enable all core plugins"
+    echo "Enabling all core plugins"
     find ${DOKKU_LIB_ROOT}/core-plugins/available -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
       if [ ! -d ${DOKKU_LIB_ROOT}/plugins/available/$plugin ]; then
         ln -s ${DOKKU_LIB_ROOT}/core-plugins/available/$plugin ${DOKKU_LIB_ROOT}/plugins/available/$plugin;
@@ -45,7 +45,7 @@ case "$1" in
     done
     chown dokku:dokku -R ${DOKKU_LIB_ROOT}/plugins ${DOKKU_LIB_ROOT}/core-plugins
 
-    echo "install all core plugins"
+    echo "Install all core plugins"
     dokku plugin:install --core
 
     rm -f ${DOKKU_ROOT}/VERSION

--- a/debian/postinst
+++ b/debian/postinst
@@ -53,7 +53,7 @@ case "$1" in
 
     if [[ -f /etc/nginx/conf.d/dokku-installer.conf ]]; then
       echo "Setting up dokku-installer"
-      /usr/local/share/dokku/contrib/dokku-installer.py onboot
+      /usr/share/dokku/contrib/dokku-installer.py onboot
 
       echo "Starting dokku-installer"
       [[ -f /etc/systemd/system ]] && systemctl daemon-reload

--- a/debian/postinst
+++ b/debian/postinst
@@ -60,7 +60,8 @@ case "$1" in
         systemctl enable dokku-installer
       fi
 
-      if echo $(service dokku-installer status 2> /dev/null || true) | grep -Eq "(inactive|waiting)" > /dev/null; then
+      installer_status="$(service dokku-installer status 2> /dev/null || true)"
+      if echo $installer_status | grep -Eq "(inactive|waiting)" > /dev/null; then
         echo "Starting dokku-installer"
         service dokku-installer start || echo "Unable to start dokku-installer"
       fi

--- a/debian/postinst
+++ b/debian/postinst
@@ -56,8 +56,13 @@ case "$1" in
       /usr/share/dokku/contrib/dokku-installer.py onboot
 
       echo "Starting dokku-installer"
-      [[ -f /etc/systemd/system ]] && systemctl daemon-reload
-      service dokku-installer start
+      if command -v systemctl &>/dev/null; then
+        systemctl daemon-reload
+      fi
+
+      if service dokku-installer status 2> /dev/null | grep -E "waiting|inactive" ; then
+        service dokku-installer start
+      fi
     fi
 
     db_get "dokku/web_config"

--- a/debian/postinst
+++ b/debian/postinst
@@ -55,13 +55,14 @@ case "$1" in
       echo "Setting up dokku-installer"
       /usr/share/dokku/contrib/dokku-installer.py onboot
 
-      echo "Starting dokku-installer"
       if command -v systemctl &>/dev/null; then
-        systemctl daemon-reload
+        echo "Enabling dokku-installer"
+        systemctl enable dokku-installer
       fi
 
-      if service dokku-installer status 2> /dev/null | grep -E "waiting|inactive" ; then
-        service dokku-installer start
+      if echo $(service dokku-installer status 2> /dev/null || true) | grep -Eq "(inactive|waiting)" > /dev/null; then
+        echo "Starting dokku-installer"
+        service dokku-installer start || echo "Unable to start dokku-installer"
       fi
     fi
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -15,6 +15,8 @@ main() {
   rm -f /etc/systemd/system/dokku-redeploy.service
   rm -f /etc/update-motd.d/99-dokku
 
+  service nginx reload
+
   if [[ "$1" == "purge" ]]; then
     rm -f ${DOKKU_ROOT}/.dokkurc ${DOKKU_ROOT}/dokkurc ${DOKKU_ROOT}/tls
     rm -f ${DOKKU_ROOT}/.ssh/authorized_keys ${DOKKU_ROOT}/.sshcommand

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,7 +1,39 @@
 #!/bin/bash
 set -eo pipefail; [[ $TRACE ]] && set -x
 
-if [[ "$1" == "purge" ]] && [[ -e /usr/share/debconf/confmodule ]]; then
-    . /usr/share/debconf/confmodule
-    db_purge
-fi
+readonly DOKKU_ROOT="${DOKKU_ROOT:-/home/dokku}"
+readonly DOKKU_LIB_ROOT="${DOKKU_LIB_PATH:-/var/lib/dokku}"
+
+main() {
+  rm -f /etc/init/dokku-installer.conf
+  rm -f /etc/init/dokku-redeploy.conf
+  rm -f /etc/systemd/system/dokku-installer.conf
+  rm -f /etc/systemd/system/dokku-redeploy.service
+  rm -f /etc/update-motd.d/99-dokku
+
+  if [[ "$1" == "purge" ]]; then
+    rm -f ${DOKKU_ROOT}/.dokkurc ${DOKKU_ROOT}/dokkurc ${DOKKU_ROOT}/tls
+    rm -f ${DOKKU_ROOT}/.ssh/authorized_keys ${DOKKU_ROOT}/.sshcommand
+    rm -f ${DOKKU_ROOT}/ENV ${DOKKU_ROOT}/HOSTNAME ${DOKKU_ROOT}/VERSION
+    rm -rf ${DOKKU_ROOT}/.cache
+    rm -rf ${DOKKU_LIB_ROOT}/core-plugins
+
+    rm -f ${DOKKU_LIB_ROOT}/plugins/config.toml
+    if [[ -d ${DOKKU_LIB_ROOT} ]]; then
+      find -L ${DOKKU_LIB_ROOT} -type l -delete
+      find ${DOKKU_LIB_ROOT} -type d -empty -delete
+    fi
+
+    if [[ -d ${DOKKU_ROOT} ]]; then
+      find -L ${DOKKU_ROOT} -type l -delete
+      find ${DOKKU_ROOT} -type d -empty -delete
+    fi
+
+    if [[ -e /usr/share/debconf/confmodule ]]; then
+      . /usr/share/debconf/confmodule
+      db_purge
+    fi
+  fi
+}
+
+main "$@"

--- a/debian/postrm
+++ b/debian/postrm
@@ -5,6 +5,10 @@ readonly DOKKU_ROOT="${DOKKU_ROOT:-/home/dokku}"
 readonly DOKKU_LIB_ROOT="${DOKKU_LIB_PATH:-/var/lib/dokku}"
 
 main() {
+  if [[ -f /etc/systemd/system/dokku-installer.conf ]] || [[ -f /etc/init/dokku-installer.conf ]]; then
+    service dokku-installer stop || true
+  fi
+
   rm -f /etc/init/dokku-installer.conf
   rm -f /etc/init/dokku-redeploy.conf
   rm -f /etc/systemd/system/dokku-installer.conf

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eo pipefail; [[ $TRACE ]] && set -x
+
+if [[ "$1" == "purge" ]] && [[ -e /usr/share/debconf/confmodule ]]; then
+    . /usr/share/debconf/confmodule
+    db_purge
+fi

--- a/debian/preinst
+++ b/debian/preinst
@@ -7,13 +7,7 @@ case "$1" in
   install)
     db_get "dokku/web_config"
     if [ "$RET" = "true" ]; then
-      INIT_CONF="/etc/init/dokku-installer.conf"
       NGINX_CONF="/etc/nginx/conf.d/dokku-installer.conf"
-
-      rm -f $INIT_CONF
-      touch $INIT_CONF
-      echo 'start on runlevel [2345]' >> $INIT_CONF
-      echo 'exec /usr/local/share/dokku/contrib/dokku-installer.py selfdestruct' >> $INIT_CONF
 
       rm -f $NGINX_CONF
       touch $NGINX_CONF

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -eo pipefail; [[ $TRACE ]] && set -x
+
+readonly DOKKU_ROOT="${DOKKU_ROOT:-/home/dokku}"
+readonly DOKKU_LIB_ROOT="${DOKKU_LIB_PATH:-/var/lib/dokku}"
+
+ps_backtrace() {
+  if [ $# -lt 1 ]; then
+    echo "Usage: $0 PID" > /dev/stderr
+    exit 1
+  fi
+
+  declare -i pid=$1;
+  ppid=0;
+  header_modifier="";
+  while : ; do
+    if [ $ppid -ne 0 ]; then
+      header_modifier=h;
+    fi;
+    ppid=$(ps -o ppid= $pid);
+    ps uww $header_modifier -p $pid;
+    if [ $pid -eq 1 ]; then
+      break;
+    fi;
+    pid=$ppid;
+  done;
+}
+
+main() {
+  # HACK: Ensure that we only delete data when purging dokku from the system
+  if ps_backtrace $BASHPID 2> /dev/null | grep dpkg | grep -- "--purge" > /dev/null; then
+    echo "Processing purge"
+
+    echo "Destroying deployed applications"
+    for app in $(DOKKU_QUIET_OUTPUT=1 dokku apps); do
+      dokku --force apps:destroy $app
+    done
+
+    # HACK: Only disable core plugins, as we don't know what data users store in non-core plugin directories
+    echo "Disabling all core plugins"
+    find ${DOKKU_LIB_ROOT}/core-plugins/available -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
+      if [ ! -d ${DOKKU_LIB_ROOT}/plugins/available/$plugin ]; then
+        rm ${DOKKU_LIB_ROOT}/plugins/available/$plugin;
+        PLUGIN_PATH=${DOKKU_LIB_ROOT}/core-plugins plugn disable $plugin
+        PLUGIN_PATH=${DOKKU_LIB_ROOT}/plugins plugn disable $plugin
+      fi
+    done
+  else
+    echo "Processing $1"
+  fi
+
+  dokku cleanup
+}
+
+main "$@"

--- a/debian/templates
+++ b/debian/templates
@@ -1,10 +1,10 @@
 Template: dokku/web_config
-Description: Use the web-based config page?
+Description: Enable the web-based config page?
 Type: boolean
 Default: true
 
 Template: dokku/vhost_enable
-Description: Use vhost based deployments?
+Description: Enable vhost-based deployments?
 Type: boolean
 Default: false
 

--- a/debian/templates
+++ b/debian/templates
@@ -9,11 +9,11 @@ Type: boolean
 Default: false
 
 Template: dokku/hostname
-Description: Machine's hostname or IP
+Description: Hostname or IP for server:
 Type: string
 Default: dokku.me
 
 Template: dokku/key_file
-Description: Keyfile for initial user
+Description: Keyfile for initial user:
 Type: string
 Default: /root/.ssh/id_rsa.pub

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -176,13 +176,13 @@ Note: The following plugins have been supplied by our community and may not have
 | ------------------------------------------------------------------------------------------------- | --------------------- | --------------------- |
 | [App name as env](https://github.com/cjblomqvist/dokku-app-name-env)                              | [cjblomqvist][]       | 0.3.x                 |
 | [Docker Direct](https://github.com/heichblatt/dokku-docker-direct)                                | [heichblatt][]        |                       |
-| [Dokku Copy App Config Files](https://github.com/alexkruegger/dokku-app-configfiles)              | [alexkruegger][]            | Compatible with 0.3.17+ |
+| [Dokku Copy App Config Files](https://github.com/alexkruegger/dokku-app-configfiles)              | [alexkruegger][]      | Compatible with 0.3.17+ |
 | [Dokku Copy App Config Files](https://github.com/heichblatt/dokku-supply-config)                  | [heichblatt][]        |                       |
 | [Dokku Name](https://github.com/alex-sherwin/dokku-name)                                          | [alex-sherwin][]      | dokku >= [c77cbf1][]  |
 | [Dokku Registry](https://github.com/agco-adm/dokku-registry)<sup>1</sup>                          | [agco-adm][]          | 0.4.0+                |
 | [git rev-parse HEAD in env](https://github.com/cjblomqvist/dokku-git-rev)                         | [cjblomqvist][]       | 0.4.0+                |
 | [Graduate (Environment Management)](https://github.com/glassechidna/dokku-graduate)               | [Benjamin-Dobell][]   | 0.3.14+               |
-| [Haproxy tcp load balancerdokku](https://github.com/256dpi/dokku-haproxy)                         | [256dpi][]            | 0.4.0+                |
+| [Haproxy tcp load balancer](https://github.com/256dpi/dokku-haproxy)                              | [256dpi][]            | 0.4.0+                |
 | [HTTP Auth Secure Apps](https://github.com/matto1990/dokku-secure-apps)                           | [matto1990][]         | 0.4.0+                |
 | [Hostname](https://github.com/michaelshobbs/dokku-hostname)                                       | [michaelshobbs][]     | 0.4.0+                |
 | [Lets Encrypt](https://github.com/sseemayer/dokku-letsencrypt)                                    | [sseemayer][]         | 0.4.0+                |
@@ -225,7 +225,7 @@ Note: The following plugins have been supplied by our community and may not have
 | [Slack Notifications](https://github.com/ribot/dokku-slack)                                       | [ribot][]             | 0.4.0+                |
 | [User ACL](https://github.com/mlebkowski/dokku-acl)                                               | [Maciej Łebkowski][]  | 0.4.0+                |
 | [Webhooks](https://github.com/nickstenning/dokku-webhooks)                                        | [nickstenning][]      |                       |
-| [Wkhtmltopdf](https://github.com/mbriskar/dokku-wkhtmltopdf)                                        | [mbriskar][]      |                       |
+| [Wkhtmltopdf](https://github.com/mbriskar/dokku-wkhtmltopdf)                                      | [mbriskar][]          |                       |
 | [Wordpress](https://github.com/dudagroup/dokku-wordpress-template)                                | [abossard][]          | Dokku dev, mariadb, volume, domains |
 
 <sup>1</sup> Forked from [jezdez/dokku-elasticsearch-plugin](https://github.com/jezdez/dokku-elasticsearch-plugin): uses Elasticsearch 1.2 (instead of 0.90), doesn't depend on dokku-link, runs as elasticsearch user instead of root, and turns off multicast autodiscovery for use in a VPS environment.
@@ -237,18 +237,18 @@ The following plugins have been removed as their functionality is now in Dokku C
 | Plugin                                                                                            | Author                | In Dokku Since                  |
 | ------------------------------------------------------------------------------------------------- | --------------------- | ------------------------------- |
 | [Custom Domains](https://github.com/neam/dokku-custom-domains)                                    | [motin][]             | v0.3.10 (domains plugin)        |
-| [Debug](https://github.com/heichblatt/dokku-debug)                                                | [heichblatt][]         | v0.3.9 (trace command)          |
+| [Debug](https://github.com/heichblatt/dokku-debug)                                                | [heichblatt][]        | v0.3.9 (trace command)          |
 | [Docker Options](https://github.com/dyson/dokku-docker-options)                                   | [dyson][]             | v0.3.17 (docker-options plugin) |
 | [Events Logger](https://github.com/alessio/dokku-events)                                          | [alessio][]           | v0.3.21 (events plugin)         |
 | [Host Port binding](https://github.com/stuartpb/dokku-bind-port)                                  | [stuartpb][]          | v0.3.17 (docker-options plugin) |
-| [List Containers](https://github.com/heichblatt/dokku-list)                                       | [heichblatt][]         | v0.3.14 (ps plugin              |
+| [List Containers](https://github.com/heichblatt/dokku-list)                                       | [heichblatt][]        | v0.3.14 (ps plugin              |
 | [Link Containers](https://github.com/rlaneve/dokku-link)                                          | [rlaneve][]           | v0.3.17 (docker-options plugin) |
 | [Multiple Domains](https://github.com/wmluke/dokku-domains-plugin)<sup>1</sup>                    | [wmluke][]            | v0.3.10 (domains plugin)        |
 | [Named-containers](https://github.com/Flink/dokku-named-containers)                               | [Flink][]             | v0.4.2 (named-containers plugin) |
 | [Nginx-Alt](https://github.com/mikexstudios/dokku-nginx-alt)                                      | [mikexstudios][]      | v0.3.10 (domains plugin)        |
 | [Persistent Storage](https://github.com/dyson/dokku-persistent-storage)                           | [dyson][]             | v0.3.17 (docker-options plugin) |
 | [PrimeCache](https://github.com/darkpixel/dokku-prime-cache)                                      | [darkpixel][]         | v0.3.0 (zero downtime deploys)  |
-| [Rebuild application](https://github.com/scottatron/dokku-rebuild)                                | [scottatron][]         | v0.3.14 (ps plugin)             |
+| [Rebuild application](https://github.com/scottatron/dokku-rebuild)                                | [scottatron][]        | v0.3.14 (ps plugin)             |
 | [Supply env vars to buildpacks](https://github.com/cameron-martin/dokku-build-env)<sup>2</sup>    | [cameron-martin][]    | v0.3.9 (build-env plugin)       |
 | [user-env-compile](https://github.com/musicglue/dokku-user-env-compile)<sup>2</sup>               | [musicglue][]         | v0.3.9 (build-env plugin)       |
 | [user-env-compile](https://github.com/motin/dokku-user-env-compile)<sup>2</sup>                   | [motin][]             | v0.3.9 (build-env plugin)       |
@@ -267,11 +267,11 @@ The following plugins are no longer maintained by their developers.
 | Plugin                                                                                            | Author                | Compatibility         |
 | ------------------------------------------------------------------------------------------------- | --------------------- | --------------------- |
 | [app-url](https://github.com/mikecsh/dokku-app-url)                                               | [mikecsh][]           | Works with 0.2.0      |
-| [CouchDB (multi containers)](https://github.com/Flink/dokku-couchdb-multi-containers)             | [Flink][]             | 0.4.0+ |
+| [CouchDB (multi containers)](https://github.com/Flink/dokku-couchdb-multi-containers)             | [Flink][]             | 0.4.0+                |
 | [CouchDB](https://github.com/racehub/dokku-couchdb-plugin)                                        | [RaceHub][]           | Compatible with 0.2.0 |
 | [Elasticsearch](https://github.com/robv/dokku-elasticsearch)                                      | [robv][]              | Not compatible with >= 0.3.0 (still uses /home/git) |
 | [Elasticsearch](https://github.com/blag/dokku-elasticsearch-plugin)<sup>1</sup>                   | [blag][]              | Compatible with 0.2.0 |
-| [Memcached](https://github.com/Flink/dokku-memcached-plugin)                                      | [Flink][]             | 0.4.0+ |
+| [Memcached](https://github.com/Flink/dokku-memcached-plugin)                                      | [Flink][]             | 0.4.0+                |
 | [MongoDB (single container)](https://github.com/jeffutter/dokku-mongodb-plugin)                   | [jeffutter][]         |                       |
 | [MySQL](https://github.com/hughfletcher/dokku-mysql-plugin)                                       | [hughfletcher][]      |                       |
 | [Neo4j](https://github.com/Aomitayo/dokku-neo4j-plugin)                                           | [Aomitayo][]          |                       |

--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -11,9 +11,8 @@ fi
 
 # temporary hack for https://github.com/dokku/dokku/issues/82
 # redeploys all apps after a reboot
-case "$DOKKU_DISTRO" in
-  ubuntu)
-    cat<<EOF > /etc/init/dokku-redeploy.conf
+if [[ $(/sbin/init --version 2> /dev/null) =~ upstart ]]; then
+  cat<<EOF > /etc/init/dokku-redeploy.conf
 description "Dokku app redeploy service"
 
 start on filesystem and started docker
@@ -23,10 +22,10 @@ script
   sudo -i -u dokku /usr/local/bin/dokku ps:restore
 end script
 EOF
-    ;;
+fi
 
-  debian|opensuse)
-    cat<<EOF > /etc/systemd/system/dokku-redeploy.service
+if [[ $(systemctl 2> /dev/null) =~ -\.mount ]]; then
+  cat<<EOF > /etc/systemd/system/dokku-redeploy.service
 [Unit]
 Description=Dokku app redeploy service
 After=docker.target
@@ -39,11 +38,10 @@ ExecStart=/usr/local/bin/dokku ps:restore
 [Install]
 WantedBy=multi-user.target
 EOF
-    if command -v systemctl &>/dev/null; then
-      systemctl enable dokku-redeploy
-    fi
-    ;;
-esac
+  if command -v systemctl &>/dev/null; then
+    systemctl enable dokku-redeploy
+  fi
+fi
 
 mkdir -p /etc/update-motd.d
 cat<<EOF > /etc/update-motd.d/99-dokku

--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -39,7 +39,9 @@ ExecStart=/usr/local/bin/dokku ps:restore
 [Install]
 WantedBy=multi-user.target
 EOF
-    systemctl enable dokku-redeploy
+    if command -v systemctl &>/dev/null; then
+      systemctl enable dokku-redeploy
+    fi
     ;;
 esac
 

--- a/plugins/apps/commands
+++ b/plugins/apps/commands
@@ -7,13 +7,13 @@ source "$PLUGIN_AVAILABLE_PATH/apps/functions"
 case "$1" in
   apps)
     dokku_log_info2_quiet "My Apps"
-    find $DOKKU_ROOT -follow -maxdepth 1 -type d  \( ! -iname ".*" \)  -not -path $DOKKU_ROOT/tls | sed 's|^\./||g' | sed 's|'$DOKKU_ROOT'\/||' | tail -n +2 | sort
+    dokku_apps
     ;;
 
   apps:create)
     apps_create $2
     ;;
-  
+
   apps:rename)
     [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
     [[ -d "$DOKKU_ROOT/$3" ]] && dokku_log_fail "Name is already taken"
@@ -31,7 +31,7 @@ case "$1" in
     plugn trigger post-app-rename $OLD_APP $NEW_APP
     echo "Renaming $OLD_APP to $NEW_APP... done"
     ;;
- 
+
   apps:destroy)
     [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
     [[ "$2" == "tls" ]] && dokku_log_fail "Unable to destroy tls directory"

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -10,7 +10,7 @@ has_tty() {
 }
 
 dokku_apps() {
-  local INSTALLED_APPS=$(find $DOKKU_ROOT -maxdepth 1 -mindepth 1 -type d ! -name 'tls' ! -name '.*' -printf "%f\n") || (dokku_log_fail "You haven't deployed any applications yet")
+  local INSTALLED_APPS=$(find $DOKKU_ROOT -follow -maxdepth 1 -mindepth 1 -type d ! -name 'tls' ! -name '.*' -printf "%f\n" | sort) || (dokku_log_fail "You haven't deployed any applications yet")
   [[ $INSTALLED_APPS ]] && echo $INSTALLED_APPS
 }
 


### PR DESCRIPTION
> Note: Even with these change, we will still only officially support whatever the current LTS of Ubuntu is at any point in time. This isn't due to favoritism or anything, we just don't have the time, resources, or desire to support anything else. 
>
> If someone wants to jump in and make the latest CentOS *just work*, I'd be happy to give them support/commit bit. FWIW, we've already allowed some (now untested) SUSE support from #751.
>
> As for the core, our next steps are to officially support Dockerfile-based deployments. You can follow along in #1076 for more details.

- Fix as many lintian issues as possible. Closes #1641.
- Add actually tested support for Ubuntu 15.04, 15.10, and Debian Jessie. Closes #1654.
- Fix issue where we made unnecessary init files for dokku-installer.
- Add python2.7 and debconf as predependencies

Todo:

- [x] Fix dokku-redeploy for systemd
- [x] Test on Ubuntu 14.04
- [x] Test on Ubuntu 15.04
- [x] Test on Ubuntu 15.10
- [x] Test on Debian Jessie 8.2