### PR TITLE
Append trailing slash '/' to $PLUGIN_DIR

### DIFF
--- a/plugins/20_events/commands
+++ b/plugins/20_events/commands
@@ -26,7 +26,7 @@ case "$1" in
     ;;
 
   events:list)
-    PLUGIN_DIR="$(dirname $0)"
+    PLUGIN_DIR="$(dirname $0)/"
     if [[ "$DOKKU_EVENTS" ]]; then
       logged="$(find $PLUGIN_DIR -type l -printf '%f ' | sort)"
       dokku_col_log_info2_quiet "Events currently logged"


### PR DESCRIPTION
This is to prevent find's misbehaviours which
lead events:list to output incorrent information.

Fixes #1839