### PR TITLE
Only strip .git directory from end of url

### DIFF
--- a/plugins/plugin/functions
+++ b/plugins/plugin/functions
@@ -77,5 +77,5 @@ uninstall_plugin() {
 plugin_name() {
   declare desc="default plugin name"
   local PLUGIN_GIT_URL="$1"
-  echo "$PLUGIN_GIT_URL" | awk -F '/' '{ print $NF }' | sed -e "s:.git::g" | sed 's:^dokku-::'
+  echo "$PLUGIN_GIT_URL" | awk -F '/' '{ print $NF }' | sed -e "s:.git$::g" | sed 's:^dokku-::'
 }


### PR DESCRIPTION
If you don't, the following url:

```
https://github.com/crisward/dokku-gitclone.git
```

will result in `dokkuclone` as the directory name under 0.5.x.