### PR TITLE
add back some deploy tests that test dokku functionality

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   pre:
     - echo 'DOCKER_OPTS="-s btrfs -e lxc -D --userland-proxy=false"' | sudo tee -a /etc/default/docker
-    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.0-circleci'
+    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci-cp-workaround'
     - sudo chmod 0755 /usr/bin/docker
   services:
     - docker
@@ -14,4 +14,4 @@ dependencies:
     - sudo -E make -e lint
 test:
   override:
-    - ./tests/ci/parallel_runner.sh testing: { parallel: true, timeout: 1800 }
+    - ./tests/ci/parallel_runner.sh testing: { parallel: true, timeout: 3600 }

--- a/tests/apps/multi/Gemfile
+++ b/tests/apps/multi/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby '1.9.3'
+ruby '2.2.4'
 
 gem 'compass', ">= 1.0.1"
 gem 'sass-globbing'

--- a/tests/ci/parallel_runner.sh
+++ b/tests/ci/parallel_runner.sh
@@ -52,6 +52,8 @@ case "$CIRCLE_NODE_INDEX" in
   2)
     echo "=====> make unit-tests (3/4) on CIRCLE_NODE_INDEX: $CIRCLE_NODE_INDEX"
     sudo -E UNIT_TEST_BATCH=3 make -e unit-tests
+    echo "=====> make deploy tests"
+    sudo -E make -e deploy-test-checks-root deploy-test-config deploy-test-multi
     ;;
 
   3)


### PR DESCRIPTION
This adds back a few app deploy tests that exercise dokku-specific functionality. For example, when we moved to docker-1.9.0 and CircleCI assured me that `docker cp` was supported in that binary, we missed that it actually didn't work because I had removed the only test (deploy-test-checks-root) that used it. 

Unfortunately this is also true of the new feature in #1836. 

reference: https://discuss.circleci.com/t/unable-to-use-docker-cp-but-it-worked-2-days-ago/1137/8