### PR TITLE
skip cleanup in ci to speed up tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
     - "~/docker"
   override:
     - ./tests/ci/parallel_runner.sh setup: { timeout: 300 }
+    - echo "export DOKKU_SKIP_CLEANUP=true" > /home/dokku/.dokkurc/dokku_skip_cleanup
   post:
     - sudo -E make -e lint
 test:

--- a/dokku
+++ b/dokku
@@ -83,8 +83,10 @@ fi
 case "$1" in
   receive)
     APP="$2"; IMAGE=$(get_app_image_name $APP); IMAGE_SOURCE_TYPE="$3"; TMP_WORK_DIR="$4"
-    dokku_log_info1 "Cleaning up..."
-    docker_cleanup
+    if [[ -z "DOKKU_SKIP_CLEANUP" ]]; then
+      dokku_log_info1 "Cleaning up..."
+      docker_cleanup
+    fi
     dokku_log_info1 "Building $APP from $IMAGE_SOURCE_TYPE..."
     dokku build "$APP" "$IMAGE_SOURCE_TYPE" "$TMP_WORK_DIR"
     release_and_deploy "$APP"

--- a/tests/ci/parallel_runner.sh
+++ b/tests/ci/parallel_runner.sh
@@ -20,6 +20,10 @@ setup_circle() {
   sudo -E make -e setup-deploy-tests
   make -e ci-dependencies
   docker version
+  # setup .dokkurc
+  sudo -E mkdir -p /home/dokku/.dokkurc
+  sudo -E chown dokku:ubuntu /home/dokku/.dokkurc
+  sudo -E chmod 775 /home/dokku/.dokkurc
 }
 
 if [[ -n "$CIRCLE_NODE_INDEX" ]] && [[ "$MODE" == "setup" ]]; then


### PR DESCRIPTION
I noticed since upgrading to docker 1.9.x that `dokku cleanup` progressively gets slower and slower as the ci progresses through the tests. So this allows us to skip that step.