### PR TITLE
bugfix: git url pattern

### DIFF
--- a/plugins/plugin/commands
+++ b/plugins/plugin/commands
@@ -16,7 +16,7 @@ case "$1" in
         [[ "$#" -gt 2 ]] && dokku_log_info1_quiet "Cannot install additional core plugins, running core plugin install trigger"
         PLUGIN_PATH="$PLUGIN_CORE_PATH" plugn trigger install
         ;;
-      https:*|git:*|ssh:*)
+      https:*|git*|ssh:*)
         shift
         download_and_enable_plugin "$@"
         plugn trigger install


### PR DESCRIPTION
github git urls format is "git@...". `dokku plugin:install` command will fail due to format not being matched.