### PR TITLE
support bash 4.2 so we don't have to modify all plugin test envs

### DIFF
--- a/plugins/docker-options/functions
+++ b/plugins/docker-options/functions
@@ -17,7 +17,9 @@ get_phases() {
   local phase
   local passed_phases
   if [[ -n "$passed_phases_list" ]]; then
-    IFS=',' read -ra passed_phases <<< "$passed_phases_list"
+    OIFS=$IFS; IFS=','
+    read -ra passed_phases <<< "$passed_phases_list"
+    IFS=$OIFS
     for phase in "${passed_phases[@]}"; do
       [[ "$phase" = @($phases_allowed) ]] || dokku_log_fail "Phase(s) must be one of [${AVAILABLE_PHASES[*]}]"
     done

--- a/tests/ci/parallel_runner.sh
+++ b/tests/ci/parallel_runner.sh
@@ -20,7 +20,7 @@ setup_circle() {
   sudo -E make -e setup-deploy-tests
   make -e ci-dependencies
   # circleci runs Ubuntu 12.04 and thus a previous version of bash (4.2) than 14.04
-  sudo apt-get install -y -q "bash=$(apt-cache show bash | egrep "^Version: 4.3" | head -1 | awk -F: '{ print $2 }' | xargs)"
+  # sudo apt-get install -y -q "bash=$(apt-cache show bash | egrep "^Version: 4.3" | head -1 | awk -F: '{ print $2 }' | xargs)"
   bash --version
   docker version
   # setup .dokkurc


### PR DESCRIPTION
My thinking here is if we’re going to have a baseline bash version requirement, then we should have a damn good reason for it. Currently, there is no real need to support `bash>=4.3`; especially not for just one line of code.

Given that this PR is so small and still maintains `bash<4.3` support, I think it’s reasonable to maintain that support for now. If we end up finding ourselves having to go through uncomfortable machinations to support `bash>=4.2`, then we punt and force the `bash>=4.3` requirement.