### PR TITLE
passing -i -t to docker exec only if tty present

### DIFF
--- a/plugins/enter/commands
+++ b/plugins/enter/commands
@@ -28,8 +28,9 @@ case "$1" in
     docker ps -q --no-trunc | grep -e "^$ID" > /dev/null || dokku_log_fail "Container is not running"
 
     EXEC_CMD=""
+    has_tty && DOKKU_RUN_OPTS+=" -i -t"
     is_image_herokuish_based "$IMAGE" && EXEC_CMD="/exec"
-    docker exec -it $ID $EXEC_CMD "${@:-/bin/bash}"
+    docker exec $DOKKU_RUN_OPTS $ID $EXEC_CMD "${@:-/bin/bash}"
     ;;
 
   help | enter:help)


### PR DESCRIPTION
When executing `dokku enter` from a crontab, I get the following error:

`cannot enable tty mode on non tty input`

Following a similar model to the run command in 00_dokku-standard/commands, this pull request should allow for `dokku enter` to work in a crontab.
