### PR TITLE
Update bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,55 +1,92 @@
-#!/bin/bash
-#
+#!/usr/bin/env bash
+set -eo pipefail; [[ $TRACE ]] && set -x
+
 # A script to bootstrap dokku.
 # It expects to be run on Ubuntu 14.04 via 'sudo'
 # If installing a tag higher than 0.3.13, it may install dokku via a package (so long as the package is higher than 0.3.13)
 # It checks out the dokku source code from Github into ~/dokku and then runs 'make install' from dokku source.
 
-# We wrap this whole script in a function, so that we won't execute
+# We wrap this whole script in functions, so that we won't execute
 # until the entire script is downloaded.
 # That's good because it prevents our output overlapping with wget's.
 # It also means that we can't run a partially downloaded script.
 
+ensure-environment() {
+  echo "Preparing to install $DOKKU_TAG from $DOKKU_REPO..."
+  if ! command -v apt-get &>/dev/null; then
+    echo "This installation script requires apt-get. For manual installation instructions, consult http://dokku.viewdocs.io/dokku/advanced-installation/"
+    exit 1
+  fi
 
-bootstrap () {
-
-
-set -eo pipefail
-export DEBIAN_FRONTEND=noninteractive
-export DOKKU_REPO=${DOKKU_REPO:-"https://github.com/dokku/dokku.git"}
-
-echo "Preparing to install $DOKKU_TAG from $DOKKU_REPO..."
-if ! command -v apt-get &>/dev/null; then
-  echo "This installation script requires apt-get. For manual installation instructions, consult http://dokku.viewdocs.io/dokku/advanced-installation/"
-  exit 1
-fi
-
-hostname -f > /dev/null 2>&1 || {
-  echo "This installation script requires that you have a hostname set for the instance. Please set a hostname for 127.0.0.1 in your /etc/hosts"
-  exit 1
+  hostname -f > /dev/null 2>&1 || {
+    echo "This installation script requires that you have a hostname set for the instance. Please set a hostname for 127.0.0.1 in your /etc/hosts"
+    exit 1
+  }
 }
 
-echo "--> Ensuring we have the proper dependencies"
-apt-get update -qq > /dev/null
-[[ $(lsb_release -sr) == "12.04" ]] && apt-get install -qq -y python-software-properties
+install-requirements() {
+  echo "--> Ensuring we have the proper dependencies"
+  apt-get update -qq > /dev/null
+  if [[ $(lsb_release -sr) == "12.04" ]]; then
+    apt-get -qq -y install python-software-properties
+  fi
+}
 
-dokku_install_source() {
-  apt-get install -qq -y git make software-properties-common
+install-dokku() {
+  if [[ -n $DOKKU_BRANCH ]]; then
+    install-dokku-from-source "origin/$DOKKU_BRANCH"
+  elif [[ -n $DOKKU_TAG ]]; then
+    local DOKKU_SEMVER="${DOKKU_TAG//v}"
+    major=$(echo "$DOKKU_SEMVER" | awk '{split($0,a,"."); print a[1]}')
+    minor=$(echo "$DOKKU_SEMVER" | awk '{split($0,a,"."); print a[2]}')
+    patch=$(echo "$DOKKU_SEMVER" | awk '{split($0,a,"."); print a[3]}')
+
+    # 0.3.13 was the first version with a debian package
+    if [[ "$major" -eq "0" ]] && [[ "$minor" -eq "3" ]] && [[ "$patch" -ge "13" ]]; then
+      install-dokku-from-package "$DOKKU_SEMVER"
+      echo "--> Running post-install dependency installation"
+      dokku plugins-install-dependencies
+    # 0.4.0 implemented a `plugin` plugin
+    elif [[ "$major" -eq "0" ]] && [[ "$minor" -ge "4" ]] && [[ "$patch" -ge "0" ]]; then
+      install-dokku-from-package "$DOKKU_SEMVER"
+      echo "--> Running post-install dependency installation"
+      sudo -E dokku plugin:install-dependencies --core
+    else
+      install-dokku-from-source "$DOKKU_TAG"
+    fi
+  else
+    install-dokku-from-package
+    echo "--> Running post-install dependency installation"
+    sudo -E dokku plugin:install-dependencies --core
+  fi
+}
+
+
+install-dokku-from-source() {
+  local DOKKU_CHECKOUT="$1"
+  apt-get -qq -y install git make software-properties-common
   cd /root
   if [[ ! -d /root/dokku ]]; then
-    git clone $DOKKU_REPO /root/dokku
+    git clone "$DOKKU_REPO" /root/dokku
   fi
 
   cd /root/dokku
   git fetch origin
-  git checkout $DOKKU_CHECKOUT
+  [[ -n $DOKKU_CHECKOUT ]] && git checkout "$DOKKU_CHECKOUT"
   make install
 }
 
-dokku_install_package() {
+install-dokku-from-package() {
+  local DOKKU_CHECKOUT="$1"
+  local NO_INSTALL_RECOMMENDS=""
+
+  if [[ -n $DOKKU_DOCKERFILE ]]; then
+    NO_INSTALL_RECOMMENDS=" --no-install-recommends "
+  fi
+
   echo "--> Initial apt-get update"
   apt-get update -qq > /dev/null
-  apt-get install -qq -y apt-transport-https
+  apt-get -qq -y install apt-transport-https
 
   echo "--> Installing docker"
   if uname -r | grep -q linode; then
@@ -65,44 +102,28 @@ dokku_install_package() {
   echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ trusty main" | tee /etc/apt/sources.list.d/dokku.list
   apt-get update -qq > /dev/null
 
+  [[ -n $DOKKU_VHOST_ENABLE ]]  && echo "dokku dokku/vhost_enable boolean $VHOST_ENABLE"         | sudo debconf-set-selections
+  [[ -n $DOKKU_WEB_CONFIG ]]    && echo "dokku dokku/web_config boolean $DOKKU_WEB_CONFIG"       | sudo debconf-set-selections
+  [[ -n $DOKKU_HOSTNAME ]]      && echo "dokku dokku/hostname string $DOKKU_HOSTNAME"            | sudo debconf-set-selections
+  [[ -n $DOKKU_SKIP_KEY_FILE ]] && echo "dokku dokku/skip_key_file boolean $DOKKU_SKIP_KEY_FILE" | sudo debconf-set-selections
+  [[ -n $DOKKU_KEY_FILE ]]      && echo "dokku dokku/key_file string $DOKKU_KEY_FILE"            | sudo debconf-set-selections
+
   if [[ -n $DOKKU_CHECKOUT ]]; then
-    apt-get install -y dokku=$DOKKU_CHECKOUT
+    # shellcheck disable=SC2086
+    apt-get -qq -y $NO_INSTALL_RECOMMENDS install "dokku=$DOKKU_CHECKOUT"
   else
-    apt-get install -y dokku
+    # shellcheck disable=SC2086
+    apt-get -qq -y $NO_INSTALL_RECOMMENDS install dokku
   fi
 }
 
-if [[ -n $DOKKU_BRANCH ]]; then
-  export DOKKU_CHECKOUT="origin/$DOKKU_BRANCH"
-  dokku_install_source
-elif [[ -n $DOKKU_TAG ]]; then
-  export DOKKU_SEMVER="${DOKKU_TAG//v}"
-  major=$(echo $DOKKU_SEMVER | awk '{split($0,a,"."); print a[1]}')
-  minor=$(echo $DOKKU_SEMVER | awk '{split($0,a,"."); print a[2]}')
-  patch=$(echo $DOKKU_SEMVER | awk '{split($0,a,"."); print a[3]}')
+main() {
+  export DEBIAN_FRONTEND=noninteractive
+  export DOKKU_REPO=${DOKKU_REPO:-"https://github.com/dokku/dokku.git"}
 
-  # 0.3.13 was the first version with a debian package
-  if [[ "$major" -eq "0" ]] && [[ "$minor" -eq "3" ]] && [[ "$patch" -ge "13" ]]; then
-    export DOKKU_CHECKOUT="$DOKKU_SEMVER"
-    dokku_install_package
-    echo "--> Running post-install dependency installation"
-    dokku plugins-install-dependencies
-  # 0.4.0 implemented a `plugin` plugin
-  elif [[ "$major" -eq "0" ]] && [[ "$minor" -ge "4" ]] && [[ "$patch" -ge "0" ]]; then
-    export DOKKU_CHECKOUT="$DOKKU_SEMVER"
-    dokku_install_package
-    echo "--> Running post-install dependency installation"
-    sudo -E dokku plugin:install-dependencies --core
-  else
-    export DOKKU_CHECKOUT="$DOKKU_TAG"
-    dokku_install_source
-  fi
-else
-  dokku_install_package
-  echo "--> Running post-install dependency installation"
-  sudo -E dokku plugin:install-dependencies --core
-fi
-
+  ensure-environment
+  install-requirements
+  install-dokku
 }
 
-bootstrap
+main "$@"


### PR DESCRIPTION
This pr makes it slightly easier to support dockerfile installations

- "simplifies" the bootstrap process by dividing it into distinct chunks
- Allows specifying `--no-install-recommends` when a dockerfile installation is detected
- Uses functions everywhere
- Removes global variables where possible
- Fixes shellcheck issues
- Allows specifying debconf via the command-line

Refs #1076