### PR TITLE
Fix plugin rename bug

### DIFF
--- a/plugins/plugin/functions
+++ b/plugins/plugin/functions
@@ -77,5 +77,5 @@ uninstall_plugin() {
 plugin_name() {
   declare desc="default plugin name"
   local PLUGIN_GIT_URL="$1"
-  echo "$PLUGIN_GIT_URL" | awk -F '/' '{ print $NF }' | sed -e "s:.git::g" | sed 's:^dokku-::'
+  echo "$PLUGIN_GIT_URL" | awk -F '/' '{ print $NF }' | sed -e "s:\.git::g" | sed 's:^dokku-::'
 }


### PR DESCRIPTION
This seems to fix the bug when plugins with git in their name get changed to dokku