### PR TITLE
only attempt to stop a checks-disabled container if it is actually running

### DIFF
--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -58,7 +58,7 @@ checks_check_deploy() {
   eval "$(config_export global)"
   eval "$(config_export app "$APP")"
 
-  if [[ "$(is_app_proctype_checks_skipped "$APP" "$PROC_TYPE")" == "true" ]]; then
+  if [[ "$(is_app_proctype_checks_skipped "$APP" "$DOKKU_APP_CONTAINER_TYPE")" == "true" ]]; then
     dokku_log_info2_quiet "Zero downtime checks for app ($APP) have been skipped. moving on..."
     exit 0
   fi

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -288,7 +288,7 @@ copy_from_image() {
 }
 
 get_app_container_ids() {
-  declare desc="returns list of docker container ids for given app/container_type"
+  declare desc="returns list of docker container ids for given app and optional container_type"
   local APP="$1"; local CONTAINER_TYPE="$2"
   verify_app_name "$APP"
   [[ -f $DOKKU_ROOT/$APP/CONTAINER ]] && DOKKU_CIDS+=$(< "$DOKKU_ROOT/$APP/CONTAINER")
@@ -315,15 +315,15 @@ get_app_container_ids() {
 }
 
 get_app_running_container_ids() {
-  declare desc="return list of running docker container ids for given apps"
-  local APP=$1
+  declare desc="return list of running docker container ids for given app and optional container_type"
+  local APP="$1" CONTAINER_TYPE="$2"
   verify_app_name "$APP"
 
   ! (is_deployed "$APP") && dokku_log_fail "App $APP has not been deployed"
-  local CIDS=$(get_app_container_ids "$APP")
+  local CIDS=$(get_app_container_ids "$APP" "$CONTAINER_TYPE")
 
   for CID in $CIDS; do
-    local APP_CONTAINER_STATUS=$(docker inspect -f '{{.State.Running}}' "$CID" || true)
+    local APP_CONTAINER_STATUS=$(docker inspect -f '{{.State.Running}}' "$CID" 2>/dev/null || true)
     [[ "$APP_CONTAINER_STATUS" == "true" ]] && local APP_RUNNING_CONTAINER_IDS+="$CID "
   done
 
@@ -540,7 +540,7 @@ dokku_deploy_cmd() {
 
     if [[ "$(is_app_proctype_checks_disabled "$APP" "$PROC_TYPE")" == "true" ]]; then
       dokku_log_info1 "zero downtime is disabled for app ($APP.$PROC_TYPE). stopping currently running containers"
-      local cid proctype_oldids="$(get_app_container_ids "$APP" "$PROC_TYPE")"
+      local cid proctype_oldids="$(get_app_running_container_ids "$APP" "$PROC_TYPE")"
       for cid in $proctype_oldids; do
         dokku_log_info2 "stopping $APP.$PROC_TYPE ($cid)"
         # shellcheck disable=SC2086

--- a/tests/unit/10_checks.bats
+++ b/tests/unit/10_checks.bats
@@ -172,3 +172,32 @@ teardown() {
   echo "status: "$status
   assert_output "web,notifications"
 }
+
+@test "(checks) checks:disable -> app start with missing containers" {
+  run bash -c "dokku ps:scale $TEST_APP worker=1"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  deploy_app
+
+  run bash -c "dokku checks:disable $TEST_APP worker"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run bash -c "dokku ps:stop $TEST_APP"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run bash -c "dokku cleanup"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run bash -c "dokku ps:start $TEST_APP"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+}


### PR DESCRIPTION
- updates `get_app_running_container_ids()` to accept an optional `CONTAINER_TYPE` argument
- use new form of `get_app_running_container_ids()` in `dokku_deploy_cmd()` to only attempt to stop running containers
- hide stderr in when calling `docker inspect` in `get_app_running_container_ids()`

example working output:
```
$ dokku ps:stop node-js-app
Stopping node-js-app ...
dokk$ dokku ls
-----> App Name           Container Type            Container Id              Status
node-js-app               web                       facb4a69cb87              stopped
node-js-app               worker                    04b523f2d5da              stopped
$ dokku cleanup
$ dokku checks node-js-app
-----> App Name           Proctypes Disabled        Proctypes Skipped
node-js-app               worker                    none
$ dokku ps:start node-js-app
-----> Releasing node-js-app (dokku/node-js-app:latest)...
-----> Deploying node-js-app (dokku/node-js-app:latest)...
-----> Attempting to run scripts.dokku.predeploy from app.json (if defined)
-----> Running 'touch /app/predeploy.test' in app container
       restoring installation cache...
       removing installation cache...
-----> App Procfile file found (/home/dokku/node-js-app/DOKKU_PROCFILE)
-----> DOKKU_SCALE file found (/home/dokku/node-js-app/DOKKU_SCALE)
=====> # test comment
=====> web=1 # testing inline comment
=====> worker=1
-----> Attempting pre-flight checks
-----> Attempt 1/2 Waiting for 2 seconds ...
       CHECKS expected result:
       http://localhost/ => "Hello World!"
-----> All checks successful!
=====> node-js-app web container output:
       Node app is running at localhost:5000
       GOT REQUEST !
=====> end node-js-app web container output
-----> zero downtime is disabled for app (node-js-app.worker). stopping currently running containers
-----> Running post-deploy
-----> Attempting to run scripts.dokku.postdeploy from app.json (if defined)
-----> Running 'touch /app/postdeploy.test' in app container
       restoring installation cache...
       removing installation cache...
=====> renaming container (568aa196a972) sad_mcclintock to node-js-app.web.1
=====> renaming container (6059446b1007) jovial_kilby to node-js-app.worker.1
-----> Configuring node-js-app.dokku.me...(using built-in template)
-----> Creating http nginx.conf
-----> Running nginx-pre-reload
       Reloading nginx
-----> Setting config vars
       DOKKU_APP_RESTORE: 1
-----> Shutting down old containers in 60 seconds
=====> facb4a69cb87493404c136d71e6423038cbb7ea97140d3660ef5d50264759e03
=====> 04b523f2d5dabf33064feaf43daa507d813c549e99997117aea43a6de0686218
=====> Application deployed:
       http://node-js-app.dokku.me
```

closes #2278