### PR TITLE
reject invalid domains in domains:add

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -753,6 +753,16 @@ strip_inline_comments() {
   echo "$stripped_line"
 }
 
+is_valid_hostname() {
+  declare desc="return 0 if argument is a valid hostname; else return 1"
+  local hostname_string="$1"; local hostname_regex='^(([a-zA-Z\*](-?[a-zA-Z0-9])*)\.)*[a-zA-Z\*](-?[a-zA-Z0-9])+\.[a-zA-Z]{2,}$'
+  if [[ $hostname_string =~ $hostname_regex ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 is_val_in_list() {
   declare desc="return true if value ($1) is in list ($2) separated by delimiter ($3); delimiter defaults to comma"
   local value="$1" list="$2" delimiter="${3:-,}"

--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -67,6 +67,11 @@ domains_add() {
   local APP="$1"; local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
 
   shift 1
+  for DOMAIN in "$@"; do
+    if ! (is_valid_hostname "$DOMAIN"); then
+      dokku_log_fail "$DOMAIN is invalid. exiting..."
+    fi
+  done
 
   for DOMAIN in "$@"; do
     if [[ $(egrep -w "^$DOMAIN$" "$APP_VHOST_PATH" > /dev/null 2>&1; echo $?) -eq 0 ]]; then

--- a/tests/unit/20_domains.bats
+++ b/tests/unit/20_domains.bats
@@ -52,6 +52,13 @@ teardown() {
   assert_success
 }
 
+@test "(domains) domains:add (invalid)" {
+  run dokku domains:add $TEST_APP http://test.app.dokku.me
+  echo "output: "$output
+  echo "status: "$status
+  assert_failure
+}
+
 @test "(domains) domains:remove" {
   run dokku domains:add $TEST_APP test.app.dokku.me
   echo "output: "$output


### PR DESCRIPTION
accepts valid domains and wildcard domains. wildcard domains are accepted by the nginx `server_name` directive.

output:
```
$ dokku domains:add node-js-app https://node-js-app3.dokku.me
https://node-js-app3.dokku.me is invalid. exiting...
```

closes #2231