### PR TITLE
issue 2311

### DIFF
--- a/docs/getting-started/install/debian.md
+++ b/docs/getting-started/install/debian.md
@@ -14,7 +14,7 @@ wget -nv -O - https://get.docker.com/ | sh
 wget -nv -O - https://packagecloud.io/gpg.key | apt-key add -
 echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ trusty main" | sudo tee /etc/apt/sources.list.d/dokku.list
 sudo apt-get update -qq > /dev/null
-sudo apt-get install dokku
+sudo apt-get install -qq -y dokku 
 sudo dokku plugin:install-dependencies --core
 ```
 


### PR DESCRIPTION
Edited the "unattended script" in the documentation so that apt-get
doesn't wait for input on the Dokku unattended install.
	modified:   getting-started/install/debian.md