### PR TITLE
Only chown of existing files

### DIFF
--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -60,4 +60,8 @@ fi
 EOF
 chmod +x /etc/update-motd.d/99-dokku
 
-chown dokku:dokku "$DOKKU_ROOT/HOSTNAME" "$DOKKU_ROOT/VHOST"
+chown dokku:dokku "$DOKKU_ROOT/HOSTNAME"
+
+if [[ -f  "$DOKKU_ROOT/VHOST" ]]; then
+  chown dokku:dokku "$DOKKU_ROOT/VHOST"
+fi


### PR DESCRIPTION
* this caused issues during installation if the file is not existent


@michaelshobbs @josegonzalez This fixed an issue with the ArchLinux installation where the installation of the plugins aborted because the VHOST file was not available. Is this file needed or just optional? Because in Line 9 of this file the VHOST is created only if the host name could be resolved by `dig`.