### PR TITLE
Dont fail when adding a duplicated domain

### DIFF
--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -66,15 +66,13 @@ domains_add() {
   verify_app_name "$1"
   local APP="$1"; local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
 
-  if [[ $(egrep -w "^${2}$" "$APP_VHOST_PATH" > /dev/null 2>&1; echo $?) -eq 0 ]]; then
-    dokku_log_fail "$2 is already defined for $APP"
-    exit 1
-  fi
-  shift 1
-
   for DOMAIN in "$@"; do
-    echo "$DOMAIN" >> "$APP_VHOST_PATH"
-    dokku_log_info1 "Added $DOMAIN to $APP"
+    if [[ $(egrep -w "^$DOMAIN$" "$APP_VHOST_PATH" > /dev/null 2>&1; echo $?) -eq 0 ]]; then
+      dokku_log_info1 "Skipping: $DOMAIN already added to $APP"
+    else
+      echo "$DOMAIN" >> "$APP_VHOST_PATH"
+      dokku_log_info1 "Added $DOMAIN to $APP"
+    fi
   done
 
   if [[ "$(is_app_vhost_enabled "$APP")" == "false" ]];then

--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -66,6 +66,8 @@ domains_add() {
   verify_app_name "$1"
   local APP="$1"; local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
 
+  shift 1
+
   for DOMAIN in "$@"; do
     if [[ $(egrep -w "^$DOMAIN$" "$APP_VHOST_PATH" > /dev/null 2>&1; echo $?) -eq 0 ]]; then
       dokku_log_info1 "Skipping: $DOMAIN already added to $APP"

--- a/tests/unit/20_domains.bats
+++ b/tests/unit/20_domains.bats
@@ -49,7 +49,7 @@ teardown() {
   run dokku domains:add $TEST_APP test.app.dokku.me
   echo "output: "$output
   echo "status: "$status
-  assert_failure
+  assert_success
 }
 
 @test "(domains) domains:remove" {


### PR DESCRIPTION
Currently we exit when trying to add a duplicated domain, even if we give a list
of domain names. This behaviour is not as it suppose to work.

**Expected behaviour**
When adding a domain, and the domain already exists, just skip that domain, and
continue with the world. This is no problem since we are already in the state we
want to be in.

**New behaviour**
When you try to add a domain that is already added, we notify the user of this
by showing a log message: `Skipping: example.com already added to example app`,
and then we continue with the list of domain names.

Fixes #2165