### PR TITLE
Fix issue with plugins having plugins command

### DIFF
--- a/dokku
+++ b/dokku
@@ -58,7 +58,7 @@ if [[ $(id -un) != "dokku" ]] && [[ ! $1 =~ plugin:* ]]; then
   exit $?
 fi
 
-if [[ $(id -un) != "root" && $1 =~ plugin:.* ]]; then
+if [[ $(id -un) != "root" && $1 =~ ^plugin:.* ]]; then
   dokku_log_fail "plugin:* commands must be run as root"
 fi
 


### PR DESCRIPTION
While adding `:plugin:install` capability to the `dokku-elasticsearch` plugin, I noticed that this check prevents my unit tests to run.

This PR fixes the issue, while maintaining the ìd` check when installing dokku plugins.