### PR TITLE
Implement restart-policy handling

### DIFF
--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -16,6 +16,8 @@ case "$1" in
     ps:restart <app>, Restart app container(s)
     ps:restartall, Restart all deployed app containers
     ps:restore, Start previously running apps e.g. after reboot
+    ps:restart-policy <app>, Shows the restart-policy for an app
+    ps:set-restart-policy <app> <policy>, Sets app restart-policy
 help_content
     }
 

--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -166,14 +166,14 @@ ps_scale() {
   fi
 }
 
-get_restart_policies() {
-  declare desc="strips docker options and prints restart policies"
-  local -r phase_file_path=$1
-  [[ -r "$phase_file_path" ]] && sed -e '/^--restart=/!d' -e 's/^--restart=/    /' < "$phase_file_path"
-}
-
 get_raw_restart_policies() {
   declare desc="strips docker options and prints raw restart policies"
   local -r phase_file_path=$1
   [[ -r "$phase_file_path" ]] && sed -e '/^--restart=/!d' < "$phase_file_path"
+}
+
+get_restart_policies() {
+  declare desc="strips docker options and prints restart policies"
+  local -r phase_file_path=$1
+  get_raw_restart_policies "$phase_file_path" | sed -e 's/^--restart=//g'
 }

--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -165,3 +165,15 @@ ps_scale() {
     release_and_deploy "$APP" "$IMAGE_TAG"
   fi
 }
+
+get_restart_policies() {
+  declare desc="strips docker options and prints restart policies"
+  local -r phase_file_path=$1
+  [[ -r "$phase_file_path" ]] && sed -e '/^--restart=/!d' -e 's/^--restart=/    /' < "$phase_file_path"
+}
+
+get_raw_restart_policies() {
+  declare desc="strips docker options and prints raw restart policies"
+  local -r phase_file_path=$1
+  [[ -r "$phase_file_path" ]] && sed -e '/^--restart=/!d' < "$phase_file_path"
+}

--- a/plugins/ps/install
+++ b/plugins/ps/install
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/docker-options/functions"
+source "$PLUGIN_AVAILABLE_PATH/ps/functions"
+
+set_default_restart_policies() {
+  declare desc="set the default restart policy for all applications if there is not one already set"
+  local APPS="$(dokku_apps)"
+  local APP
+
+  for APP in $APPS; do
+    local RESTART_POLICIES=$(get_restart_policies "$(get_phase_file_path "deploy")")
+    if [[ -z "$RESTART_POLICIES" ]]; then
+      local passed_phases=(deploy)
+      add_passed_docker_option passed_phases[@] "--restart=on-failure:10"
+    fi
+  done
+}
+
+set_default_restart_policies "$@"

--- a/plugins/ps/post-create
+++ b/plugins/ps/post-create
@@ -5,10 +5,12 @@ source "$PLUGIN_AVAILABLE_PATH/docker-options/functions"
 source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 
 ps_post_create() {
-  declare desc="ps post-stop plugin trigger"
-  local trigger="ps_post_stop"
+  declare desc="ps post-create plugin trigger"
+  local trigger="ps_post_create"
   local APP="$1"
 
   local passed_phases=(deploy)
   add_passed_docker_option passed_phases[@] "--restart=on-failure:10"
 }
+
+ps_post_create "$@"

--- a/plugins/ps/post-create
+++ b/plugins/ps/post-create
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/docker-options/functions"
+source "$PLUGIN_AVAILABLE_PATH/ps/functions"
+
+ps_post_create() {
+  declare desc="ps post-stop plugin trigger"
+  local trigger="ps_post_stop"
+  local APP="$1"
+
+  local passed_phases=(deploy)
+  add_passed_docker_option passed_phases[@] "--restart=on-failure:10"
+}

--- a/plugins/ps/subcommands/restart-policy
+++ b/plugins/ps/subcommands/restart-policy
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/docker-options/functions"
+source "$PLUGIN_AVAILABLE_PATH/ps/functions"
+
+ps_restart_policy_cmd() {
+  declare desc="shows the restart-policy for an app"
+  local cmd="ps:restart-policy"
+  local passed_phases="deploy"
+  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$2" && local APP="$2"
+
+  echo "$APP restart-policy:"
+  get_restart_policies "$(get_phase_file_path "$passed_phases")"
+}
+
+ps_restart_policy_cmd "$@"

--- a/plugins/ps/subcommands/restart-policy
+++ b/plugins/ps/subcommands/restart-policy
@@ -11,7 +11,7 @@ ps_restart_policy_cmd() {
   [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$2" && local APP="$2"
 
-  echo "$APP restart-policy:"
+  dokku_log_info2_quiet "$APP restart-policy:"
   get_restart_policies "$(get_phase_file_path "$passed_phases")"
 }
 

--- a/plugins/ps/subcommands/set-restart-policy
+++ b/plugins/ps/subcommands/set-restart-policy
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/docker-options/functions"
+source "$PLUGIN_AVAILABLE_PATH/ps/functions"
+
+ps_set_restart_policy_cmd() {
+  declare desc="sets app restart-policy"
+  local cmd="ps:set-restart-policy"
+  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$2" && local APP="$2"
+  local RESTART_POLICY="$3"
+  local RE_RESTART_POLICY="^(no|unless-stopped|always|on-failure(:[1-9][0-9]*)?)$"
+
+  if [[ ! "$RESTART_POLICY" =~ $RE_RESTART_POLICY ]]; then
+    dokku_log_fail "Please specify an valid restart policy matching the following regex: ${RE_RESTART_POLICY}"
+  fi
+
+  local RESTART_POLICIES=$(get_raw_restart_policies "$(get_phase_file_path "deploy")")
+  local passed_phases=(deploy)
+
+  for policy in $RESTART_POLICIES; do
+    remove_passed_docker_option passed_phases[@] "$policy"
+  done
+
+  dokku_log_info1_quiet "Setting restart policy: ${RESTART_POLICY}"
+  local passed_phases=(deploy)
+  add_passed_docker_option passed_phases[@] "--restart=${RESTART_POLICY}"
+}
+
+ps_set_restart_policy_cmd "$@"

--- a/tests/ci/parallel_runner.sh
+++ b/tests/ci/parallel_runner.sh
@@ -28,6 +28,8 @@ setup_circle() {
   sudo -E mkdir -p /home/dokku/.dokkurc
   sudo -E chown dokku:ubuntu /home/dokku/.dokkurc
   sudo -E chmod 775 /home/dokku/.dokkurc
+  # pull node:4 image for testing
+  sudo docker pull node:4
 }
 
 if [[ -n "$CIRCLE_NODE_INDEX" ]] && [[ "$MODE" == "setup" ]]; then

--- a/tests/unit/10_ps-dockerfile.bats
+++ b/tests/unit/10_ps-dockerfile.bats
@@ -224,20 +224,3 @@ teardown() {
   done
 }
 
-@test "(ps:scale) procfile commands extraction" {
-  source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-  source "$PLUGIN_CORE_AVAILABLE_PATH/ps/functions"
-  cat <<EOF > "$DOKKU_ROOT/$TEST_APP/DOKKU_PROCFILE"
-web: node web.js
-worker: node worker.js
-EOF
-  run get_cmd_from_procfile "$TEST_APP" web
-  echo "output: "$output
-  echo "status: "$status
-  assert_output "node web.js"
-
-  run get_cmd_from_procfile "$TEST_APP" worker
-  echo "output: "$output
-  echo "status: "$status
-  assert_output "node worker.js"
-}

--- a/tests/unit/10_ps-general.bats
+++ b/tests/unit/10_ps-general.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  create_app
+}
+
+teardown() {
+  destroy_app
+}
+
+@test "(ps:scale) procfile commands extraction" {
+  source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+  source "$PLUGIN_CORE_AVAILABLE_PATH/ps/functions"
+  cat <<EOF > "$DOKKU_ROOT/$TEST_APP/DOKKU_PROCFILE"
+web: node web.js
+worker: node worker.js
+EOF
+  run get_cmd_from_procfile "$TEST_APP" web
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "node web.js"
+
+  run get_cmd_from_procfile "$TEST_APP" worker
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "node worker.js"
+}
+
+@test "(ps:restart-policy) default policy" {
+  run bash -c "dokku --quiet ps:restart-policy $TEST_APP"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "on-failure:10"
+}
+
+
+@test "(ps:restart-policy) ps:set-restart-policy, ps:restart-policy" {
+  for policy in no unless-stopped always on-failure on-failure:20; do
+    run bash -c "dokku ps:set-restart-policy $TEST_APP $policy"
+    echo "output: "$output
+    echo "status: "$status
+    assert_success
+
+    run bash -c "dokku --quiet ps:restart-policy $TEST_APP"
+    echo "output: "$output
+    echo "status: "$status
+    assert_output "$policy"
+  done
+}
+
+@test "(ps:restart-policy) deployed policy" {
+  test_restart_policy="on-failure:20"
+  run bash -c "dokku ps:set-restart-policy $TEST_APP $test_restart_policy"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run bash -c "dokku --quiet ps:restart-policy $TEST_APP"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "$test_restart_policy"
+
+  deploy_app dockerfile
+
+  CID=$(< $DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
+  run bash -c "docker inspect -f '{{ .HostConfig.RestartPolicy.Name }}:{{ .HostConfig.RestartPolicy.MaximumRetryCount }}' $CID"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "$test_restart_policy"
+}

--- a/tests/unit/20_docker-options.bats
+++ b/tests/unit/20_docker-options.bats
@@ -67,10 +67,10 @@ teardown() {
   echo "output: "$output
   echo "status: "$status
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP | wc -l | grep -q 0"
+  run /bin/bash -c "dokku docker-options $TEST_APP | xargs"
   echo "output: "$output
   echo "status: "$status
-  assert_success
+  assert_output "Deploy options: --restart=on-failure:10"
 }
 
 @test "(docker-options) docker-options:remove (build phase)" {
@@ -105,10 +105,10 @@ teardown() {
   echo "output: "$output
   echo "status: "$status
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP deploy"
+  run /bin/bash -c "dokku docker-options $TEST_APP deploy | xargs"
   echo "output: "$output
   echo "status: "$status
-  assert_output "Deploy options: none"
+  assert_output "Deploy options: --restart=on-failure:10"
 }
 
 @test "(docker-options) docker-options:remove (run phase)" {


### PR DESCRIPTION
Applications without a restart-policy will have their policies set to `on-failure:10`. Users can completely unset the restart-policy using the `docker-options` plugin, though this will be equivalent to setting it explicitly to `no`.

Restart policies must be explicitly set, and the following are all valid:

- no
- unless-stopped
- always
- on-failure
- on-failure:NUMBER

TODO:

- [x] Tests (please save me @michaelshobbs)

Closes #1734