### PR TITLE
install bash 4.3.x on circleci

### DIFF
--- a/tests/ci/parallel_runner.sh
+++ b/tests/ci/parallel_runner.sh
@@ -19,6 +19,9 @@ setup_circle() {
   sudo -E CI=true make -e install
   sudo -E make -e setup-deploy-tests
   make -e ci-dependencies
+  # circleci runs Ubuntu 12.04 and thus a previous version of bash (4.2) than 14.04
+  sudo apt-get install -y -q "bash=$(apt-cache show bash | egrep "^Version: 4.3" | head -1 | awk -F: '{ print $2 }' | xargs)"
+  bash --version
   docker version
   # setup .dokkurc
   sudo -E mkdir -p /home/dokku/.dokkurc


### PR DESCRIPTION
needed by #1848 

```
$ bash --version
GNU bash, version 4.2.25(1)-release (x86_64-pc-linux-gnu)
$ bats tests/unit/20_docker-options.bats
...
11 tests, 6 failures
$ sudo apt-get install -y -q bash=$(apt-cache show bash | egrep "^Version: 4.3" | head -1 | awk -F: '{ print $2 }' | xargs)
...
Setting up bash (4.3-7ubuntu1.5) ...
...
$ bash --version
GNU bash, version 4.3.11(1)-release (x86_64-pc-linux-gnu)
$ bats tests/unit/20_docker-options.bats
...
11 tests, 0 failures
```