### PR TITLE
Fix ignored settings in the CHECKS file

### DIFF
--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -131,8 +131,8 @@ checks_check_deploy() {
     line=$(strip_inline_comments "$line")
     # Name/value pair
     if [[ "$line" =~ ^.+= ]]; then
-      NAME=${TRIM%=*}
-      VALUE=${TRIM#*=}
+      NAME=${line%=*}
+      VALUE=${line#*=}
       [[ "$NAME" = "WAIT" ]] && local WAIT=$VALUE
       [[ "$NAME" = "TIMEOUT" ]] && local TIMEOUT=$VALUE
       [[ "$NAME" = "ATTEMPTS" ]] && local ATTEMPTS=$VALUE


### PR DESCRIPTION
I used settings in the `CHECKS` file.
But they are ignored after upgraded from v0.4.14 to v0.5.3.
This fixes typo and they work well again.