### PR TITLE
Adds support for ArchLinux as host OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ endif
 
 include tests.mk
 include deb.mk
+include arch.mk
 
 all:
 	# Type "make install" to install.
@@ -155,4 +156,3 @@ vagrant-acl-add:
 
 vagrant-dokku:
 	vagrant ssh -- "sudo -H -u root bash -c 'dokku $(RUN_ARGS)'"
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,6 +76,16 @@ Vagrant::configure("2") do |config|
     vm.vm.provision :shell, :inline => "cd /root/dokku && make deb-all"
   end
 
+  config.vm.define "build-arch", autostart: false do |vm|
+    vm.vm.box = "bugyt/archlinux"
+    vm.vm.synced_folder File.dirname(__FILE__), "/dokku"
+    vm.vm.synced_folder "#{File.dirname(__FILE__)}/../dokku-arch", "/dokku-arch"
+    vm.vm.network :forwarded_port, guest: 80, host: FORWARDED_PORT
+    vm.vm.hostname = "#{DOKKU_DOMAIN}"
+    vm.vm.network :private_network, ip: DOKKU_IP
+    vm.vm.provision :shell, :inline => "cd /dokku && make arch-all", privileged: false
+  end
+
   if Pathname.new(PUBLIC_KEY_PATH).exist?
     config.vm.provision :file, source: PUBLIC_KEY_PATH, destination: '/tmp/id_rsa.pub'
     config.vm.provision :shell, :inline => "rm -f /root/.ssh/authorized_keys && mkdir -p /root/.ssh && sudo cp /tmp/id_rsa.pub /root/.ssh/authorized_keys"

--- a/arch.mk
+++ b/arch.mk
@@ -1,0 +1,28 @@
+.PHONY: arch-all arch-dokku
+
+arch-all: arch-dokku
+	echo "Done"
+
+arch-setup:
+	echo "-> Updating pacman repository and installing package helper"
+	sudo pacman -Sy
+	sudo pacman -S --needed --noconfirm pkgbuild-introspection
+
+	echo "-> Download, build and install cower (dependency of pacaur) and pacaur"
+	curl -so /tmp/cower.tar.gz https://aur.archlinux.org/cgit/aur.git/snapshot/cower.tar.gz
+	curl -so /tmp/pacaur.tar.gz https://aur.archlinux.org/cgit/aur.git/snapshot/pacaur.tar.gz
+	tar -xzf /tmp/cower.tar.gz -C /tmp
+	tar -xzf /tmp/pacaur.tar.gz -C /tmp
+	gpg --recv-key 1EB2638FF56C0C53
+	cd /tmp/cower; makepkg -sri --noconfirm
+	cd /tmp/pacaur; makepkg -sri --noconfirm
+
+	echo "-> Installing build requirements"
+	pacaur --noconfirm --noedit -S plugn
+
+arch-dokku: arch-setup
+	echo "-> Update package sums, create metadata file and test the build of the package"
+	git describe --tags > /tmp/VERSION
+	cat /tmp/VERSION | cut -d '-' -f 1 | cut -d 'v' -f 2 > /tmp/STABLE_VERSION
+	sed -i -e "s/pkgver=.*/pkgver=`cat /tmp/STABLE_VERSION`/" /dokku-arch/PKGBUILD
+	cd /dokku-arch; updpkgsums; mksrcinfo; makepkg -fd

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -23,6 +23,7 @@ To propose a release, the following tasks need to be performed:
 - Debian packages *must* be created via `vagrant up build`
 - The packages should be uploaded to packagecloud.io
 - All changes are pushed to master and the tag should be turned into a release which will contain the changelog.
+- ArchLinux package description *must* be updated via `vagrant up build-arch` (needs to be done after the tag is pushed to GitHub, because it is based on that)
 
 ## Versioning
 
@@ -56,6 +57,24 @@ If new versions of other packages were created, these should also be pushed at t
 
 > If you are a maintainer and need the PACKAGECLOUD_TOKEN in order to make a release, please contact @josegonzalez to get this information.
 
+## ArchLinux Pacakages
+
+ArchLinux packages are not really build, because all that is needed for an Arch User Repo (AUR) package is the description of how to build the package. To make this process as easy as possible there is a vagrant box called `build-arch` that updates the version of this build description (a file called `PKGBUILD`), then runs some helper scripts to fill all aditional information and does test if the package could be build. Then only those changes need to be pushed to the AUR repo and an updated version of the package is ready for usage for our ArchLinux users. For detailed information see the section below.
+
+The workflow looks like this:
+
+```shell
+# having dokku-arch in ../dokku-arch
+vagrant up build-arch
+# wait for "==> build-arch: ==> Finished making: dokku 0.4.14-2 (Mon Feb 22 23:20:37 CET 2016)"
+cd ../dokku-arch
+git add PKGBUILD .SRCINFO
+git commit -m 'Update to dokku 0.9.9'
+git push aur master
+```
+
+> If you are a maintainer and need access to the AUR repositories in order to make a release, please contact @morrisjobke or @josegonzalez to get this co-maintainership.
+
 ## Changelog format
 
 The `HISTORY.md` should be added to based on the changes made since the previous release. This can be done by reviewing all merged pull requests to the master branch on github. The format is as follows:
@@ -77,3 +96,28 @@ Some description concerning major changes in this release, or potential incompat
 
 - #SOME_ID: @pull-request-creator Description
 ```
+
+## Detailed information for ArchLinux packages
+
+All of the information to build the ArchLinux package is in the AUR git repository (see [dokku AUR page](https://aur.archlinux.org/packages/dokku/)). The release of a AUR package only consists of pushing the package information into the AUR git repo. Then users could use that information to build the package on their machines.
+
+To update the package clone the repository and adjust the files in the repository. Then a helper script - `updpkgsums` - to update the SHA sum could  be called (check against the original SHA sum). Another helper script - `mksrcinfo` - needs to be called to update the meta information of the package in a file called `.SRCINFO`. The next step builds the package locally for verification - `makepkg`. As last step commit your changes and push the commit.
+
+* dependencies are defined in the `depends` attribute in `PKGBUILD`
+* build steps during package build time are defined in the `package()` method in `PKGBUILD`
+* steps that should be executed during install/update/remove time are defined in the file `dokku.install`
+* detailed information about all attributes in `PKGBUILD` could be found in the [ArchLinux wiki](https://wiki.archlinux.org/index.php/PKGBUILD)
+* detailed information about the AUR workflow could be found in the [AUR article](https://wiki.archlinux.org/index.php/Arch_User_Repository) in the ArchLinux wiki
+
+That is the usual workflow:
+
+```shell
+updpkgsums # update sha sums - compare them with the original ones
+mksrcinfo # update package metadata for AUR
+makepkg # test package builds
+git add PKGBUILD .SRCINFO
+git commit -m 'Update to dokku 0.9.9'
+git push
+```
+
+> If there is something unclear simply ask @morrisjobke for help.

--- a/dokku
+++ b/dokku
@@ -3,6 +3,9 @@ set -eo pipefail
 shopt -s nullglob
 
 case "$(lsb_release -si)" in
+  Arch)
+    export DOKKU_DISTRO=${DOKKU_DISTRO:="arch"}
+    ;;
   Debian)
     export DOKKU_DISTRO=${DOKKU_DISTRO:="debian"}
     ;;

--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -9,6 +9,8 @@ if [[ ! -f  "$DOKKU_ROOT/VHOST" ]]; then
   [[ $(dig +short "$(< "$DOKKU_ROOT/HOSTNAME")") ]] && cp "$DOKKU_ROOT/HOSTNAME" "$DOKKU_ROOT/VHOST"
 fi
 
+dokku_path=$(which dokku)
+
 # temporary hack for https://github.com/dokku/dokku/issues/82
 # redeploys all apps after a reboot
 if [[ $(/sbin/init --version 2> /dev/null) =~ upstart ]]; then
@@ -19,7 +21,7 @@ start on filesystem and started docker
 
 script
   sleep 2 # give docker some time
-  sudo -i -u dokku /usr/local/bin/dokku ps:restore
+  sudo -i -u dokku $dokku_path ps:restore
 end script
 EOF
 fi
@@ -33,7 +35,7 @@ After=docker.target
 [Service]
 Type=simple
 User=dokku
-ExecStart=/usr/local/bin/dokku ps:restore
+ExecStart=$dokku_path ps:restore
 
 [Install]
 WantedBy=multi-user.target

--- a/plugins/20_events/install
+++ b/plugins/20_events/install
@@ -2,7 +2,8 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 
-DOKKU_RSYSLOG_FILTER=/etc/rsyslog.d/99-dokku.conf
+DOKKU_RSYSLOG_FILTER_DIR=/etc/rsyslog.d
+DOKKU_RSYSLOG_FILTER=$DOKKU_RSYSLOG_FILTER_DIR/99-dokku.conf
 DOKKU_LOGROTATE_FILE=/etc/logrotate.d/dokku
 
 flag_rsyslog_needs_restart=n
@@ -11,7 +12,7 @@ flag_rsyslog_needs_restart=n
 # exits gracefully if the path already exists
 mkdir -m 775 -p "$DOKKU_LOGS_DIR"
 case "$DOKKU_DISTRO" in
-  debian)
+  arch|debian)
     chgrp dokku "$DOKKU_LOGS_DIR"
     ;;
   *)
@@ -22,7 +23,7 @@ esac
 if [[ ! -f  "$DOKKU_EVENTS_LOGFILE" ]]; then
   touch "$DOKKU_EVENTS_LOGFILE"
   case "$DOKKU_DISTRO" in
-    debian)
+    arch|debian)
       chgrp dokku "$DOKKU_EVENTS_LOGFILE"
       ;;
     *)
@@ -33,7 +34,7 @@ if [[ ! -f  "$DOKKU_EVENTS_LOGFILE" ]]; then
   chmod 664 "$DOKKU_EVENTS_LOGFILE"
 fi
 
-if [[ ! -f  "$DOKKU_RSYSLOG_FILTER" ]]; then
+if [[ -d "$DOKKU_RSYSLOG_FILTER_DIR" && ! -f  "$DOKKU_RSYSLOG_FILTER" ]]; then
   cat >"$DOKKU_RSYSLOG_FILTER" <<EOF
 :syslogtag, contains, "dokku" $DOKKU_EVENTS_LOGFILE
 EOF
@@ -64,7 +65,7 @@ EOF
   flag_rsyslog_needs_restart=y
 fi
 
-if [[ "$flag_rsyslog_needs_restart" == "y" ]]; then
+if [[ -f "$DOKKU_RSYSLOG_FILTER" && "$flag_rsyslog_needs_restart" == "y" ]]; then
   service rsyslog restart
 fi
 

--- a/plugins/nginx-vhosts/dependencies
+++ b/plugins/nginx-vhosts/dependencies
@@ -25,4 +25,8 @@ case "$DOKKU_DISTRO" in
   opensuse)
     zypper -q in -y nginx bind-utils
     ;;
+
+  arch)
+    pacman -S --noconfirm --noprogressbar --needed nginx bind-tools
+    ;;
 esac

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -32,6 +32,10 @@ restart_nginx() {
     opensuse)
       sudo /sbin/service nginx reload > /dev/null
       ;;
+
+    arch)
+      sudo /usr/bin/systemctl reload nginx
+	  ;;
   esac
 }
 

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -13,6 +13,10 @@ case "$DOKKU_DISTRO" in
   opensuse)
     echo "%dokku ALL=(ALL) NOPASSWD:/sbin/service nginx reload, /usr/sbin/nginx -t" > /etc/sudoers.d/dokku-nginx
     ;;
+
+  arch)
+    echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl reload nginx, /usr/sbin/nginx -t" > /etc/sudoers.d/dokku-nginx
+    ;;
 esac
 
 chmod 0440 /etc/sudoers.d/dokku-nginx
@@ -56,5 +60,9 @@ case "$DOKKU_DISTRO" in
 
   opensuse)
     /sbin/service nginx start
+    ;;
+
+  arch)
+    /usr/bin/systemctl start nginx
     ;;
 esac

--- a/plugins/nginx-vhosts/post-delete
+++ b/plugins/nginx-vhosts/post-delete
@@ -14,4 +14,8 @@ case "$DOKKU_DISTRO" in
   opensuse)
     sudo /sbin/service nginx reload > /dev/null
     ;;
+
+  arch)
+    sudo /usr/bin/systemctl reload nginx
+    ;;
 esac


### PR DESCRIPTION
* fix rsyslog handling

@josegonzalez I tried to get dokku running on ArchLinux instead of fiddling more around with the "let it run in docker" approach (see #1076). I hope this is okay too.

This also comes with an updated PKGBUILD for the Arch User Repo: ~~https://github.com/MorrisJobke/aur-dokku/compare/update-to-0.4.13~~ https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=dokku&id=87eec064d569e3a1b6f42dfcbca5502d38e51601

The only thing left for the Arch package to work is the herokuish app. I will look into this later.