### PR TITLE
Fix removal of domains with schema

### DIFF
--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -92,7 +92,7 @@ domains_remove() {
   shift 1
 
   for DOMAIN in "$@"; do
-    sed -i "/^$DOMAIN$/d" "$DOKKU_ROOT/$APP/VHOST"
+    sed -i "\|^$DOMAIN\$|d" "$DOKKU_ROOT/$APP/VHOST"
     dokku_log_info1 "Removed $DOMAIN from $APP"
   done
   plugn trigger post-domains-update "$APP" "remove" "$@"


### PR DESCRIPTION
In at least one case a customer of ours added a domain including
a schema, as in “http://domain.tld/”. That is obviously incorrect, but
then they couldn't remove it using the dokku command:

    $ dokku domains:remove app7 http://domain.tld/
    sed: -e expression #1, char 9: unknown command: `/'

This patch changes the sed command to use the "\CregexpC" syntax. The
character used is a vertical pipe, which is far less likely to be used
in a URL. After the change:

    $ dokku domains:remove app7 http://domain.tld/
    -----> Removed http://domain.tld/ from app7
