### PR TITLE
Fixed Nginx websocket configuration issue

### DIFF
--- a/plugins/nginx-vhosts/templates/location.config
+++ b/plugins/nginx-vhosts/templates/location.config
@@ -10,7 +10,7 @@
     proxy_pass  http://{{ .APP }};
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
+    proxy_set_header Connection \"Upgrade\";
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
The quotes are dropped during template generation, so they should be escaped. Also switched to using uppercase leading character as there seems to be better compatibility:
https://github.com/websocket-rails/websocket-rails/issues/55

As an example this change was required in order to run http://web.sockethook.io/ - which is a nice and simple test case because zero configuration is required.