### PR TITLE
Add support for heroku's script.postdeploy hook

### DIFF
--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -8,6 +8,7 @@ git_build_app_repo() {
   declare desc="builds local git app repo for app"
   verify_app_name "$1"
   local APP="$1"; local REV="$2"
+  local DOKKU_FIRST_DEPLOY=false
 
   # clean up after ourselves
   local GIT_BUILD_APP_REPO_TMP_WORK_DIR=$(mktemp -d "/tmp/dokku_git.XXXX")
@@ -21,7 +22,8 @@ git_build_app_repo() {
   chmod 755 "$GIT_BUILD_APP_REPO_TMP_WORK_DIR"
   unset GIT_DIR GIT_WORK_TREE
   pushd "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" > /dev/null
-  [[ ! -d "$DOKKU_ROOT/$APP" ]] && apps_create "$APP"
+  [[ ! -d "$DOKKU_ROOT/$APP" ]] && DOKKU_FIRST_DEPLOY=true
+  [[ "$DOKKU_FIRST_DEPLOY" == "true" ]] && apps_create "$APP"
   GIT_DIR="$DOKKU_ROOT/$APP" git tag -d "$TMP_TAG" &> /dev/null || true
   GIT_DIR="$DOKKU_ROOT/$APP" git tag "$TMP_TAG" "$REV" &> /dev/null
   git init &> /dev/null
@@ -40,6 +42,7 @@ git_build_app_repo() {
     plugn trigger pre-receive-app "$APP" "herokuish" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV"
     dokku receive "$APP" "herokuish" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
   fi
+  [[ "$DOKKU_FIRST_DEPLOY" == "true" ]] && plugn trigger post-initial-deploy "$APP"
 }
 
 git_hook_cmd() {


### PR DESCRIPTION
This hook is a bit different from the scripts.dokku.postdeploy in that it only applies to the *first* deploy, not every deploy, and is thus suitable for hooks such as:

- slack notification: user just deployed a test application [here](http://example.com).

Also adds a new hook, `post-initial-deploy`.