### PR TITLE
allow all apps to be restored on boot

### DIFF
--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -91,12 +91,14 @@ ps_start() {
   local APP="$1"; verify_app_name "$APP"
   local IMAGE_TAG=$(get_running_image_tag "$APP");
 
-  ! (is_deployed "$APP") && echo "App $APP has not been deployed" && exit 0
-
-  if ! (is_app_running "$APP"); then
-    release_and_deploy "$APP" "$IMAGE_TAG"
+  if (is_deployed "$APP"); then
+    if ! (is_app_running "$APP"); then
+      release_and_deploy "$APP" "$IMAGE_TAG"
+    else
+      echo "App $APP already running"
+    fi
   else
-    echo "App $APP already running"
+    echo "App $APP has not been deployed"
   fi
 }
 


### PR DESCRIPTION
When rebooting a Dokku host the init process tries to restore all apps
using `dokku ps:restore`, alphabetically. If an app is defined but not
deployed, the function `ps_start` called by `dokku ps:restore` will
exit 0 and stop trying to restore the other apps later in the alphabet.
This change fixes the restore behaviour.