### PR TITLE
Migrate all dokku related configuration to filedb wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOKKU_VERSION = master
 
-FILEDB_URL ?= https://raw.githubusercontent.com/josegonzalez/bash-filedb/v0.0.3/filedb
+FILEDB_URL ?= https://raw.githubusercontent.com/josegonzalez/bash-filedb/v0.3.0/filedb
 SSHCOMMAND_URL ?= https://raw.githubusercontent.com/dokku/sshcommand/v0.4.0/sshcommand
 PLUGN_URL ?= https://github.com/dokku/plugn/releases/download/v0.2.1/plugn_0.2.1_linux_x86_64.tgz
 SIGIL_URL ?= https://github.com/gliderlabs/sigil/releases/download/v0.4.0/sigil_0.4.0_Linux_x86_64.tgz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DOKKU_VERSION = master
 
+FILEDB_URL ?= https://raw.githubusercontent.com/josegonzalez/bash-filedb/v0.0.3/filedb
 SSHCOMMAND_URL ?= https://raw.githubusercontent.com/dokku/sshcommand/v0.4.0/sshcommand
 PLUGN_URL ?= https://github.com/dokku/plugn/releases/download/v0.2.1/plugn_0.2.1_linux_x86_64.tgz
 SIGIL_URL ?= https://github.com/gliderlabs/sigil/releases/download/v0.4.0/sigil_0.4.0_Linux_x86_64.tgz
@@ -47,6 +48,7 @@ packer:
 
 copyfiles:
 	cp dokku /usr/local/bin/dokku
+	mkdir -p ${DOKKU_LIB_ROOT}/config
 	mkdir -p ${CORE_PLUGINS_PATH} ${PLUGINS_PATH}
 	rm -rf ${CORE_PLUGINS_PATH}/*
 	test -d ${CORE_PLUGINS_PATH}/enabled || PLUGIN_PATH=${CORE_PLUGINS_PATH} plugn init
@@ -62,7 +64,7 @@ copyfiles:
 		PLUGIN_PATH=${CORE_PLUGINS_PATH} plugn enable $$plugin ;\
 		PLUGIN_PATH=${PLUGINS_PATH} plugn enable $$plugin ;\
 		done
-	chown dokku:dokku -R ${PLUGINS_PATH} ${CORE_PLUGINS_PATH}
+	chown dokku:dokku -R ${PLUGINS_PATH} ${CORE_PLUGINS_PATH} ${DOKKU_LIB_ROOT}/config
 	$(MAKE) addman
 
 addman:
@@ -79,7 +81,7 @@ plugin-dependencies: plugn
 plugins: plugn docker
 	sudo -E dokku plugin:install --core
 
-dependencies: apt-update sshcommand plugn docker help2man man-db sigil
+dependencies: apt-update filedb sshcommand plugn docker help2man man-db sigil
 	$(MAKE) -e stack
 
 apt-update:
@@ -90,6 +92,10 @@ help2man:
 
 man-db:
 	apt-get install -qq -y man-db
+
+filedb:
+	wget -qO /usr/local/bin/filedb ${FILEDB_URL}
+	chmod +x /usr/local/bin/filedb
 
 sshcommand:
 	wget -qO /usr/local/bin/sshcommand ${SSHCOMMAND_URL}

--- a/deb.mk
+++ b/deb.mk
@@ -10,7 +10,7 @@ DOKKU_ARCHITECTURE = amd64
 
 FILEDB_DESCRIPTION = 'A command line tool for manipulating a simple, flat-file database.'
 FILEDB_REPO_NAME ?= josegonzalez/filedb
-FILEDB_VERSION ?= 0.0.3
+FILEDB_VERSION ?= 0.3.0
 FILEDB_ARCHITECTURE = amd64
 FILEDB_PACKAGE_NAME = filedb_$(FILEDB_VERSION)_$(FILEDB_ARCHITECTURE).deb
 FILEDB_URL ?= https://raw.githubusercontent.com/josegonzalez/bash-filedb/$(SSHCOMMAND_VERSION)/filedb

--- a/deb.mk
+++ b/deb.mk
@@ -8,6 +8,13 @@ DOKKU_DESCRIPTION = 'Docker powered mini-Heroku in around 100 lines of Bash'
 DOKKU_REPO_NAME ?= dokku/dokku
 DOKKU_ARCHITECTURE = amd64
 
+FILEDB_DESCRIPTION = 'A command line tool for manipulating a simple, flat-file database.'
+FILEDB_REPO_NAME ?= josegonzalez/filedb
+FILEDB_VERSION ?= 0.0.3
+FILEDB_ARCHITECTURE = amd64
+FILEDB_PACKAGE_NAME = filedb_$(FILEDB_VERSION)_$(FILEDB_ARCHITECTURE).deb
+FILEDB_URL ?= https://raw.githubusercontent.com/josegonzalez/bash-filedb/$(SSHCOMMAND_VERSION)/filedb
+
 PLUGN_DESCRIPTION = 'Hook system that lets users extend your application with plugins'
 PLUGN_REPO_NAME ?= dokku/plugn
 PLUGN_VERSION ?= 0.2.1
@@ -29,7 +36,7 @@ SIGIL_ARCHITECTURE = amd64
 SIGIL_PACKAGE_NAME = sigil_$(SIGIL_VERSION)_$(SIGIL_ARCHITECTURE).deb
 SIGIL_URL = https://github.com/gliderlabs/sigil/releases/download/v$(SIGIL_VERSION)/sigil_$(SIGIL_VERSION)_Linux_x86_64.tgz
 
-.PHONY: install-from-deb deb-all deb-herokuish deb-dokku deb-plugn deb-setup deb-sshcommand deb-sigil
+.PHONY: install-from-deb deb-all deb-herokuish deb-dokku deb-plugn deb-setup deb-filedb deb-sshcommand deb-sigil
 
 install-from-deb:
 	@echo "--> Initial apt-get update"
@@ -108,6 +115,22 @@ deb-dokku: deb-setup
 	git rev-parse HEAD > /tmp/build/var/lib/dokku/GIT_REV
 	sed -i "s/^Version: .*/Version: `cat /tmp/build/var/lib/dokku/STABLE_VERSION`/g" /tmp/build/DEBIAN/control
 	dpkg-deb --build /tmp/build "/vagrant/dokku_`cat /tmp/build/var/lib/dokku/STABLE_VERSION`_$(DOKKU_ARCHITECTURE).deb"
+	mv *.deb /tmp
+
+deb-filedb:
+	rm -rf /tmp/tmp /tmp/build $(FILEDB_PACKAGE_NAME)
+	mkdir -p /tmp/tmp /tmp/build /tmp/build/usr/local/bin
+
+	@echo "-> Downloading package"
+	wget -q -O /tmp/tmp/filedb-$(FILEDB_VERSION) $(FILEDB_URL)
+
+	@echo "-> Copying files into place"
+	mkdir -p "/tmp/build/usr/local/bin"
+	cp /tmp/tmp/filedb-$(FILEDB_VERSION) /tmp/build/usr/local/bin/filedb
+	chmod +x /tmp/build/usr/local/bin/filedb
+
+	@echo "-> Creating $(FILEDB_PACKAGE_NAME)"
+	sudo fpm -t deb -s dir -C /tmp/build -n filedb -v $(FILEDB_VERSION) -a $(FILEDB_ARCHITECTURE) -p $(FILEDB_PACKAGE_NAME) --url "https://github.com/$(FILEDB_REPO_NAME)" --description $(FILEDB_DESCRIPTION) --license 'MIT License' .
 	mv *.deb /tmp
 
 deb-plugn: deb-setup

--- a/debian/postinst
+++ b/debian/postinst
@@ -22,6 +22,10 @@ case "$1" in
     mkdir -p ${DOKKU_LIB_ROOT}/data ${DOKKU_LIB_ROOT}/data/storage
     chown dokku:dokku -R ${DOKKU_LIB_ROOT}/data
 
+    echo "Setting up config directories"
+    mkdir -p ${DOKKU_LIB_ROOT}/config
+    chown dokku:dokku -R ${DOKKU_LIB_ROOT}/config
+
     echo "Setting up plugin directories"
     # should be replaced by `plugn init`
     mkdir -p ${DOKKU_LIB_ROOT}/core-plugins/available ${DOKKU_LIB_ROOT}/plugins/available

--- a/plugins/00_dokku-standard/exec-app-json-scripts
+++ b/plugins/00_dokku-standard/exec-app-json-scripts
@@ -58,8 +58,8 @@ execute_script() {
       dokku_container_log_verbose_quiet "$id"
       if [[ "$PHASE_SCRIPT_KEY" != "postdeploy" ]];then
         if ! is_image_herokuish_based "$IMAGE"; then
-          local DOKKU_DOCKERFILE_ENTRYPOINT=$(config_get "$APP" DOKKU_DOCKERFILE_ENTRYPOINT)
-          local DOKKU_DOCKERFILE_CMD=$(config_get "$APP" DOKKU_DOCKERFILE_CMD)
+          local DOKKU_DOCKERFILE_ENTRYPOINT=$(get_config_value "app.$APP" DOKKU_DOCKERFILE_ENTRYPOINT)
+          local DOKKU_DOCKERFILE_CMD=$(get_config_value "app.$APP" DOKKU_DOCKERFILE_CMD)
           [[ -n "$DOKKU_DOCKERFILE_ENTRYPOINT" ]] && local DOCKER_COMMIT_ENTRYPOINT_CHANGE_ARG="--change='$DOKKU_DOCKERFILE_ENTRYPOINT'"
           [[ -n "$DOKKU_DOCKERFILE_CMD" ]] && local DOCKER_COMMIT_CMD_CHANGE_ARG="--change='$DOKKU_DOCKERFILE_CMD'"
 

--- a/plugins/00_dokku-standard/subcommands/build
+++ b/plugins/00_dokku-standard/subcommands/build
@@ -36,13 +36,13 @@ dokku_build_cmd() {
     dockerfile)
       # extract first port from Dockerfile
       local DOCKERFILE_PORTS=$(get_dockerfile_exposed_ports Dockerfile)
-      [[ -n "$DOCKERFILE_PORTS" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_PORTS="$DOCKERFILE_PORTS"
+      [[ -n "$DOCKERFILE_PORTS" ]] && set_config_value "app.$APP" DOKKU_DOCKERFILE_PORTS "$DOCKERFILE_PORTS"
 
       # extract ENTRYPOINT/CMD from Dockerfile
       local DOCKERFILE_ENTRYPOINT=$(extract_directive_from_dockerfile Dockerfile ENTRYPOINT)
-      [[ -n "$DOCKERFILE_ENTRYPOINT" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_ENTRYPOINT="$DOCKERFILE_ENTRYPOINT"
+      [[ -n "$DOCKERFILE_ENTRYPOINT" ]] && set_config_value "app.$APP" DOKKU_DOCKERFILE_ENTRYPOINT "$DOCKERFILE_ENTRYPOINT"
       local DOCKERFILE_CMD=$(extract_directive_from_dockerfile Dockerfile CMD)
-      [[ -n "$DOCKERFILE_CMD" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_CMD="$DOCKERFILE_CMD"
+      [[ -n "$DOCKERFILE_CMD" ]] && set_config_value "app.$APP" DOKKU_DOCKERFILE_CMD "$DOCKERFILE_CMD"
       plugn trigger pre-build-dockerfile "$APP"
 
       [[ "$DOKKU_DOCKERFILE_CACHE_BUILD" == "false" ]] && DOKKU_DOCKER_BUILD_OPTS="$DOKKU_DOCKER_BUILD_OPTS --no-cache"

--- a/plugins/00_dokku-standard/subcommands/deploy
+++ b/plugins/00_dokku-standard/subcommands/deploy
@@ -42,8 +42,8 @@ dokku_deploy_cmd() {
       [[ -n "$DOKKU_HEROKUISH" ]] && local START_CMD="/start $PROC_TYPE"
 
       if [[ -z "$DOKKU_HEROKUISH" ]]; then
-        local DOKKU_DOCKERFILE_PORTS=($(config_get "$APP" DOKKU_DOCKERFILE_PORTS || true))
-        local DOKKU_DOCKERFILE_START_CMD=$(config_get "$APP" DOKKU_DOCKERFILE_START_CMD || true)
+        local DOKKU_DOCKERFILE_PORTS=($(get_config_value "app.$APP" DOKKU_DOCKERFILE_PORTS || true))
+        local DOKKU_DOCKERFILE_START_CMD=$(get_config_value "app.$APP" DOKKU_DOCKERFILE_START_CMD || true)
         local DOKKU_PROCFILE_START_CMD=$(get_cmd_from_procfile "$APP" "$PROC_TYPE")
         local START_CMD=${DOKKU_DOCKERFILE_START_CMD:-$DOKKU_PROCFILE_START_CMD}
       fi
@@ -131,7 +131,7 @@ dokku_deploy_cmd() {
   if [[ -n "$oldids" ]]; then
 
     if [[ -z "$DOKKU_WAIT_TO_RETIRE" ]]; then
-      local DOKKU_APP_DOKKU_WAIT_TO_RETIRE=$(config_get "$APP" DOKKU_WAIT_TO_RETIRE || true)
+      local DOKKU_APP_DOKKU_WAIT_TO_RETIRE=$(get_config_value "app.$APP" DOKKU_WAIT_TO_RETIRE || true)
       local DOKKU_GLOBAL_DOKKU_WAIT_TO_RETIRE=$(config_get --global DOKKU_WAIT_TO_RETIRE || true)
       local DOKKU_WAIT_TO_RETIRE=${DOKKU_APP_DOKKU_WAIT_TO_RETIRE:="$DOKKU_GLOBAL_DOKKU_WAIT_TO_RETIRE"}
     fi

--- a/plugins/00_dokku-standard/subcommands/receive
+++ b/plugins/00_dokku-standard/subcommands/receive
@@ -14,7 +14,7 @@ dokku_receive_cmd() {
     dokku_log_info1 "DOKKU_SKIP_CLEANUP set. Skipping dokku cleanup"
   fi
   dokku_log_info1 "Building $APP from $IMAGE_SOURCE_TYPE..."
-  config_set --no-restart "$APP" DOKKU_APP_TYPE="$IMAGE_SOURCE_TYPE" &> /dev/null
+  set_config_value "app.$APP" DOKKU_APP_TYPE "$IMAGE_SOURCE_TYPE" &> /dev/null
   dokku build "$APP" "$IMAGE_SOURCE_TYPE" "$TMP_WORK_DIR"
   release_and_deploy "$APP"
 }

--- a/plugins/00_dokku-standard/subcommands/run
+++ b/plugins/00_dokku-standard/subcommands/run
@@ -13,7 +13,7 @@ dokku_run_cmd() {
   shift 2
 
   if [[ -z "$DOKKU_RM_CONTAINER" ]]; then
-    local DOKKU_APP_RM_CONTAINER=$(config_get "$APP" DOKKU_RM_CONTAINER || true)
+    local DOKKU_APP_RM_CONTAINER=$(get_config_value "app.$APP" DOKKU_RM_CONTAINER || true)
     local DOKKU_GLOBAL_RM_CONTAINER=$(config_get --global DOKKU_RM_CONTAINER || true)
     local DOKKU_RM_CONTAINER=${DOKKU_APP_RM_CONTAINER:="$DOKKU_GLOBAL_RM_CONTAINER"}
   fi

--- a/plugins/apps/post-delete
+++ b/plugins/apps/post-delete
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 app_post_delete() {
   declare desc="apps post-delete plugin trigger"
@@ -13,6 +14,8 @@ app_post_delete() {
   docker rm -f $(docker ps -a --no-trunc | egrep "dokku/${APP}:" | awk '{ print $1 }' | xargs) &>/dev/null || true
   # shellcheck disable=SC2046
   docker rmi $(docker images -q "$IMAGE_REPO" | xargs) &>/dev/null || true
+  # clear out all dokku-related application configuration
+  clear_config_domain "app.$APP"
 }
 
 app_post_delete "$@"

--- a/plugins/checks/functions
+++ b/plugins/checks/functions
@@ -6,7 +6,7 @@ source "$PLUGIN_AVAILABLE_PATH/config/functions"
 is_app_checks_enabled() {
   declare desc="return app zero-downtime checks status"
   local APP="$1"; verify_app_name "$APP"
-  local DOKKU_CHECKS_ENABLED=$(config_get "$APP" DOKKU_CHECKS_ENABLED)
+  local DOKKU_CHECKS_ENABLED=$(get_config_value "app.$APP" DOKKU_CHECKS_ENABLED)
 
   if [[ -z "$DOKKU_CHECKS_ENABLED" ]] || [[ "$DOKKU_CHECKS_ENABLED" == "1" ]];then
     local status=true

--- a/plugins/checks/install
+++ b/plugins/checks/install
@@ -20,13 +20,14 @@ migrate_checks_vars() {
     local APP_SKIP_DEFAULT_CHECKS=$(dokku config:get "$app" DOKKU_SKIP_DEFAULT_CHECKS || true)
 
     if [[ "$APP_SKIP_ALL_CHECKS" == "true" ]] || [[ "$APP_SKIP_DEFAULT_CHECKS" == "true" ]] || \
-       [[ "$GLOBAL_SKIP_ALL_CHECKS" == "true" ]] || [[ "$GLOBAL_SKIP_DEFAULT_CHECKS" == "true" ]]; then
-       dokku_log_info2 ""
-       dokku_log_info2 "zero downtime disabled for app ($app)"
-      config_set --no-restart "$app" DOKKU_CHECKS_ENABLED=0
+      [[ "$GLOBAL_SKIP_ALL_CHECKS" == "true" ]] || [[ "$GLOBAL_SKIP_DEFAULT_CHECKS" == "true" ]]; then
+      dokku_log_info2 ""
+      dokku_log_info2 "zero downtime disabled for app ($app)"
+      set_config_value "app.$app" DOKKU_CHECKS_ENABLED 0
     fi
     if [[ -n "$APP_SKIP_ALL_CHECKS" ]] || [[ -n "$APP_SKIP_DEFAULT_CHECKS" ]]; then
-      config_unset --no-restart "$app" DOKKU_SKIP_ALL_CHECKS DOKKU_SKIP_DEFAULT_CHECKS
+      unset_config_value "app.$app" DOKKU_SKIP_ALL_CHECKS
+      unset_config_value "app.$app" DOKKU_SKIP_DEFAULT_CHECKS
     fi
     dokku_log_info2 "Migration complete"
     dokku_log_info2 ""
@@ -34,7 +35,8 @@ migrate_checks_vars() {
 
   if [[ -n "$GLOBAL_SKIP_ALL_CHECKS" ]] || [[ -n "$GLOBAL_SKIP_DEFAULT_CHECKS" ]]; then
     dokku_log_info1 "Removing global zero downtime settings"
-    config_unset --global DOKKU_SKIP_ALL_CHECKS DOKKU_SKIP_DEFAULT_CHECKS
+    config_unset --global DOKKU_SKIP_ALL_CHECKS
+    config_unset --global DOKKU_SKIP_DEFAULT_CHECKS
   fi
 }
 

--- a/plugins/checks/subcommands/disable
+++ b/plugins/checks/subcommands/disable
@@ -10,12 +10,11 @@ checks_disable_cmd() {
 
   if [[ "$(is_app_checks_enabled "$APP")" == "true" ]]; then
     dokku_log_info1 "Disabling zero downtime for app ($APP)"
-    [[ "$2" == "--no-restart" ]] && local CONFIG_SET_ARGS=$2
     # shellcheck disable=SC2086
-    config_set $CONFIG_SET_ARGS $APP DOKKU_CHECKS_ENABLED=0
+    set_config_value "app.$APP" DOKKU_CHECKS_ENABLED 0
   else
     dokku_log_info1 "zero downtime is already disable for app ($APP)"
   fi
 }
 
-checks_disable_cmd "$2" --no-restart
+checks_disable_cmd "$2"

--- a/plugins/checks/subcommands/enable
+++ b/plugins/checks/subcommands/enable
@@ -10,12 +10,11 @@ checks_enable_cmd() {
 
   if [[ "$(is_app_checks_enabled "$APP")" == "false" ]]; then
     dokku_log_info1 "Enabling zero downtime for app ($APP)"
-    [[ "$2" == "--no-restart" ]] && local CONFIG_SET_ARGS=$2
     # shellcheck disable=SC2086
-    config_set $CONFIG_SET_ARGS $APP DOKKU_CHECKS_ENABLED=1
+    set_config_value "app.$APP" DOKKU_CHECKS_ENABLED 1
   else
     dokku_log_info1 "zero downtime is already enabled for app ($APP)"
   fi
 }
 
-checks_enable_cmd "$2" --no-restart
+checks_enable_cmd "$2"

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -390,7 +390,7 @@ release_and_deploy() {
       local IMAGE_SOURCE_TYPE="dockerfile"
     fi
 
-    local DOKKU_APP_SKIP_DEPLOY="$(config_get "$APP" DOKKU_SKIP_DEPLOY || true)"
+    local DOKKU_APP_SKIP_DEPLOY="$(get_config_value "app.$APP" DOKKU_SKIP_DEPLOY || true)"
     local DOKKU_GLOBAL_SKIP_DEPLOY="$(config_get --global DOKKU_SKIP_DEPLOY || true)"
 
     local DOKKU_SKIP_DEPLOY=${DOKKU_APP_SKIP_DEPLOY:="$DOKKU_GLOBAL_SKIP_DEPLOY"}
@@ -513,7 +513,7 @@ is_app_vhost_enabled() {
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
   local APP=$1; verify_app_name "$APP"
-  local NO_VHOST=$(config_get "$APP" NO_VHOST)
+  local NO_VHOST=$(get_config_value "app.$APP" NO_VHOST)
   local APP_VHOST_ENABLED=true
 
   if [[ "$NO_VHOST" == "1" ]]; then
@@ -530,8 +530,8 @@ disable_app_vhost() {
   local APP=$1; verify_app_name "$APP"
   local APP_VHOST_FILE="$DOKKU_ROOT/$APP/VHOST"
   local APP_URLS_FILE="$DOKKU_ROOT/$APP/URLS"
-  local DOKKU_NGINX_PORT=$(config_get "$APP" DOKKU_NGINX_PORT)
-  local DOKKU_NGINX_SSL_PORT=$(config_get "$APP" DOKKU_NGINX_SSL_PORT)
+  local DOKKU_NGINX_PORT=$(get_config_value "app.$APP" DOKKU_NGINX_PORT)
+  local DOKKU_NGINX_SSL_PORT=$(get_config_value "app.$APP" DOKKU_NGINX_SSL_PORT)
 
   if [[ -f "$APP_VHOST_FILE" ]]; then
     dokku_log_info1 "VHOST support disabled, deleting $APP/VHOST"
@@ -542,15 +542,14 @@ disable_app_vhost() {
     rm "$APP_URLS_FILE"
   fi
   if [[ "$DOKKU_NGINX_PORT" == "80" ]]; then
-    config_unset --no-restart "$APP" DOKKU_NGINX_PORT
+    unset_config_value "app.$APP" DOKKU_NGINX_PORT
   fi
   if [[ "$DOKKU_NGINX_SSL_PORT" == "443" ]]; then
-    config_unset --no-restart "$APP" DOKKU_NGINX_SSL_PORT
+    unset_config_value "app.$APP" DOKKU_NGINX_SSL_PORT
   fi
 
-  [[ "$2" == "--no-restart" ]] && local CONFIG_SET_ARGS=$2
   # shellcheck disable=SC2086
-  config_set $CONFIG_SET_ARGS $APP NO_VHOST=1
+  set_config_value "app.$APP" NO_VHOST 1
 }
 
 enable_app_vhost() {
@@ -559,10 +558,10 @@ enable_app_vhost() {
 
   local APP=$1; verify_app_name "$APP"
 
-  config_unset --no-restart "$APP" DOKKU_NGINX_PORT DOKKU_NGINX_SSL_PORT
-  [[ "$2" == "--no-restart" ]] && local CONFIG_SET_ARGS=$2
+  unset_config_value "app.$APP" DOKKU_NGINX_PORT
+  unset_config_value "app.$APP" DOKKU_NGINX_SSL_PORT
   # shellcheck disable=SC2086
-  config_set $CONFIG_SET_ARGS "$APP" NO_VHOST=0
+  set_config_value "app.$APP" NO_VHOST 0
 }
 
 get_dockerfile_exposed_ports() {
@@ -583,7 +582,7 @@ get_app_raw_tcp_ports() {
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
   local APP="$1"; verify_app_name "$APP"
-  local DOCKERFILE_PORTS="$(config_get "$APP" DOKKU_DOCKERFILE_PORTS)"
+  local DOCKERFILE_PORTS="$(get_config_value "app.$APP" DOKKU_DOCKERFILE_PORTS)"
   for p in $DOCKERFILE_PORTS; do
     if [[ ! "$p" =~ .*udp.* ]]; then
       p=${p//\/tcp}
@@ -637,8 +636,8 @@ get_app_urls() {
     esac
   else
     local SCHEME="http"; local SSL="$DOKKU_ROOT/$APP/tls"
-    local DOKKU_NGINX_PORT=$(config_get "$APP" DOKKU_NGINX_PORT || true)
-    local DOKKU_NGINX_SSL_PORT=$(config_get "$APP" DOKKU_NGINX_SSL_PORT || true)
+    local DOKKU_NGINX_PORT=$(get_config_value "app.$APP" DOKKU_NGINX_PORT || true)
+    local DOKKU_NGINX_SSL_PORT=$(get_config_value "app.$APP" DOKKU_NGINX_SSL_PORT || true)
 
     if [[ -e "$SSL/server.crt" && -e "$SSL/server.key" ]]; then
       local SCHEME="https"

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -133,6 +133,7 @@ config_get() {
   declare desc="get value of given config var"
   [[ "$1" == "config:get" ]] || set -- "config:get" "$@"
   config_parse_args "$@"
+  local APP="$2" KEY="$3"
 
   if [[ -z $3 ]]; then
     echo "Usage: dokku config:get APP KEY"
@@ -140,12 +141,15 @@ config_get() {
     exit 1
   fi
 
+  [[ " DOKKU_APP_RESTORE DOKKU_CHECKS_ENABLED DOKKU_DISABLE_PROXY DOKKU_DOCKERFILE_CMD DOKKU_DOCKERFILE_ENTRYPOINT DOKKU_DOCKERFILE_PORTS DOKKU_DOCKERFILE_PORTS DOKKU_DOCKERFILE_START_CMD DOKKU_NGINX_PORT DOKKU_NGINX_PORT DOKKU_NGINX_SSL_PORT DOKKU_NGINX_SSL_PORT DOKKU_RM_CONTAINER DOKKU_SKIP_DEPLOY DOKKU_WAIT_TO_RETIRE NO_VHOST " == *" $KEY "* ]] && {
+    get_config_value "app.$APP" "$KEY"
+    return 0
+  }
+
   config_create "$ENV_FILE"
   if [[ ! -s $ENV_FILE ]]; then
     return 0
   fi
-
-  local KEY="$3"
 
   grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" "$ENV_FILE" | grep "^export $KEY=" | cut -d"=" -f2- | sed -e "s/^'//" -e "s/'$//"
 }
@@ -183,6 +187,10 @@ config_set() {
     local VALUE=$(echo ${var} | cut -d"=" -f2-)
 
     if [[ $KEY =~ [a-zA-Z_][a-zA-Z0-9_]* ]]; then
+      [[ " DOKKU_APP_RESTORE DOKKU_CHECKS_ENABLED DOKKU_DISABLE_PROXY DOKKU_DOCKERFILE_CMD DOKKU_DOCKERFILE_ENTRYPOINT DOKKU_DOCKERFILE_PORTS DOKKU_DOCKERFILE_PORTS DOKKU_DOCKERFILE_START_CMD DOKKU_NGINX_PORT DOKKU_NGINX_PORT DOKKU_NGINX_SSL_PORT DOKKU_NGINX_SSL_PORT DOKKU_RM_CONTAINER DOKKU_SKIP_DEPLOY DOKKU_WAIT_TO_RETIRE NO_VHOST " == *" $KEY "* ]] && {
+        set_config_value "app.$APP" "$KEY" "$VALUE"
+        continue
+      }
       local RESTART_APP=true
       local ENV_TEMP=$(echo "${ENV_TEMP}" | sed "/^export $KEY=/ d")
       local ENV_TEMP="${ENV_TEMP}
@@ -226,6 +234,10 @@ config_unset() {
   local VARS="${*:3}"
 
   for var in $VARS; do
+    [[ " DOKKU_APP_RESTORE DOKKU_CHECKS_ENABLED DOKKU_DISABLE_PROXY DOKKU_DOCKERFILE_CMD DOKKU_DOCKERFILE_ENTRYPOINT DOKKU_DOCKERFILE_PORTS DOKKU_DOCKERFILE_PORTS DOKKU_DOCKERFILE_START_CMD DOKKU_NGINX_PORT DOKKU_NGINX_PORT DOKKU_NGINX_SSL_PORT DOKKU_NGINX_SSL_PORT DOKKU_RM_CONTAINER DOKKU_SKIP_DEPLOY DOKKU_WAIT_TO_RETIRE NO_VHOST " == *" $KEY "* ]] && {
+      unset_config_value "app.$APP" "$KEY"
+      continue
+    }
     dokku_log_info1 "Unsetting $var"
     local ENV_TEMP=$(echo "${ENV_TEMP}" | sed "/^export $var=/ d")
 

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -202,7 +202,7 @@ ${var}"
     plugn trigger post-config-update "$APP" "set" "$@"
   fi
 
-  local DOKKU_APP_RESTORE=$(config_get "$APP" DOKKU_APP_RESTORE || true)
+  local DOKKU_APP_RESTORE=$(get_config_value "app.$APP" DOKKU_APP_RESTORE || true)
   if [[ "$DOKKU_CONFIG_RESTART" == "true" ]] && [[ "$DOKKU_APP_RESTORE" != 0 ]]; then
     dokku_log_info1 "Restarting app $APP"
     dokku ps:restart "$APP"
@@ -234,10 +234,33 @@ config_unset() {
 
   plugn trigger post-config-update "$APP" "unset" "$@"
 
-  local DOKKU_APP_RESTORE=$(config_get "$APP" DOKKU_APP_RESTORE || true)
+  local DOKKU_APP_RESTORE=$(get_config_value "app.$APP" DOKKU_APP_RESTORE || true)
   if [[ "$DOKKU_CONFIG_RESTART" == "true" ]] && [[ "$DOKKU_APP_RESTORE" != 0 ]]; then
     dokku_log_info1 "Restarting app $APP"
     dokku ps:restart "$APP"
   fi
+}
 
+get_config_value() {
+  declare desc="uses filedb to get a configuration value"
+  local DOMAIN="$1" KEY="$2"
+  FILEDB_ROOT="$DOKKU_LIB_ROOT/config" filedb get-value "$DOMAIN" "$KEY"
+}
+
+set_config_value() {
+  declare desc="uses filedb to get a configuration value"
+  local DOMAIN="$1" KEY="$2" VALUE="$3"
+  FILEDB_ROOT="$DOKKU_LIB_ROOT/config" filedb set-value "$DOMAIN" "$KEY" "$VALUE"
+}
+
+unset_config_value() {
+  declare desc="uses filedb to get a configuration value"
+  local DOMAIN="$1" KEY="$2" VALUE="$3"
+  FILEDB_ROOT="$DOKKU_LIB_ROOT/config" filedb unset-value "$DOMAIN" "$KEY"
+}
+
+clear_config_domain() {
+  declare desc="uses filedb to clear a configuration domain"
+  local DOMAIN="$1"
+  FILEDB_ROOT="$DOKKU_LIB_ROOT/config" filedb drop-domain "$DOMAIN"
 }

--- a/plugins/config/install
+++ b/plugins/config/install
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+
+create_filedb_directory() {
+  declare desc="creates the FILEDB_ROOT directory for use with dokku-specific app config variables"
+  local FILEDB_ROOT="$DOKKU_LIB_ROOT/config"
+  mkdir -p "$FILEDB_ROOT"
+  chown dokku:dokku "$FILEDB_ROOT"
+}
+
+migrate_config_vars() {
+  declare desc="migrates deprecated CONFIG variables to centralized counterpart introduced in 0.6.x"
+  local APPS="$(dokku_apps)"
+  local KEYS=(DOKKU_APP_RESTORE DOKKU_CHECKS_ENABLED DOKKU_DISABLE_PROXY DOKKU_DOCKERFILE_CMD DOKKU_DOCKERFILE_ENTRYPOINT DOKKU_DOCKERFILE_PORTS DOKKU_DOCKERFILE_PORTS DOKKU_DOCKERFILE_START_CMD DOKKU_NGINX_PORT DOKKU_NGINX_PORT DOKKU_NGINX_SSL_PORT DOKKU_NGINX_SSL_PORT DOKKU_RM_CONTAINER DOKKU_SKIP_DEPLOY DOKKU_WAIT_TO_RETIRE NO_VHOST)
+  local app key
+
+  dokku_log_info1 "Migrating app-specific dokku config variables"
+
+  for app in $APPS; do
+    local DOMAIN="app.$APP"
+    for key in "${KEYS[@]}"; do
+      local VALUE=$(config_get "$app" "key")
+      if [[ -n "$VALUE" ]]; then
+        set_config_value "$DOMAIN" "$key" "$VALUE"
+        config_unset --no-restart "$app" "$key" &> /dev/null
+      fi
+
+      dokku_log_info2 "Config migration for ${app} complete"
+      dokku_log_info2 ""
+    done
+  done
+}
+
+create_filedb_directory "$@"
+migrate_config_vars "$@"

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -59,8 +59,8 @@ configure_nginx_ports() {
   declare desc="configure nginx listening ports"
   local APP=$1; verify_app_name "$APP"
   local RAW_TCP_PORTS="$(get_app_raw_tcp_ports "$APP")"
-  local DOKKU_NGINX_PORT=$(config_get "$APP" DOKKU_NGINX_PORT)
-  local DOKKU_NGINX_SSL_PORT=$(config_get "$APP" DOKKU_NGINX_SSL_PORT)
+  local DOKKU_NGINX_PORT=$(get_config_value "app.$APP" DOKKU_NGINX_PORT)
+  local DOKKU_NGINX_SSL_PORT=$(get_config_value "app.$APP" DOKKU_NGINX_SSL_PORT)
   local IS_APP_VHOST_ENABLED="$(is_app_vhost_enabled "$APP")"
 
   if [[ -z "$DOKKU_NGINX_PORT" ]]; then
@@ -73,7 +73,7 @@ configure_nginx_ports() {
       fi
     fi
     if [[ -n "$NGINX_PORT" ]]; then
-      config_set --no-restart "$APP" DOKKU_NGINX_PORT="${NGINX_PORT}"
+      set_config_value "app.$APP" DOKKU_NGINX_PORT "${NGINX_PORT}"
     fi
   fi
 
@@ -84,7 +84,7 @@ configure_nginx_ports() {
     else
       local NGINX_SSL_PORT=443
     fi
-    config_set --no-restart "$APP" DOKKU_NGINX_SSL_PORT="${NGINX_SSL_PORT}"
+    set_config_value "app.$APP" DOKKU_NGINX_SSL_PORT "${NGINX_SSL_PORT}"
   fi
 }
 
@@ -131,7 +131,7 @@ nginx_build_config() {
   local NGINX_TEMPLATE_SOURCE="built-in"; local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
   local RAW_TCP_PORTS="$(get_app_raw_tcp_ports "$APP")"
 
-  local DOKKU_DISABLE_PROXY=$(config_get "$APP" DOKKU_DISABLE_PROXY)
+  local DOKKU_DISABLE_PROXY=$(get_config_value "app.$APP" DOKKU_DISABLE_PROXY)
   local IS_APP_VHOST_ENABLED=$(is_app_vhost_enabled "$APP")
 
   if [[ -z "$DOKKU_DISABLE_PROXY" ]]; then
@@ -170,8 +170,8 @@ nginx_build_config() {
 
     # setup nginx listen ports
     configure_nginx_ports "$APP"
-    local NGINX_PORT=$(config_get "$APP" DOKKU_NGINX_PORT)
-    local NGINX_SSL_PORT=$(config_get "$APP" DOKKU_NGINX_SSL_PORT)
+    local NGINX_PORT=$(get_config_value "app.$APP" DOKKU_NGINX_PORT)
+    local NGINX_SSL_PORT=$(get_config_value "app.$APP" DOKKU_NGINX_SSL_PORT)
 
     local NONSSL_VHOSTS=$(get_app_domains "$APP")
     local NOSSL_SERVER_NAME=$(echo "$NONSSL_VHOSTS" | xargs)

--- a/plugins/proxy/functions
+++ b/plugins/proxy/functions
@@ -8,7 +8,7 @@ is_app_proxy_enabled() {
   local APP="$1"; verify_app_name "$APP"
   local APP_PROXY_ENABLED=true
 
-  local DOKKU_DISABLE_PROXY=$(config_get "$APP" DOKKU_DISABLE_PROXY)
+  local DOKKU_DISABLE_PROXY=$(get_config_value "app.$APP" DOKKU_DISABLE_PROXY)
   if [[ -n "$DOKKU_DISABLE_PROXY" ]]; then
     local APP_PROXY_ENABLED=false
   fi

--- a/plugins/proxy/subcommands/disable
+++ b/plugins/proxy/subcommands/disable
@@ -12,9 +12,8 @@ proxy_disable_cmd() {
 
   if [[ "$(is_app_proxy_enabled "$APP")" == "true" ]]; then
     dokku_log_info1 "Disabling proxy for app ($APP)"
-    [[ "$2" == "--no-restart" ]] && local CONFIG_SET_ARGS=$2
     # shellcheck disable=SC2086
-    config_set $CONFIG_SET_ARGS $APP DOKKU_DISABLE_PROXY=1
+    set_config_value "app.$APP" DOKKU_DISABLE_PROXY 1
     plugn trigger proxy-disable "$APP"
   else
     dokku_log_info1 "proxy is already disable for app ($APP)"

--- a/plugins/proxy/subcommands/enable
+++ b/plugins/proxy/subcommands/enable
@@ -12,9 +12,8 @@ proxy_enable_cmd() {
 
   if [[ "$(is_app_proxy_enabled "$APP")" == "false" ]]; then
     dokku_log_info1 "Enabling proxy for app ($APP)"
-    [[ "$2" == "--no-restart" ]] && local CONFIG_SET_ARGS=$2
     # shellcheck disable=SC2086
-    config_unset $CONFIG_SET_ARGS $APP DOKKU_DISABLE_PROXY
+    unset_config_value "app.$APP" DOKKU_DISABLE_PROXY
     plugn trigger proxy-enable "$APP"
   else
     dokku_log_info1 "proxy is already enabled for app ($APP)"

--- a/plugins/ps/post-deploy
+++ b/plugins/ps/post-deploy
@@ -10,7 +10,7 @@ ps_post_deploy() {
   local APP="$1"
 
   remove_procfile "$APP"
-  config_set --no-restart "$APP" DOKKU_APP_RESTORE=1
+  set_config_value "app.$APP" DOKKU_APP_RESTORE 1
 }
 
 ps_post_deploy "$@"

--- a/plugins/ps/post-stop
+++ b/plugins/ps/post-stop
@@ -9,5 +9,5 @@ ps_post_stop() {
   local trigger="ps_post_stop"
   local APP="$1"
 
-  config_set --no-restart "$APP" DOKKU_APP_RESTORE=0
+  set_config_value "app.$APP" DOKKU_APP_RESTORE 0
 }

--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -8,7 +8,7 @@ ps_restore_cmd() {
   declare desc="starts all apps with DOKKU_APP_RESTORE not set to 0 via command line"
   local cmd="ps:restore"
   for app in $(dokku_apps); do
-    local DOKKU_APP_RESTORE=$(config_get "$app" DOKKU_APP_RESTORE || true)
+    local DOKKU_APP_RESTORE=$(get_config_value "app.$APP" DOKKU_APP_RESTORE || true)
     if [[ $DOKKU_APP_RESTORE != 0 ]]; then
       echo "Restoring app $app ..."
       ps_start "$app"

--- a/plugins/tar/subcommands/build-locked
+++ b/plugins/tar/subcommands/build-locked
@@ -27,7 +27,7 @@ tar_build_locked_cmd() {
   tar -x -C "$TAR_BUILD_TMP_WORK_DIR" -f "$DOKKU_ROOT/$APP/src.tar" --strip-components="$BOGUS_PARTS"
   chmod -R u+r "$TAR_BUILD_TMP_WORK_DIR"
 
-  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]]; then
+  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && [[ -z $(config_get "$APP" BUILDPACK_URL || true) ]]; then
     plugn trigger pre-receive-app "$APP" "dockerfile" "$TAR_BUILD_TMP_WORK_DIR"
     dokku receive "$APP" "dockerfile" "$TAR_BUILD_TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
   else

--- a/tests/unit/10_checks.bats
+++ b/tests/unit/10_checks.bats
@@ -25,10 +25,10 @@ teardown() {
   dokku checks:disable $TEST_APP
   assert_success
 
-  run bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_ENABLED"
+  run bash -c "dokku checks $TEST_APP | grep -q false"
   echo "output: "$output
   echo "status: "$status
-  assert_output "0"
+  assert_success
 }
 
 @test "(checks) checks:enable" {
@@ -38,8 +38,8 @@ teardown() {
   dokku checks:enable $TEST_APP
   assert_success
 
-  run bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_ENABLED"
+  run bash -c "dokku checks $TEST_APP | grep -q true"
   echo "output: "$output
   echo "status: "$status
-  assert_output "1"
+  assert_success
 }

--- a/tests/unit/20_nginx-vhosts_1.bats
+++ b/tests/unit/20_nginx-vhosts_1.bats
@@ -21,7 +21,7 @@ teardown() {
   HOSTNAME=$(< "$DOKKU_ROOT/HOSTNAME")
   check_urls http://${HOSTNAME}:[0-9]+
 
-  NGINX_PORT="$(config_get $TEST_APP DOKKU_NGINX_PORT)"
+  NGINX_PORT="$(get_config_value $TEST_APP DOKKU_NGINX_PORT)"
   assert_http_success http://${HOSTNAME}:${NGINX_PORT}
 
   dokku domains:enable $TEST_APP
@@ -59,7 +59,7 @@ teardown() {
   HOSTNAME=$(< "$DOKKU_ROOT/HOSTNAME")
   check_urls http://${HOSTNAME}:[0-9]+
 
-  NGINX_PORT="$(config_get $TEST_APP DOKKU_NGINX_PORT)"
+  NGINX_PORT="$(get_config_value $TEST_APP DOKKU_NGINX_PORT)"
   assert_http_success http://${HOSTNAME}:${NGINX_PORT}
 }
 
@@ -71,7 +71,7 @@ teardown() {
   HOSTNAME=$(< "$DOKKU_ROOT/HOSTNAME")
   check_urls http://${HOSTNAME}:[0-9]+
 
-  NGINX_PORT="$(config_get $TEST_APP DOKKU_NGINX_PORT)"
+  NGINX_PORT="$(get_config_value $TEST_APP DOKKU_NGINX_PORT)"
   assert_http_success http://${HOSTNAME}:${NGINX_PORT}
 }
 


### PR DESCRIPTION
This change allows us to stop polluting the environment
for deployed applications, making configuration setting/unsetting
a simple matter of calling filedb.

This change breaks compatibility with plugins that expected dokku
config to be available via `dokku config:get`, as it will also
silently migrate this configuration.