### PR TITLE
Highlight features that are yet to come

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -238,8 +238,8 @@ blockquote {
   margin-bottom: 30px;
 }
 blockquote.new-as-of {
-  border-left: 4px solid #f0ad4e;
-  background-color: #f0dc6e;
+  border-left: 4px solid #d1f2a5;
+  background-color: #effab4;
 }
 blockquote.not-yet-released {
   border-left: 4px solid #ef5b58;

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -238,6 +238,10 @@ blockquote {
   margin-bottom: 30px;
 }
 blockquote.new-as-of {
+  border-left: 4px solid #f0ad4e;
+  background-color: #f0dc6e;
+}
+blockquote.not-yet-released {
   border-left: 4px solid #ef5b58;
   background-color: #f9ad76;
 }

--- a/docs/checks-examples.md
+++ b/docs/checks-examples.md
@@ -1,6 +1,6 @@
 # Zero Downtime Deploys
 
-> Plugin management is New as of 0.5.0
+> Plugin management is not yet released and only available in master
 
 ```
 checks <app>                                                                                 Show zero-downtime status

--- a/docs/deployment/deployment-tasks.md
+++ b/docs/deployment/deployment-tasks.md
@@ -1,6 +1,6 @@
 # Deployment Tasks
 
-> not yet released and only available in master
+> Not yet released and only available in master
 
 Sometimes you need to run a command on at deployment time, but before an app is completely deployed.
 Common use cases include:

--- a/docs/deployment/deployment-tasks.md
+++ b/docs/deployment/deployment-tasks.md
@@ -1,6 +1,6 @@
 # Deployment Tasks
 
-> New as of 0.5.0
+> not yet released and only available in master
 
 Sometimes you need to run a command on at deployment time, but before an app is completely deployed.
 Common use cases include:

--- a/docs/deployment/dockerfiles.md
+++ b/docs/deployment/dockerfiles.md
@@ -42,7 +42,7 @@ Setting `$DOKKU_DOCKERFILE_CACHE_BUILD` to `true` or `false` will enable or disa
 
 ### Procfiles and Multiple Processes
 
-> New as of 0.5.0
+> not yet released and only available in master
 
 You can also customize the run command using a `Procfile`, much like you would on Heroku or
 with a buildpack deployed app. The `Procfile` should contain one or more lines defining [process

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -4,6 +4,7 @@ Dokku is released in intervals *at most* three weeks apart, though may be releas
 
 To propose a release, the following tasks need to be performed:
 
+- Update all blockquote references of `not yet released and only available in master` to point to release version.
 - The installable version must be changed in the `contrib/dokku-installer.py` file.
 - The installable version must be changed in the `debian/control` file.
 - The installable version must be changed in the `docs/home.html` file

--- a/docs/dokku-storage.md
+++ b/docs/dokku-storage.md
@@ -1,6 +1,6 @@
 # Dokku Core Storage Plugin
 
-> New as of 0.5.0
+> not yet released and only available in master
 
 The preferred method to mount external containers to a dokku managed container, is to use the dokku storage plugin.
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -10,7 +10,7 @@ nginx:error-logs <app> [-t]                                                     
 
 ## Customizing the nginx configuration
 
-> New as of 0.5.0
+> not yet released and only available in master
 
 Dokku uses a templating library by the name of [sigil](https://github.com/gliderlabs/sigil) to generate nginx configuration for each app. If you'd like to provide a custom template for your application, there are a couple options:
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,6 +1,6 @@
 # Proxy plugin
 
-> New as of 0.5.0
+> not yet released and only available in master
 
 As of dokku 0.5.0, the proxy functionality has been decoupled from the nginx-vhosts plugin into the proxy plugin. In the future this will allow other proxy software (HAproxy for example) to be used instead of nginx.
 

--- a/docs/template.html
+++ b/docs/template.html
@@ -36,6 +36,9 @@
     <link href="https://cdn.rawgit.com/dokku/dokku/v0.4.14/docs/assets/style.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet">
     <style>
+      blockquote.new-as-of {border-left:4px solid #d1f2a5;background-color:#effab4;}
+      blockquote.not-yet-released {border-left:4px solid #ef5b58;background-color:#f9ad76;}
+
       .rst-versions.rst-badge {display: block;}
       .rst-other-versions {text-align: left;}
       .rst-other-versions a {border: 0;}
@@ -78,11 +81,18 @@
       .rst-versions.rst-badge.shift-up .rst-current-version .fa-book{float:left}
       .rst-versions.rst-badge.shift-up .rst-current-version .icon-book{float:left}
       .rst-versions.rst-badge .rst-current-version{width:auto;height:30px;line-height:30px;padding:0 6px;display:block;text-align:center}
-      @media screen and (max-width: 768px){.rst-versions{width:85%;display:none}
-      .rst-versions.shift{display:block}img{width:100%;height:auto}}
+      .dev-warning, .outdated-warning {position: absolute;top: 0;width: 100%;padding: 8px 20px 8px;-moz-box-sizing: border-box;-webkit-box-sizing: border-box;box-sizing: border-box;background-image: -webkit-linear-gradient(-45deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 50%, rgba(0,0,0,0.04) 50%, rgba(0,0,0,0.04) 75%, transparent 75%, transparent);background-image: -moz-linear-gradient(-45deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 50%, rgba(0,0,0,0.04) 50%, rgba(0,0,0,0.04) 75%, transparent 75%, transparent);background-image: linear-gradient(135deg, rgba(0,0,0,0.04) 25%, transparent 25%, transparent 50%, rgba(0,0,0,0.04) 50%, rgba(0,0,0,0.04) 75%, transparent 75%, transparent);font-family: "Roboto", Corbel, Avenir, "Lucida Grande", "Lucida Sans", sans-serif;font-size: 14px;text-align: center;background-color: #ffe761;}
+      @media screen and (max-width: 768px){
+        .rst-versions{width:85%;display:none}
+        .rst-versions.shift{display:block}img{width:100%;height:auto}
+        .dev-warning, .outdated-warning { position: fixed; min-width: 768px;}
+      }
     </style>
   </head>
   <body>
+    <div class="dev-warning doc-floating-warning" style="display:none">
+      This document is for dokku's development version, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page.
+    </div>
     <div class="header">
       <div class="container-fluid">
         <div class="row">
@@ -192,6 +202,10 @@
       </div>
     </div>
 
+    <div class="dev-warning doc-floating-warning" style="display:none">
+      This document is for dokku's development version, which can be significantly different from previous releases. For older releases, use the version selector floating in the bottom right corner of this page.
+    </div>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/1.3.0/anchor.js"></script>
     <script>
     document.addEventListener("DOMContentLoaded", function (e) {
@@ -250,9 +264,9 @@
       };
 
       Array.prototype.forEach.call(blockquotes, function (el, i) {
-        if (el.innerHTML.indexOf('New as of') !== -1) {
+        if (el.innerHTML.toLowerCase().indexOf('new as of') !== -1) {
           addClass(el, 'new-as-of');
-        } else if (el.innerHTML.indexOf('not yet released') !== -1) {
+        } else if (el.innerHTML.toLowerCase().indexOf('not yet released') !== -1) {
           addClass(el, 'not-yet-released');
         }
       });
@@ -326,6 +340,13 @@
           addVersionLink(version);
         });
       };
+
+      if (currentVersion == 'master') {
+        document.querySelectorAll('.dev-warning')[0].style.position = 'relative';
+        Array.prototype.forEach.call(document.querySelectorAll('.dev-warning'), function (el, i) {
+          el.style.display = '';
+        });
+      }
 
       data = ls2.load('max-versions');
       if (!data) {

--- a/docs/template.html
+++ b/docs/template.html
@@ -252,6 +252,8 @@
       Array.prototype.forEach.call(blockquotes, function (el, i) {
         if (el.innerHTML.indexOf('New as of') !== -1) {
           addClass(el, 'new-as-of');
+        } else if (el.innerHTML.indexOf('not yet released') !== -1) {
+          addClass(el, 'not-yet-released');
         }
       });
       Array.prototype.forEach.call(classNames, function (className, i) {


### PR DESCRIPTION
 - Tone down "new as of version" boxes
 - Replace all "New as of 0.5" with "yet to be released" text
 - Use strong red only for "yet to be released" boxes

Fixes #1989 

It now looks like this:

![screen shot 2016-03-13 at 11 31 16](https://cloud.githubusercontent.com/assets/40496/13728170/9c1fef10-e90f-11e5-9bb9-c426c3e6948d.png)
![screen shot 2016-03-13 at 11 25 59](https://cloud.githubusercontent.com/assets/40496/13728171/9c22b722-e90f-11e5-9c90-9e9df58af48b.png)

