### PR TITLE
Use Markdown for sponsors page, so it's clickable from GitHub

### DIFF
--- a/SPONSORS
+++ b/SPONSORS
@@ -1,2 +1,0 @@
-Deis	       http://deis.io
-DigitalOcean https://www.digitalocean.com/

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,2 +1,3 @@
 [Deis](http://deis.io)
+
 [DigitalOcean](https://www.digitalocean.com/)

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,2 @@
+[Deis](http://deis.io)
+[DigitalOcean](https://www.digitalocean.com/)


### PR DESCRIPTION
I got as far as the sponsors page, but couldn't click Deis to get to their site. Other docs (README, etc) are already using Markdown, so this changes SPONSORS to do so.

AFAIK, satisfies https://github.com/dokku/dokku/blob/master/CONTRIBUTING.md#submitting-changes and the rest of that doc.