### PR TITLE
Prevent dokku to hang on events:help

### DIFF
--- a/plugins/20_events/commands
+++ b/plugins/20_events/commands
@@ -39,7 +39,7 @@ case "$1" in
     ;;
 
   help | events:help)
-    cat && cat<<EOF
+    cat<<EOF
     events [-t], Show the last events (-t follows)
     events:list, List logged events
     events:on, Enable events logger


### PR DESCRIPTION
Update events:help case against to Dokku 0.4's new help screen handling.