### PR TITLE
named-containers: handle multiple old containers and don't attempt to rename a dead container

### DIFF
--- a/plugins/named-containers/post-deploy
+++ b/plugins/named-containers/post-deploy
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 
 APP="$1"; APP_ROOT="$DOKKU_ROOT/$APP"
 [[ -z $(stat -t "$APP_ROOT"/CONTAINER.* 2>/dev/null) ]] && exit 0
 for container in "$APP_ROOT"/CONTAINER.*; do
   DYNO=$(echo "$container" | sed -r 's/.*CONTAINER\.(.*)/\1/') || true
   NAME="$APP.$DYNO"
-  PREVIOUS=$(docker ps -a -q -f name="^.?$NAME\$") || true
-  if [[ -n $PREVIOUS ]]; then
-    docker rename "$NAME" "$NAME.$(date +%s)" > /dev/null
+  CURRENT_CONTAINER_ID="$(< $container)"
+  PREVIOUS_CIDS=$(docker ps -a -q -f name="^.?$NAME\$" | xargs) || true
+  if [[ -n $PREVIOUS_CIDS ]]; then
+    dokku_log_info1_quiet "Found previous container(s) ($PREVIOUS_CIDS) named $NAME"
+    # in case $PREVIOUS_CIDS has more than one entry
+    for cid in $PREVIOUS_CIDS; do
+      PREVIOUS_CONTAINER_STATUS=$(docker inspect -f '{{.State.Status}}' "$cid" || echo "dead")
+      # dead containers cannot be renamed
+      if [[ "$PREVIOUS_CONTAINER_STATUS" != "dead" ]]; then
+        CONTAINER_DATE_NAME="$NAME.$(date +%s)"
+        dokku_log_info2_quiet "renaming container ($cid) ${NAME} to $CONTAINER_DATE_NAME"
+        docker rename "$NAME" "$CONTAINER_DATE_NAME" > /dev/null
+      fi
+    done
   fi
   ID=$(cat "$container")
   CURRENT_NAME=$(docker inspect -f '{{.Name}}' "$ID" | tr -d /)
+  dokku_log_info2_quiet "renaming container (${ID:0:12}) $CURRENT_NAME to $NAME"
   docker rename "$CURRENT_NAME" "$NAME" > /dev/null
 done


### PR DESCRIPTION
- handles multiple "previous" containers given the name filter
- skips attempting to rename "dead" containers
- adds some output to indicate what the crap it's trying to do

this should solve the majority of the variance we've seen with this plugin