### PR TITLE
mount storage mounts on build and filter for dockerfile apps

### DIFF
--- a/plugins/00_dokku-standard/subcommands/build
+++ b/plugins/00_dokku-standard/subcommands/build
@@ -47,6 +47,9 @@ dokku_build_cmd() {
 
       [[ "$DOKKU_DOCKERFILE_CACHE_BUILD" == "false" ]] && DOKKU_DOCKER_BUILD_OPTS="$DOKKU_DOCKER_BUILD_OPTS --no-cache"
       local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$IMAGE_SOURCE_TYPE")
+      # strip --volume and -v args from DOCKER_ARGS
+      local DOCKER_ARGS=$(sed -e "s/--volume=[[:graph:]]\+[[:blank:]]\?//g" -e "s/-v[[:blank:]]\?[[:graph:]]\+[[:blank:]]\?//g" <<< "$DOCKER_ARGS")
+
       # shellcheck disable=SC2086
       docker build $DOCKER_ARGS $DOKKU_DOCKER_BUILD_OPTS -t $IMAGE .
 

--- a/plugins/storage/subcommands/mount
+++ b/plugins/storage/subcommands/mount
@@ -7,7 +7,7 @@ source "$PLUGIN_CORE_AVAILABLE_PATH/docker-options/functions"
 storage_mount_cmd() {
   declare desc="Add bind-mount, redeploy app if running"
   local cmd="storage:mount"
-  local passed_phases=(deploy run)
+  local passed_phases=(build deploy run)
   [[ -z $3 || $4 ]] && dokku_log_fail "storage:mount requires an app and a two paths divided by colon."
   verify_app_name "$2" && local APP="$2"
   verify_paths "$3" && local MOUNT_PATH="$3"

--- a/plugins/storage/subcommands/unmount
+++ b/plugins/storage/subcommands/unmount
@@ -7,7 +7,7 @@ source "$PLUGIN_CORE_AVAILABLE_PATH/docker-options/functions"
 storage_unmount_cmd() {
   declare desc="Remove bind-mount, restart app if running"
   local cmd="storage:unmount"
-  local passed_phases=(deploy run)
+  local passed_phases=(build deploy run)
   [[ -z $3 || $4 ]] && dokku_log_fail "storage:unmount requires an app and a two paths divided by colon."
   verify_app_name "$2" && local APP="$2"
   verify_paths "$3" && local MOUNT_PATH="$3"

--- a/tests/unit/20_storage.bats
+++ b/tests/unit/20_storage.bats
@@ -38,3 +38,18 @@ teardown() {
   assert_output "Mount path does not exist."
   assert_failure
 }
+
+@test "(storage) storage:mount (dockerfile)" {
+  run /bin/bash -c "dokku storage:mount $TEST_APP /tmp/mount:/mount"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  deploy_app dockerfile
+
+  CID=$(< $DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
+  run /bin/bash -c "docker inspect -f '{{ .HostConfig.Binds }}' $CID"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "[/tmp/mount:/mount]"
+}


### PR DESCRIPTION
Some buildpacks offer their own pre/post hooks. A user may want to do something with a configured storage mount during the build phase. This PR allows storage mounts in the build phase for buildpack apps but filters those docker_args for dockerfile apps.

works for the python example in the originating issue
```
$ dokku apps:create python-test
Creating python-test... done
$ dokku storage:mount python-test /tmp/python-test:/opt/test
$ cat bin/post_compile
#!/usr/bin/env bash
date >> /opt/test/datetime.lst

$ git push dokku@dokku.me:python-test master
Pseudo-terminal will not be allocated because stdin is not a terminal.
Counting objects: 12, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (8/8), done.
Writing objects: 100% (12/12), 1.02 KiB | 0 bytes/s, done.
Total 12 (delta 1), reused 0 (delta 0)
-----> Cleaning up...
-----> Building python-test from herokuish...
-----> Adding BUILD_ENV to build environment...
-----> Python app detected
-----> Installing python-2.7.11
       $ pip install -r requirements.txt
       Collecting Flask==0.9 (from -r requirements.txt (line 1))
       Downloading Flask-0.9.tar.gz (481kB)
       Collecting Jinja2==2.6 (from -r requirements.txt (line 2))
       Downloading Jinja2-2.6.tar.gz (389kB)
       Collecting Werkzeug==0.8.3 (from -r requirements.txt (line 3))
       Downloading Werkzeug-0.8.3.tar.gz (1.1MB)
       Collecting gunicorn==0.17.2 (from -r requirements.txt (line 4))
       Downloading gunicorn-0.17.2.tar.gz (360kB)
       Installing collected packages: Werkzeug, Jinja2, Flask, gunicorn
       Running setup.py install for Werkzeug: started
       Running setup.py install for Werkzeug: finished with status 'done'
       Running setup.py install for Jinja2: started
       Running setup.py install for Jinja2: finished with status 'done'
       Running setup.py install for Flask: started
       Running setup.py install for Flask: finished with status 'done'
       Running setup.py install for gunicorn: started
       Running setup.py install for gunicorn: finished with status 'done'
       Successfully installed Flask-0.9 Jinja2-2.6 Werkzeug-0.8.3 gunicorn-0.17.2

-----> Running post-compile hook
---
       config_vars:

-----> Discovering process types
       Procfile declares types -> web
-----> Releasing python-test (dokku/python-test:latest)...
-----> Deploying python-test (dokku/python-test:latest)...
-----> Attempting to run scripts.dokku.predeploy from app.json (if defined)
-----> App Procfile file found (/home/dokku/python-test/DOKKU_PROCFILE)
-----> DOKKU_SCALE file not found in app image. Generating one based on Procfile...
-----> New DOKKU_SCALE file generated
=====> web=1
-----> Running pre-flight checks
-----> Attempt 1/5 Waiting for 5 seconds ...
       CHECKS expected result:
       http://localhost/ => "python/flask"
-----> All checks successful!
=====> python-test web container output:
       2016-06-10 20:53:49 [11] [INFO] Starting gunicorn 0.17.2
       2016-06-10 20:53:49 [11] [INFO] Listening at: http://0.0.0.0:5000 (11)
       2016-06-10 20:53:49 [11] [INFO] Using worker: sync
       2016-06-10 20:53:49 [146] [INFO] Booting worker with pid: 146
=====> end python-test web container output
-----> Running post-deploy
-----> Attempting to run scripts.dokku.postdeploy from app.json (if defined)
=====> renaming container (9795e2de49cd) tender_booth to python-test.web.1
-----> Creating new /home/dokku/python-test/VHOST...
-----> Setting config vars
       DOKKU_NGINX_PORT: 80
-----> Configuring python-test.dokku.me...(using built-in template)
-----> Creating http nginx.conf
-----> Running nginx-pre-reload
       Reloading nginx
-----> Setting config vars
       DOKKU_APP_RESTORE: 1
=====> Application deployed:
       http://python-test.dokku.me

To dokku@dokku.me:python-test
 * [new branch]      master -> master
$ cat /tmp/python-test/datetime.lst
Fri Jun 10 20:53:30 UTC 2016
```

closes #2207