### PR TITLE
Add CI deployment recipe

### DIFF
--- a/docs/deployment/images.md
+++ b/docs/deployment/images.md
@@ -67,7 +67,7 @@ it directly to the host running dokku.
 
 1. Build image on CI (or locally)
 
-```sh
+```shell
 $ docker build -t dokku/test-app:v42
 ```
 
@@ -75,13 +75,13 @@ $ docker build -t dokku/test-app:v42
 
 2. Deploy image to dokku host
 
-```sh
+```shell
 $ docker save dokku/test-app:v42 | ssh my.dokku.host "docker load | dokku tags:deploy test-app v42"
 ```
 
 Here's a more complete example using the above method:
 
-```sh
+```shell
 #!/bin/bash
 
 docker build -t dokku/test-app:v42

--- a/docs/deployment/images.md
+++ b/docs/deployment/images.md
@@ -79,6 +79,9 @@ $ docker build -t dokku/test-app:v42
 $ docker save dokku/test-app:v42 | ssh my.dokku.host "docker load | dokku tags:deploy test-app v42"
 ```
 
+> Note: You can also use a Docker Registry to push and pull the image rather than uploading it
+> directly.
+
 Here's a more complete example using the above method:
 
 ```shell


### PR DESCRIPTION
As requested in #2097, this adds instructions on how to build images on a CI service and have it deployed directly to a host running dokku.