### PR TITLE
Clarify where to put nginx custom template without `WORKDIR`

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -17,6 +17,7 @@ Dokku uses a templating library by the name of [sigil](https://github.com/glider
 - Copy the following example template to a file named `nginx.conf.sigil` and either:
   - check it into the root of your app repo
   - `ADD` it to your dockerfile `WORKDIR`
+  - if your dockerfile has no `WORKDIR`, `ADD` it to the `/app` folder
 
 ### Example Custom Template
 Use case: add an `X-Served-By` header to requests


### PR DESCRIPTION
Docker assume `/` as [default `WORKDIR`](https://docs.docker.com/engine/reference/run/#workdir), but dokku [looks in the `/app` folder](https://github.com/dokku/dokku/blob/master/plugins/common/functions#L257)

[ci skip]