### PR TITLE
show available types and ids on dokku enter error

### DIFF
--- a/docs/deployment/one-off-processes.md
+++ b/docs/deployment/one-off-processes.md
@@ -68,6 +68,8 @@ dokku enter node-js-app web.1
 dokku enter node-js-app --container-id ID
 ```
 
+Additionally, you can run `enter` with no container-type. If only a single container-type is defined in your app, you will be dropped into the only running container. This behavior is not supported when specifying a custom command; as described below.
+
 By default, it runs a `/bin/bash`, but can also be used to run a custom command:
 
 ```shell

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -311,6 +311,22 @@ get_app_running_container_ids() {
   echo "$APP_RUNNING_CONTAINER_IDS"
 }
 
+get_app_running_container_types() {
+  declare desc="return list of running container types for given app"
+  local APP=$1 CONTAINER_TYPES
+  verify_app_name "$APP"
+
+  ! (is_deployed "$APP") && dokku_log_fail "App $APP has not been deployed"
+
+  CONTAINER_TYPES="$(find "$DOKKU_ROOT/$APP" -maxdepth 1 -name "CONTAINER.*" -print0 | xargs -0)"
+  if [[ -n "$CONTAINER_TYPES" ]]; then
+    CONTAINER_TYPES="${CONTAINER_TYPES//$DOKKU_ROOT\/$APP\//}"
+    CONTAINER_TYPES="$(tr " " $'\n' <<< "$CONTAINER_TYPES" | awk -F. '{ print $2 }' | xargs)"
+  fi
+
+  echo "$CONTAINER_TYPES"
+}
+
 get_cmd_from_procfile() {
   declare desc="parse cmd from app Procfile"
   local APP=$1; local PROC_TYPE=$2; local DOKKU_PROCFILE="$DOKKU_ROOT/$APP/DOKKU_PROCFILE"

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -321,7 +321,7 @@ get_app_running_container_types() {
   CONTAINER_TYPES="$(find "$DOKKU_ROOT/$APP" -maxdepth 1 -name "CONTAINER.*" -print0 | xargs -0)"
   if [[ -n "$CONTAINER_TYPES" ]]; then
     CONTAINER_TYPES="${CONTAINER_TYPES//$DOKKU_ROOT\/$APP\//}"
-    CONTAINER_TYPES="$(tr " " $'\n' <<< "$CONTAINER_TYPES" | awk -F. '{ print $2 }' | xargs)"
+    CONTAINER_TYPES="$(tr " " $'\n' <<< "$CONTAINER_TYPES" | awk -F. '{ print $2 }' | sort | uniq | xargs)"
   fi
 
   echo "$CONTAINER_TYPES"

--- a/plugins/enter/subcommands/default
+++ b/plugins/enter/subcommands/default
@@ -7,13 +7,14 @@ enter_default_cmd() {
   local cmd="enter"
   local APP="$2"; local CONTAINER_TYPE="$3"; local IMAGE_TAG=$(get_running_image_tag "$APP"); local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
   verify_app_name "$APP"
+  local AVAILABLE_CONTAINER_TYPES="$(get_app_running_container_types "$APP")"
 
-  [[ ! -n "$3" ]] && dokku_log_fail "No container id specified"
+  [[ ! -n "$3" ]] && dokku_log_warn "No container type specified." && dokku_log_fail "Available types for app ($APP): $AVAILABLE_CONTAINER_TYPES"
 
   if [[ "$3" == "--container-id" ]]; then
-    [[ ! -n "$4" ]] && dokku_log_fail "No container id specified"
-
     local DOKKU_APP_CIDS=( $(get_app_container_ids "$APP") )
+    [[ ! -n "$4" ]] && dokku_log_warn "No container id specified." && dokku_log_fail "Available ids for app ($APP): ${DOKKU_APP_CIDS[@]}"
+
     printf -- '%s\n' "${DOKKU_APP_CIDS[@]}" | grep -q -e "^$4" || dokku_log_fail "Invalid container id for app"
     local ID=$(printf -- '%s\n' "${DOKKU_APP_CIDS[@]}" | grep -e "^$4")
     shift 4

--- a/plugins/enter/subcommands/default
+++ b/plugins/enter/subcommands/default
@@ -7,26 +7,45 @@ enter_default_cmd() {
   local cmd="enter"
   local APP="$2"; local CONTAINER_TYPE="$3"; local IMAGE_TAG=$(get_running_image_tag "$APP"); local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
   verify_app_name "$APP"
-  local AVAILABLE_CONTAINER_TYPES="$(get_app_running_container_types "$APP")"
+  local AVAILABLE_CONTAINER_TYPES=($(get_app_running_container_types "$APP"))
 
-  [[ ! -n "$3" ]] && dokku_log_warn "No container type specified." && dokku_log_fail "Available types for app ($APP): $AVAILABLE_CONTAINER_TYPES"
+  if [[ -z "$3" ]]; then
+    if [[ ${#AVAILABLE_CONTAINER_TYPES[@]} -gt 1 ]]; then
+      dokku_log_warn "No container type specified."
+      dokku_log_fail "Available types for app ($APP): ${AVAILABLE_CONTAINER_TYPES[@]}"
+    else
+      CONTAINER_TYPE="${AVAILABLE_CONTAINER_TYPES[0]}"
+    fi
+  fi
 
   if [[ "$3" == "--container-id" ]]; then
     local DOKKU_APP_CIDS=( $(get_app_container_ids "$APP") )
-    [[ ! -n "$4" ]] && dokku_log_warn "No container id specified." && dokku_log_fail "Available ids for app ($APP): ${DOKKU_APP_CIDS[@]}"
-
-    printf -- '%s\n' "${DOKKU_APP_CIDS[@]}" | grep -q -e "^$4" || dokku_log_fail "Invalid container id for app"
+    if [[ ! -n "$4" ]]; then
+      dokku_log_warn "No container id specified."
+      dokku_log_fail "Available ids for app ($APP): ${DOKKU_APP_CIDS[@]}"
+    fi
+    if ! (printf -- '%s\n' "${DOKKU_APP_CIDS[@]}" | grep -q -e "^$4"); then
+      dokku_log_warn "Invalid container id for app"
+      dokku_log_fail "Available ids for app ($APP): ${DOKKU_APP_CIDS[@]}"
+    fi
     local ID=$(printf -- '%s\n' "${DOKKU_APP_CIDS[@]}" | grep -e "^$4")
     shift 4
   else
     local DOKKU_APP_CIDS=( $(get_app_container_ids "$APP" "$CONTAINER_TYPE") )
     local ID=${DOKKU_APP_CIDS[0]}
-    [[ ! -n $ID ]] && dokku_log_fail "No containers found for type '$CONTAINER_TYPE'"
-    shift 3
+    if [[ ! -n $ID ]]; then
+      dokku_log_warn "No containers found for type '$CONTAINER_TYPE'"
+      dokku_log_fail "Available types for app ($APP): ${AVAILABLE_CONTAINER_TYPES[@]}"
+    fi
+    if [[ $3 ]]; then
+      shift 3
+    else
+      shift 2
+    fi
   fi
 
-  docker ps -aq --no-trunc | grep -e "^$ID" > /dev/null || dokku_log_fail "Container does not exist"
-  docker ps -q --no-trunc | grep -e "^$ID" > /dev/null || dokku_log_fail "Container is not running"
+  docker inspect "$ID" &> /dev/null || dokku_log_fail "Container does not exist"
+  docker inspect -f '{{ .State.Running }}' "$ID" | grep -q "true" > /dev/null || dokku_log_fail "Container is not running"
 
   local EXEC_CMD=""
   has_tty && local DOKKU_RUN_OPTS+=" -i -t"

--- a/tests/unit/20_docker-options.bats
+++ b/tests/unit/20_docker-options.bats
@@ -150,10 +150,10 @@ teardown() {
   deploy_app
 
   CID=$(< $DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
-  run /bin/bash -c "docker inspect -f '{{ .Config.Volumes }}' $CID"
+  run /bin/bash -c "docker inspect -f '{{ .Config.Volumes }}' $CID | sed -e 's:map::g' | tr -d '[]' | tr ' ' $'\n' | sort | xargs"
   echo "output: "$output
   echo "status: "$status
-  assert_output "map[/tmp:{} /var/tmp:{}]"
+  assert_output "/tmp:{} /var/tmp:{}"
 }
 
 @test "(docker-options) docker-options:add (all phases over SSH)" {


### PR DESCRIPTION
- [x] show available process-types or container-ids
- [x] auto-populate if only one process-type or container
- [x] update docs

example output:
```
$ dokku enter node-js-app
 !     No container type specified.
Available types for app (node-js-app): web worker
$ dokku enter node-js-app --container-id
 !     No container id specified.
Available ids for app (node-js-app): 95d5b4daf6e9fa0db9358588ad84f004ca6fcc828d1d7d0f75320de117fb1818 d1900a88847773250de2f00d33a4b265beb953c4a2b26c2b59c0893879422d50
```

closes #2174