### PR TITLE
Drop apparmor requirement to support systemd systems

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 Architecture: amd64
 Depends: locales, git, make, curl, gcc, man-db, sshcommand, gliderlabs-sigil, docker-engine-cs (>= 1.9.1) | docker-engine (>= 1.9.1), software-properties-common, python-software-properties
 Recommends: herokuish
-Pre-Depends: nginx, dnsutils, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo, python2.7, debconf
+Pre-Depends: nginx, dnsutils, cgroupfs-mount | cgroup-lite, plugn, sudo, python2.7, debconf
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 Description: Docker-powered PaaS that helps build and manage the lifecycle of applications
  Dokku is an extensible, open source Platform as a Service


### PR DESCRIPTION
On Debian Jessie, apparmor conflicts with systemd. As we only required it for lxc-docker, dropping the requirement is the best course of action.