### PR TITLE
fix get_running_image_tag() with docker 1.10.x

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -167,7 +167,7 @@ get_running_image_tag() {
   verify_app_name "$APP"
 
   CIDS=( $(get_app_container_ids $APP) )
-  RUNNING_IMAGE_TAG=$(docker ps -a --no-trunc | egrep ${CIDS[0]} 2>/dev/null | awk '{ print $2 }' | awk -F: '{ print $2 }' || echo '')
+  RUNNING_IMAGE_TAG=$(docker inspect -f '{{ .Config.Image }}' ${CIDS[0]} 2>/dev/null | awk -F: '{ print $2 }' || echo '')
   echo $RUNNING_IMAGE_TAG
 }
 


### PR DESCRIPTION
docker 1.10.x changed the format of `docker ps -a`; which we should rely on anyway. This change uses `docker inspect` output instead. All other instances of `docker ps ...| egrep ...` are simplistic enough for now.