### PR TITLE
Add distinction for fully qualified domain name

### DIFF
--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -31,7 +31,9 @@ get_default_vhost() {
       local SUBDOMAIN=${APP/%\.${VHOST}/}
       local hostname=$(: | plugn trigger nginx-hostname "$APP" "$SUBDOMAIN" "$VHOST")
       if [[ ! -n $hostname ]]; then
-        if [[ "$APP" == *.* ]] && [[ "$SUBDOMAIN" == "$APP" ]]; then
+        if [[ "$APP" == *. ]]; then
+          local hostname="${app/\//-}"
+        elif [[ "$APP" == *.* ]] && [[ "$SUBDOMAIN" == "$APP" ]]; then
           local hostname="${APP/\//-}"
         else
           local hostname="${APP/\//-}.$VHOST"


### PR DESCRIPTION
When publishing a fully-qualified domain name (Add initial check for FQDN termination or FQDN: a DNS entry terminated by a period), it will now bypass all other checks and just publish that domain name as is.

Refs #2005.