### PR TITLE
move include to server section

### DIFF
--- a/plugins/nginx-vhosts/templates/tcp.server.config
+++ b/plugins/nginx-vhosts/templates/tcp.server.config
@@ -26,8 +26,8 @@ server {
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Request-Start $msec;
   }
+  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 }
-include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 {{ if $.DOKKU_APP_LISTENERS }}
 upstream {{ $.APP }}-{{ $port }} {
 {{ range $.DOKKU_APP_LISTENERS | split " " }}  server {{ . }}:{{ $port }};{{ end }}


### PR DESCRIPTION
This replicates the behaviour of `location.config` and makes the letsencrypt plugin usable again for Dockerfile deployments