### PR TITLE
Implement repo:gc and repo:purge-cache

### DIFF
--- a/plugins/00_dokku-standard/subcommands/build
+++ b/plugins/00_dokku-standard/subcommands/build
@@ -19,7 +19,7 @@ dokku_build_cmd() {
       local id=$(tar -c . | docker run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /app && tar -xC /app")
       test "$(docker wait "$id")" -eq 0
       docker commit "$id" "$IMAGE" > /dev/null
-      [[ -d $CACHE_DIR ]] || mkdir "$CACHE_DIR"
+      [[ -d $CACHE_DIR ]] || mkdir -p "$CACHE_DIR"
       plugn trigger pre-build-buildpack "$APP"
 
       local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$IMAGE_SOURCE_TYPE")

--- a/plugins/repo/commands
+++ b/plugins/repo/commands
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+[[ " help repo:help " == *" $1 "* ]] || exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+case "$1" in
+  help | repo:help)
+    help_content_func () {
+      declare desc="return repo plugin help content"
+      cat<<help_content
+    repo:gc <app>, Runs 'git gc --agressive' against the application's repo
+    repo:purge-cache <app>, Deletes the contents of the build cache stored in the repository
+help_content
+    }
+
+    if [[ $1 = "repo:help" ]] ; then
+        echo -e 'Usage: dokku repo[:COMMAND]'
+        echo ''
+        echo "Runs commands that interact with the app's repo"
+        echo ''
+        echo 'Additional commands:'
+        help_content_func | sort | column -c2 -t -s,
+    else
+        help_content_func
+    fi
+    ;;
+
+  *)
+    exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
+    ;;
+
+esac

--- a/plugins/repo/plugin.toml
+++ b/plugins/repo/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "dokku core repo plugin"
+version = "0.5.3"
+[plugin.config]

--- a/plugins/repo/subcommands/gc
+++ b/plugins/repo/subcommands/gc
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+
+repo_gc() {
+  declare desc="runs 'git gc --agressive' against the application's repo"
+  local cmd="repo:gc"
+  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
+  local APP="$2"; local APP_DIR="$DOKKU_ROOT/$APP"
+  verify_app_name "$APP"
+
+  GIT_DIR="$APP_DIR" git gc --aggressive
+}
+
+repo_gc "$@"

--- a/plugins/repo/subcommands/purge-cache
+++ b/plugins/repo/subcommands/purge-cache
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+
+repo_purge_cache() {
+  declare desc="deletes the contents of the build cache stored in the repository"
+  local cmd="repo:purge-cache"
+  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
+  local APP="$2";
+  verify_app_name "$APP"
+
+  local IMAGE=$(get_app_image_name "$APP"); local CACHE_DIR="$DOKKU_ROOT/$APP/cache"
+
+  if [[ -d $CACHE_DIR ]]; then
+    docker run "$DOKKU_GLOBAL_RUN_ARGS" --rm -v "$CACHE_DIR:/cache" "$IMAGE" find /cache -depth -mindepth 1 -maxdepth 1 -exec rm -Rf {} \; || true
+    mkdir -p "$CACHE_DIR" || true
+  fi
+}
+
+repo_purge_cache "$@"

--- a/tests/unit/10_repo.bats
+++ b/tests/unit/10_repo.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  deploy_app
+}
+
+teardown() {
+  destroy_app
+}
+
+@test "(repo) repo:gc, repo:purge-cache" {
+  run dokku repo:gc $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run bash -c "find $DOKKU_ROOT/$TEST_APP/cache -type f | wc -l | grep 0"
+  echo "output: "$output
+  echo "status: "$status
+  assert_failure
+  run dokku repo:purge-cache $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  run bash -c "find $DOKKU_ROOT/$TEST_APP/cache -type f | wc -l | grep 0"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+}


### PR DESCRIPTION
These are helper plugins that mimic the repo plugin: https://github.com/heroku/heroku-repo

The following commands will remain unimplemented:

- `clone`: not useful for the host client to clone
- `download`: currently not possible for us to "host" a tarball of the repo
- `reset`: we still store files in the repo (though we shouldn't) so we cannot easily reinitialize the repository.

Also fixes a potential race condition if two separate processes create an application's `$CACHE_DIR`.

Closes #1570