### PR TITLE
Delete bad symlinks without confirmation

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -43,6 +43,7 @@ case "$1" in
         PLUGIN_PATH=${DOKKU_LIB_ROOT}/plugins plugn enable $plugin
       fi
     done
+    find -L ${DOKKU_LIB_ROOT} -type l -delete
     chown dokku:dokku -R ${DOKKU_LIB_ROOT}/plugins ${DOKKU_LIB_ROOT}/core-plugins
 
     echo "Install all core plugins"


### PR DESCRIPTION
This fixes issues where the deleted backup plugin causes warnings during `plugn` runs.