### PR TITLE
fix dokku run --rm regression

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -134,9 +134,11 @@ case "$1" in
 
     shift 2
 
-    DOKKU_APP_RM_CONTAINER=$(dokku config:get $APP DOKKU_RM_CONTAINER || true)
-    DOKKU_GLOBAL_RM_CONTAINER=$(dokku config:get --global DOKKU_RM_CONTAINER || true)
-    DOKKU_RM_CONTAINER=${DOKKU_APP_RM_CONTAINER:="$DOKKU_GLOBAL_RM_CONTAINER"}
+    if [[ -z "$DOKKU_RM_CONTAINER" ]]; then
+      DOKKU_APP_RM_CONTAINER=$(dokku config:get $APP DOKKU_RM_CONTAINER || true)
+      DOKKU_GLOBAL_RM_CONTAINER=$(dokku config:get --global DOKKU_RM_CONTAINER || true)
+      DOKKU_RM_CONTAINER=${DOKKU_APP_RM_CONTAINER:="$DOKKU_GLOBAL_RM_CONTAINER"}
+    fi
 
     DOCKER_ARGS=$(: | plugn trigger docker-args-run $APP $IMAGE_TAG)
     [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" -e TRACE=true "


### PR DESCRIPTION
- don't override DOKKU_RM_CONTAINER if it's already set 
- adds test for dokku --rm/DOKKU_RM_CONTAINER env var set

@josegonzalez your call on cutting another 0.4.x for this
fixes #1906