### PR TITLE
fix missing $ sign in default nginx template

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -49,7 +49,7 @@ server {
   ssl_certificate_key {{ $.APP_SSL_PATH }}/server.key;
 
   keepalive_timeout   70;
-  {{ if eq $.SPDY_SUPPORTED "true" }}add_header          Alternate-Protocol  {{ .NGINX_SSL_PORT }}:npn-spdy/2;{{ end }}
+  {{ if eq $.SPDY_SUPPORTED "true" }}add_header          Alternate-Protocol  {{ $.NGINX_SSL_PORT }}:npn-spdy/2;{{ end }}
 
   location    / {
 


### PR DESCRIPTION
missed the `$`