### PR TITLE
Add InfluxDB to plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -158,9 +158,10 @@ Note: The following plugins have been supplied by our community and may not have
 
 | Plugin                                                                                            | Author                | Compatibility         |
 | ------------------------------------------------------------------------------------------------- | --------------------- | --------------------- |
-| [etcd](https://github.com/basgys/dokku-etcd)                                                      | [basgys][]            | 0.4.x                  |
-| [RethinkDB](https://github.com/stuartpb/dokku-rethinkdb-plugin)                                   | [stuartpb][]          | 0.3.x                  |
-| [FakeSNS](https://github.com/cu12/dokku-fake_sns)                                                 | [cu12][]              | 0.5.0+                 |
+| [etcd](https://github.com/basgys/dokku-etcd)                                                      | [basgys][]            | 0.4.x                 |
+| [FakeSNS](https://github.com/cu12/dokku-fake_sns)                                                 | [cu12][]              | 0.5.0+                |
+| [InfluxDB](https://github.com/basgys/dokku-influxdb)                                              | [basgys][]            | 0.4.x                 |
+| [RethinkDB](https://github.com/stuartpb/dokku-rethinkdb-plugin)                                   | [stuartpb][]          | 0.3.x                 |
 
 [dccee02]: https://github.com/jeffutter/dokku-riakcs-plugin/commit/dccee02702e7001851917b7814e78a99148fb709
 


### PR DESCRIPTION
Here is a dokku plugin for InfluxDB. It is not production ready yet.