### PR TITLE
Improved documentation for using official dokku_client.sh

### DIFF
--- a/docs/community/clients.md
+++ b/docs/community/clients.md
@@ -13,6 +13,10 @@ To install, simply clone the dokku repository down and add the `dokku` alias poi
 ```shell
 git clone git@github.com:dokku/dokku.git ~/.dokku
 
+# optional: make sure that the dokku_client.sh version matches your dokku version
+cd ~/.dokku
+git checkout <tag/branch>
+
 # add the following to either your
 # .bashrc, .bash_profile, or .profile file
 alias dokku='$HOME/.dokku/contrib/dokku_client.sh'


### PR DESCRIPTION
I've noticed that dokku_client.sh wasn't working as I expected it to (many commands failing). Following the docs lead me to install the master version rather than 0.4.14.

I think it makes sense to explicitly remind in the docs that the version needs to be specified.