### PR TITLE
Clarify 0.5.0 migration guide about `EXPOSE`

### DIFF
--- a/docs/appendices/0.5.0-migration-guide.md
+++ b/docs/appendices/0.5.0-migration-guide.md
@@ -17,6 +17,9 @@
 - Replaced "magic" `NO_VHOST` variable with `domains:enable/disable`
 - Simplified zero downtime control
   - `checks:enable/disable`
-## Dockerfile apps with multiple ports
-- Dockerfiles with multiple `EXPOSE` clauses will get all **tcp** ports proxied by default (nginx does not support proxying udp)
-  - UDP can be exposed by disabling the nginx proxy with `dokku proxy:disable myapp`
+
+## Dockerfile apps with exposed ports
+
+- Dockerfiles with `EXPOSE` clauses will get [all **tcp** ports proxied by default](/dokku/deployment/dockerfiles/#exposed-ports)
+  - Note that nginx will proxy the same port numbers to listen publicly
+  - UDP ports can be exposed by disabling the [nginx proxy](/dokku/proxy/) with `dokku proxy:disable myapp`


### PR DESCRIPTION
- Make it clear that there is now a 1:1 port mapping
- Add links to relevant documentation