### PR TITLE
url subcommand returns http even if https is configured

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -991,7 +991,7 @@ get_app_urls() {
     local URLS="$(merge_dedupe_list "$port_urls $app_urls" " ")"
     case "$1" in
       url)
-        echo "$URLS" | tr ' ' '\n' | head -n1
+        echo "$URLS" | tr ' ' '\n' | tail -1
       ;;
       urls)
         echo "$URLS" | tr ' ' '\n' | sort

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -961,6 +961,7 @@ get_container_ports() {
 
 get_app_urls() {
   declare desc="print an app's available urls"
+  source "$PLUGIN_AVAILABLE_PATH/certs/functions"
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
   source "$PLUGIN_AVAILABLE_PATH/domains/functions"
   source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
@@ -976,7 +977,7 @@ get_app_urls() {
       local port_map app_vhost
       local app_vhosts=$(get_app_domains "$APP")
       for port_map in $DOKKU_PROXY_PORT_MAP; do
-        local scheme="$(awk -F ':' '{ print $1 }' <<< "$port_map")"
+      local scheme="$(awk -F ':' '{ print $1 }' <<< "$port_map")"
         local listen_port="$(awk -F ':' '{ print $2 }' <<< "$port_map")"
         for app_vhost in $app_vhosts; do
           if [[ "$listen_port" != "80" ]] && [[ "$listen_port" != "443" ]]; then
@@ -991,7 +992,11 @@ get_app_urls() {
     local URLS="$(merge_dedupe_list "$port_urls $app_urls" " ")"
     case "$1" in
       url)
-        echo "$URLS" | tr ' ' '\n' | tail -1
+        if is_ssl_enabled "$APP"; then
+          echo "$URLS" | tr ' ' '\n' | grep https | head -n1
+        else
+          echo "$URLS" | tr ' ' '\n' | head -n1
+        fi
       ;;
       urls)
         echo "$URLS" | tr ' ' '\n' | sort

--- a/tests/unit/40_core_2.bats
+++ b/tests/unit/40_core_2.bats
@@ -20,6 +20,15 @@ assert_urls() {
   assert_output < <(tr ' ' '\n' <<< "${urls}" | sort)
 }
 
+assert_url() {
+  url=$1
+  run dokku url $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  echo "url: ${url}"
+  assert_output < <("${url}")
+}
+
 build_nginx_config() {
   # simulate nginx post-deploy
   dokku domains:setup $TEST_APP
@@ -60,6 +69,15 @@ build_nginx_config() {
   assert_urls "http://${TEST_APP}.dokku.me" "https://${TEST_APP}.dokku.me"
   add_domain "test.dokku.me"
   assert_urls "http://test.dokku.me" "http://${TEST_APP}.dokku.me" "https://test.dokku.me" "https://${TEST_APP}.dokku.me"
+}
+
+@test "(core) url (app ssl)" {
+  setup_test_tls
+  assert_url "https://dokku.me"
+  build_nginx_config
+  assert_url "https://${TEST_APP}.dokku.me"
+  add_domain "test.dokku.me"
+  assert_url "https://test.dokku.me" "https://${TEST_APP}.dokku.me"
 }
 
 @test "(core) urls (wildcard ssl)" {


### PR DESCRIPTION
I recently upgraded to the latest version and noticed that the behaviour of `dokku url APP` has been changed and returns `http` scheme instead of `https`. This unfortunately breaks the deployment for some of my applications.

I know about the `dokku urls` command, although I was wondering if this change was really intended as I couldn't find anything in release notes. Also since `http` really just redirects to `https` if certs are configured it's really not the correct address to display.

If you think this should go in, I'll add a test as well.
