### PR TITLE
Add skip_keyfile option for deb package

### DIFF
--- a/debian/preinst
+++ b/debian/preinst
@@ -27,7 +27,8 @@ case "$1" in
       exit 0
     fi
 
-    if [ -z "${DEBCONF_RECONFIGURE}" ]; then
+    db_get "dokku/skip_key_file"
+    if [ -z "${DEBCONF_RECONFIGURE}" ] && [ "$RET" != "true" ]; then
       db_get "dokku/key_file"
       if [ ! -f "$RET" ]; then
           echo "Error: keyfile '$RET' not found."

--- a/debian/templates
+++ b/debian/templates
@@ -13,6 +13,11 @@ Description: Hostname or IP for server:
 Type: string
 Default: dokku.me
 
+Template: dokku/skip_key_file
+Description: Skip key file requirement?
+Type: boolean
+Default: false
+
 Template: dokku/key_file
 Description: Keyfile for initial user:
 Type: string

--- a/docs/getting-started/install/debian.md
+++ b/docs/getting-started/install/debian.md
@@ -37,4 +37,5 @@ After setting the desired options, proceed with the installation as described ab
 | dokku/web_config   | boolean | true                  | Use web-based config for below options                                   |
 | dokku/vhost_enable | boolean | false                 | Use vhost-based deployments (e.g. <app>.dokku.me)                        |
 | dokku/hostname     | string  | dokku.me              | Hostname, used as vhost domain and for showing app URL after deploy      |
+| dokku/skip_key_file| boolean | false                 | Don't check for the existence of the dokku/key_file. Warning: This setting this to true, will require you to manually add an SSH key later on. |
 | dokku/key_file     | string  | /root/.ssh/id_rsa.pub | SSH key to add to the Dokku user (Will be ignored on `dpkg-reconfigure`) |


### PR DESCRIPTION
There are cases where we don't want the check for keyfile, this will add a
config option, that allows you to skip this particular check.

Fixes #1851