### PR TITLE
Fix ps_restart to not exit early

### DIFF
--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -128,9 +128,11 @@ ps_restart() {
   local APP="$1"; verify_app_name "$APP"
   local IMAGE_TAG=$(get_running_image_tag "$APP")
 
-  ! (is_deployed "$APP") && echo "App $APP has not been deployed" && exit 0
-
-  release_and_deploy "$APP" "$IMAGE_TAG"
+  if is_deployed "$APP"; then
+    release_and_deploy "$APP" "$IMAGE_TAG"
+  else
+    echo "App $APP has not been deployed"
+  fi
 }
 
 ps_scale() {


### PR DESCRIPTION
ps_restartall_cmd (aka `dokku ps:restartall`) calls the `ps_restart` function from a loop, so if `ps_restart` does an `exit 0` if it finds an app that hasn't been deployed (in my case due to `dokku ps:scale web=0`), then it exits the `ps:restartall` loop early and hence just doesn't restart all the apps.