### PR TITLE
(client) Add dokku git remote when specifying app name

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -68,19 +68,23 @@ if [[ ! -z $DOKKU_HOST ]]; then
       esac
     fi
 
-    if [[ "$1" = "apps:create" ]] && [[ -z "$2" ]]; then
-      appname=$(random_name)
-      counter=0
-      while ssh "dokku@$DOKKU_HOST" apps 2>/dev/null| grep -q "$appname"; do
-        if [[ $counter -ge 100 ]]; then
-          echo "Error: could not reasonably generate a new app name. try cleaning up some apps..."
-          ssh "dokku@$DOKKU_HOST" apps
-          exit 1
-        else
-          appname=$(random_name)
-          counter=$((counter+1))
-        fi
-      done
+    if [[ "$1" = "apps:create" ]]; then
+      if [[ -z "$2" ]]; then
+        appname=$(random_name)
+        counter=0
+        while ssh "dokku@$DOKKU_HOST" apps 2>/dev/null| grep -q "$appname"; do
+          if [[ $counter -ge 100 ]]; then
+            echo "Error: could not reasonably generate a new app name. try cleaning up some apps..."
+            ssh "dokku@$DOKKU_HOST" apps
+            exit 1
+          else
+            appname=$(random_name)
+            counter=$((counter+1))
+          fi
+        done
+      else
+        appname="$2"
+      fi
       if git remote add dokku "dokku@$DOKKU_HOST:$appname"; then
         echo "-----> Dokku remote added at $DOKKU_HOST"
         echo "-----> Application name is $appname"

--- a/tests/unit/20_client.bats
+++ b/tests/unit/20_client.bats
@@ -27,12 +27,28 @@ teardown() {
   assert_success
 }
 
-@test "(client) apps:create AND apps:destroy" {
+@test "(client) apps:create AND apps:destroy with random name" {
   setup_client_repo
   run bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh apps:create"
   echo "output: "$output
   echo "status: "$status
   assert_success
+  git remote | grep dokku
+  run bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh --force apps:destroy"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+}
+
+@test "(client) apps:create AND apps:destroy with name" {
+  setup_client_repo
+  local test_app_name=test-apps-create-with-name
+  run bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh apps:create $test_app_name"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  git remote | grep dokku
+  git remote -v | grep $test_app_name
   run bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh --force apps:destroy"
   echo "output: "$output
   echo "status: "$status


### PR DESCRIPTION
Previously the client would only add the git remote for you if it was generating a random name for you. I'd like it to add the remote regardless. If this is not the intended behavior then feel free to ignore this PR. It's just something that's bothered me.