### PR TITLE
Add ability to remove a specific port mapping tuple

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -12,7 +12,7 @@ proxy:enable <app>                                                              
 proxy:ports <app>                                                                                        List proxy port mappings for app
 proxy:ports-add <app> <scheme>:<host-port>:<container-port> [<scheme>:<host-port>:<container-port>...]   Set proxy port mappings for app
 proxy:ports-clear <app>                                                                                  Clear all proxy port mappings for app
-proxy:ports-remove <app> <host-port> [<host-port>...]                                                    Unset proxy port mappings for app
+proxy:ports-remove <app> <host-port> [<host-port>|<scheme>:<host-port>:<container-port>...]              Unset proxy port mappings for app
 proxy:set <app> <proxy-type>                                                                             Set proxy type for app
 ```
 

--- a/plugins/proxy/commands
+++ b/plugins/proxy/commands
@@ -13,7 +13,7 @@ case "$1" in
     proxy:ports <app>, List proxy port mappings for app
     proxy:ports-clear <app>, Clear all proxy port mappings for app
     proxy:ports-add <app> <scheme>:<host-port>:<container-port> [<scheme>:<host-port>:<container-port>...], Set proxy port mappings for app
-    proxy:ports-remove <app> <host-port> [<host-port>...], Unset proxy port mappings for app
+    proxy:ports-remove <app> <host-port> [<host-port>|<scheme>:<host-port>:<container-port>...], Unset proxy port mappings for app
     proxy:set <app> <proxy-type>, Set proxy type for app
 help_content
     }

--- a/plugins/proxy/subcommands/ports-remove
+++ b/plugins/proxy/subcommands/ports-remove
@@ -9,13 +9,19 @@ proxy_ports_remove_cmd() {
   local cmd="proxy:ports-remove"
   local APP="$2"; verify_app_name "$APP"
   local PROXY_PORT_MAP="$(config_get "$APP" DOKKU_PROXY_PORT_MAP || true)"
+  local RE_PORT='^[0-9]+$'
   shift 2
 
   local INPUT_PORTS="$*"
   if [[ -n "$INPUT_PORTS" ]]; then
     local port
+    PROXY_PORT_MAP=" $PROXY_PORT_MAP "
     for port in $INPUT_PORTS; do
-      PROXY_PORT_MAP="$(sed -r "s/[[:alnum:]]+:$port:[[:alnum:]]+//g" <<< "$PROXY_PORT_MAP")"
+      if [[ "$port" =~ $RE_PORT ]]; then
+        PROXY_PORT_MAP="$(sed -r "s/[[:alnum:]]+:$port:[[:alnum:]]+//g" <<< "$PROXY_PORT_MAP")"
+      else
+        PROXY_PORT_MAP="$(sed -r "s/ $port / /g" <<< "$PROXY_PORT_MAP")"
+      fi
     done
     PROXY_PORT_MAP="$(echo "$PROXY_PORT_MAP" | xargs)"
     PROXY_PORT_MAP="$(merge_dedupe_list "$PROXY_PORT_MAP" " ")"

--- a/tests/unit/40_proxy.bats
+++ b/tests/unit/40_proxy.bats
@@ -64,7 +64,7 @@ assert_external_port() {
 }
 
 @test "(proxy) proxy:ports (list/add/remove/clear)" {
-  run dokku proxy:ports-add $TEST_APP http:8080:5000 https:8443:5000
+  run dokku proxy:ports-add $TEST_APP http:8080:5000 https:8443:5000 http:1234:5001
   echo "output: "$output
   echo "status: "$status
   assert_success
@@ -72,9 +72,19 @@ assert_external_port() {
   run /bin/bash -c "dokku --quiet proxy:ports $TEST_APP | xargs"
   echo "output: "$output
   echo "status: "$status
-  assert_output "http 8080 5000 https 8443 5000"
+  assert_output "http 1234 5001 http 8080 5000 https 8443 5000"
 
   run /bin/bash -c "dokku proxy:ports-remove $TEST_APP 8080"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run /bin/bash -c "dokku --quiet proxy:ports $TEST_APP | xargs"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "http 1234 5001 https 8443 5000"
+
+  run /bin/bash -c "dokku proxy:ports-remove $TEST_APP http:1234:5001"
   echo "output: "$output
   echo "status: "$status
   assert_success


### PR DESCRIPTION
This allows users to specify port 80 after an application has had domain added. Normally, when we first add an extra domain, the following tuple is added:

    http:80:5000

A user might then want to remap port 80 to another port, such as port 8080:

    dokku proxy:ports-add APP http:80:8080

The application would then have the following proxy map:

    http:80:5000 http:80:8080

As nginx vhosts are resolved in FIFO order, the "correct" upstream of 8080 would basically be ignored. The workaround would be to remove the original port mapping, but the following:

    dokku proxy:ports-remove APP 80

Would remove *both* entries and then re-add the default of `http:80:5000`. Thus it was not possible to use the porcelain to correct the port mapping and a user would have to fall back to using the following hack to fix their mapping:

    dokku config:set APP DOKKU_PROXY_PORT_MAP='http:80:8080'

You can now use the previous syntax *as well as* the following to remove a port mapping:

    dokku proxy:ports-remove APP http:80:5000