### PR TITLE
Write out /home/dokku/HOSTNAME as specified by the web installer.

### DIFF
--- a/contrib/dokku-installer.py
+++ b/contrib/dokku-installer.py
@@ -95,6 +95,9 @@ class GetHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 os.remove('{0}/VHOST'.format(dokku_root))
             except OSError:
                 pass
+        with open('{0}/HOSTNAME'.format(dokku_root), 'w') as f:
+            f.write(params['hostname'].value)
+
 
         command = ['sshcommand', 'acl-add', 'dokku', 'admin']
         for key in params['keys'].value.split("\n"):


### PR DESCRIPTION
Hey! Just a quick little fix for the web installer. When ported to Python, it looks like writing out the value of the hostname field to `/home/dokku/HOSTNAME` was accidentally dropped and only `/home/dokku/VHOST` is written.

Compare to the current implementation to the current one, specifically: 
 https://github.com/dokku/dokku/blob/32f1bc53962204b92e35512891b3a4dc8e844ccb/contrib/dokku-installer.rb#L55