### PR TITLE
test detached container is running

### DIFF
--- a/tests/unit/30_core_1.bats
+++ b/tests/unit/30_core_1.bats
@@ -115,11 +115,11 @@ build_nginx_config() {
 @test "(core) run (detached)" {
   deploy_app
 
-  RANDOM_RUN_CID="$(dokku --detach run $TEST_APP bash)"
-  run bash -c "docker inspect $RANDOM_RUN_CID"
+  RANDOM_RUN_CID="$(dokku --detach run $TEST_APP sleep 300)"
+  run bash -c "docker inspect -f '{{ .State.Status }}' $RANDOM_RUN_CID"
   echo "output: "$output
   echo "status: "$status
-  assert_success
+  assert_output "running"
 
   run bash -c "docker stop $RANDOM_RUN_CID"
   echo "output: "$output


### PR DESCRIPTION
`docker stop` exits `0` even if the container is stopped/exited. Test that our detached container stays up. 
```
root@dokku:~/dokku# docker ps -a | grep serene_boyd
ef08e96f02b4        gliderlabs/herokuish:latest   "bash"              49 minutes ago      Exited (0) 42 minutes ago                       serene_boyd
root@dokku:~/dokku# docker stop serene_boyd ; echo $?
serene_boyd
0
```