### PR TITLE
Don't run DeleteInstallerThread() until after set_debconf_selection

### DIFF
--- a/contrib/dokku-installer.py
+++ b/contrib/dokku-installer.py
@@ -107,13 +107,13 @@ class GetHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             proc.stdin.close()
             proc.wait()
 
-        if 'selfdestruct' in sys.argv:
-            DeleteInstallerThread()
-
         set_debconf_selection('boolean', 'skip_key_file', 'true')
         set_debconf_selection('boolean', 'vhost_enable', vhost_enable)
         set_debconf_selection('boolean', 'web_config', 'false')
         set_debconf_selection('string', 'hostname', params['hostname'].value)
+
+        if 'selfdestruct' in sys.argv:
+            DeleteInstallerThread()
 
         self.send_response(200)
         self.end_headers()


### PR DESCRIPTION
There seems to be a bit of a race condition here. Using the installer on 0.6.1, I continually get "Something went wrong." The browser's console shows:

> ﻿jquery.min.js:6 POST http://example.com/setup net::ERR_CONNECTION_REFUSED

The installer itself, fails on posting the response:

```
Exception happened during processing of request from ('127.0.0.1', 51870)
Traceback (most recent call last):
  File "/usr/lib/python2.7/SocketServer.py", line 295, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 321, in process_request
    self.finish_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.7/SocketServer.py", line 651, in __init__
    self.finish()
  File "/usr/lib/python2.7/SocketServer.py", line 710, in finish
    self.wfile.close()
  File "/usr/lib/python2.7/socket.py", line 279, in close
    self.flush()
  File "/usr/lib/python2.7/socket.py", line 303, in flush
    self._sock.sendall(view[write_offset:write_offset+buffer_size])
error: [Errno 32] Broken pipe
----------------------------------------
```

Moving the call to DeleteInstallerThread() after the new  set_debconf_selection calls resolves the problem for me.