### PR TITLE
add 10.0.0.2 so *.dokku.me works

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,8 @@ dependencies:
   override:
     - ./tests/ci/parallel_runner.sh setup: { timeout: 300 }
     - echo "export DOKKU_SKIP_CLEANUP=true" > /home/dokku/.dokkurc/dokku_skip_cleanup
+    # dokku.me now resolves to 10.0.0.2. add 10.0.0.2/24 to eth0
+    - sudo ip a a 10.0.0.2/24 broadcast 10.0.0.255 dev eth0
   post:
     - sudo -E make -e lint
 test:


### PR DESCRIPTION
Tried playing with `dnsmasq` but Circle uses it already in it's container env. So this is a lightweight way to short circuit `10.0.0.2` back to the test container.