### PR TITLE
implement dokku report command

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-[[ " build release trace delete ls run url urls version help " == *" $1 "* ]] || exit $DOKKU_NOT_IMPLEMENTED_EXIT
+[[ " build release trace delete ls run url urls report version help " == *" $1 "* ]] || exit $DOKKU_NOT_IMPLEMENTED_EXIT
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/config/functions"
@@ -190,6 +190,21 @@ case "$1" in
       echo "$SCHEME://$(< "$DOKKU_ROOT/VHOST")"
     fi
   ;;
+
+  report)
+    dokku_log_info1 "uname: $(uname -a)"
+    dokku_log_info1 "memory: "
+    free -m
+    dokku_log_info1 "docker version: "
+    docker version
+    dokku_log_info1 "docker daemon info: "
+    docker -D info
+    dokku_log_info1 "herokuish version: "
+    docker run --rm -ti gliderlabs/herokuish:latest herokuish version
+    dokku_log_info1 "dokku version: $(dokku version)"
+    dokku_log_info1 "dokku plugins: "
+    dokku plugin
+    ;;
 
   version)
     cat "$DOKKU_ROOT/VERSION" || dokku_log_fail "Unable to determine dokku's version"


### PR DESCRIPTION
rolls up the following commands into a single shortcut
- `uname -a`
- `free -m`
- `docker version`
- `docker -D info`
- `docker run --rm -ti gliderlabs/herokuish:latest herokuish version`
- `dokku version`
- `dokku plugin`