### PR TITLE
Fix too many redirects

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,13 @@ Vagrant::configure("2") do |config|
     vm.vm.network :forwarded_port, guest: 80, host: FORWARDED_PORT
     vm.vm.hostname = "#{DOKKU_DOMAIN}"
     vm.vm.network :private_network, ip: DOKKU_IP
+
+    # Use the same nameserver as the host machine in order to avoid the "too many redirects" problem.
+    vm.vm.provider :virtualbox do |vb|
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "off"]
+      vb.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
+    end
+
     vm.vm.provision :shell, :inline => "export DEBIAN_FRONTEND=noninteractive && apt-get update > /dev/null && apt-get -qq -y install git > /dev/null && cd /root/dokku && #{make_cmd}"
     vm.vm.provision :shell, :inline => "cd /root/dokku && make dokku-installer"
     vm.vm.provision :shell do |s|


### PR DESCRIPTION
Fixes a problem often seen on Yosemite. Example error message on vagrant up:

```
Error response from daemon: Get
https://registry-1.docker.io/v2/library/postgres/manifests/9.5.0: Get https://auth.docker.io/token scope=repository%3Alibrary%2Fpostgres%3Apull&service=registry.docker.io: dial tcp: lookup auth.docker.io on 10.0.2.3:53: too many redirects
```

Solution borrows heavily from https://github.com/deis/deis/pull/4107