### PR TITLE
fix: use new Go template for extracting IP

### DIFF
--- a/dokku
+++ b/dokku
@@ -141,7 +141,7 @@ case "$1" in
             ipaddr=127.0.0.1
           else
             id=$(docker run -d -e PORT=$port $DOCKER_ARGS $IMAGE $START_CMD)
-            ipaddr=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $id)
+            ipaddr=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $id)
           fi
         else
           id=$(docker run -d $DOCKER_ARGS $IMAGE $START_CMD)

--- a/dokku
+++ b/dokku
@@ -142,6 +142,10 @@ case "$1" in
           else
             id=$(docker run -d -e PORT=$port $DOCKER_ARGS $IMAGE $START_CMD)
             ipaddr=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $id)
+            # Docker < 1.9 compatibility
+            if [[ -z $ipaddr ]]; then
+              ipaddr=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $id)
+            fi
           fi
         else
           id=$(docker run -d $DOCKER_ARGS $IMAGE $START_CMD)


### PR DESCRIPTION
I was running into issues with the IP addresses, and it seems that it's using an incorrect/outdated syntax for retrieving the container's IP Address. In multi-host networking `NetworkSettings.IPAddress` is empty.

The docker documentation at https://docs.docker.com/engine/reference/commandline/inspect/
uses a different syntax which I've tested to work both on multi-host and standard bridge networking.

If you're interested in the other issues and the work/hacks I've been doing related to #1795, let me know. In the meantime, I think this fix is needed.