### PR TITLE
Properly remap http port 80 mappings to https 443 when adding an ssl certificate

### DIFF
--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -12,6 +12,8 @@ domains:remove <app> DOMAIN              # Remove a domain from app
 domains:set-global <domain>              # Set global domain name
 ```
 
+> Adding a domain before deploying an application will result in port mappings being set. This may cause issues for applications that use non-standard ports, as those will not be automatically detected. Please refer to the [proxy documentation](/dokku/advanced-usage/proxy-management/) for information as to how to reconfigure the mappings.
+
 ## Customizing hostnames
 
 Applications typically have the following structure for their hostname:

--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -98,9 +98,6 @@ server {
   access_log  /var/log/nginx/{{ .APP }}-access.log;
   error_log   /var/log/nginx/{{ .APP }}-error.log;
 
-  # set a custom header for requests
-  add_header X-Served-By www-ec2-01;
-
   location    / {
     proxy_pass  http://{{ .APP }};
     proxy_http_version 1.1;

--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -17,6 +17,8 @@ certs:update <app> CRT KEY               # Update an SSL Endpoint on an app. Can
 dokku nginx:import-ssl <app> < certs.tar
 ```
 
+> Adding an ssl certificate before deploying an application will result in port mappings being updated. This may cause issues for applications that use non-standard ports, as those may not be automatically detected. Please refer to the [proxy documentation](/dokku/advanced-usage/proxy-management/) for information as to how to reconfigure the mappings.
+
 ## Per-application certificate management
 
 Dokku provides built-in support for managing SSL certificates on a per-application basis. SSL is managed via nginx outside of application containers, and as such can be updated on-the-fly without rebuilding containers. At this time, applications only support a single SSL certificate at a time. To support multiple domains for a single application, wildcard certificate usage is encouraged.

--- a/docs/template.html
+++ b/docs/template.html
@@ -160,7 +160,7 @@
             <a href="/{{NAME}}/advanced-usage/docker-options/" class="list-group-item">Docker Container Options</a>
             <a href="/{{NAME}}/advanced-usage/event-logs/" class="list-group-item">Event Logs</a>
             <a href="/{{NAME}}/advanced-usage/persistent-storage/" class="list-group-item">Persistent Storage</a>
-            <a href="/{{NAME}}/advanced-usage/proxy-management/" class="list-group-item">Proxy Management</a>
+            <a href="/{{NAME}}/advanced-usage/proxy-management/" class="list-group-item">Proxy and Port Management</a>
             <a href="/{{NAME}}/advanced-usage/repository-management/" class="list-group-item">Repository Management</a>
 
             <a href="#" class="list-group-item disabled">Community Contributions</a>

--- a/plugins/certs/subcommands/add
+++ b/plugins/certs/subcommands/add
@@ -38,7 +38,6 @@ certs_set() {
   if is_file_import "$CRT_FILE" "$KEY_FILE"; then
     # importing from file
     true
-
   elif is_tar_import; then
     local CERTS_SET_TMP_WORK_DIR=$(mktemp -d "/tmp/dokku_certs_set.XXXX")
     pushd "$CERTS_SET_TMP_WORK_DIR" &> /dev/null
@@ -64,10 +63,8 @@ certs_set() {
     else
       local KEY_FILE=$KEY_FILE_SEARCH
     fi
-
   else
     dokku_log_fail "Tar archive containing server.crt and server.key expected on stdin"
-
   fi
 
   mkdir -p "$APP_SSL_PATH"

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -524,7 +524,7 @@ dokku_deploy_cmd() {
   local cmd="deploy"
   source "$PLUGIN_AVAILABLE_PATH/checks/functions"
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
-  source "$PLUGIN_CORE_AVAILABLE_PATH/proxy/functions"
+  source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 
   [[ -z $1 ]] && dokku_log_fail "Please specify an app to deploy"
   local APP="$1"; local IMAGE_TAG="$2"; local IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -267,7 +267,7 @@ nginx_build_config() {
     # echo "sigil ${SIGIL_PARAMS[@]}"
     sigil "${SIGIL_PARAMS[@]}" | cat -s > "$NGINX_CONF"
 
-    if is_deployed "$APP"; then
+    if (is_deployed "$APP"); then
       dokku_log_info1 "Creating $SCHEME nginx.conf"
       mv "$NGINX_CONF" "$DOKKU_ROOT/$APP/nginx.conf"
     else
@@ -275,7 +275,7 @@ nginx_build_config() {
       rm -f "$NGINX_CONF"
     fi
 
-    if is_deployed "$APP"; then
+    if (is_deployed "$APP"); then
       dokku_log_info1 "Running nginx-pre-reload"
       plugn trigger nginx-pre-reload "$APP" "$DOKKU_APP_LISTEN_PORT" "$DOKKU_APP_LISTEN_IP"
 
@@ -294,7 +294,7 @@ nginx_build_config() {
       dokku_log_info1 "deleting nginx.conf"
       rm "$DOKKU_ROOT/$APP/nginx.conf"
 
-      if is_deployed "$APP"; then
+      if (is_deployed "$APP"); then
         dokku_log_info1 "reloading nginx after nginx.conf deletion"
         validate_nginx && restart_nginx
       fi

--- a/plugins/nginx-vhosts/post-certs-remove
+++ b/plugins/nginx-vhosts/post-certs-remove
@@ -9,7 +9,10 @@ nginx_post_certs_remove() {
   local trigger="nginx_post_certs_remove"
   local APP="$1"
   if [[ "$(get_app_proxy_type "$APP")" == "nginx" ]]; then
-    config_unset --no-restart "$APP" DOKKU_NGINX_PORT DOKKU_NGINX_SSL_PORT DOKKU_PROXY_PORT_MAP
+    config_unset --no-restart "$APP" DOKKU_NGINX_SSL_PORT
+
+    # shellcheck disable=SC2046
+    remove_proxy_ports "$APP" $(filter_app_proxy_ports "$APP" "https" "443")
   fi
 }
 

--- a/plugins/nginx-vhosts/post-certs-update
+++ b/plugins/nginx-vhosts/post-certs-update
@@ -20,7 +20,12 @@ nginx_post_certs_update() {
       config_unset --no-restart "$APP" DOKKU_NGINX_SSL_PORT
     fi
     if [[ "$DOKKU_PROXY_PORT_MAP" == *http:80:* ]]; then
-      config_unset --no-restart "$APP" DOKKU_PROXY_PORT_MAP
+      # shellcheck disable=SC2046
+      remove_proxy_ports "$APP" $(filter_app_proxy_ports "$APP" "https" "443")
+      # shellcheck disable=SC2046
+      for port_map in $(filter_app_proxy_ports "$APP" "http" "80"); do
+        add_proxy_ports "$APP" "https:443:$(cut -d ':' -f3 <<< "$port_map")"
+      done
     fi
   fi
 }

--- a/plugins/nginx-vhosts/proxy-disable
+++ b/plugins/nginx-vhosts/proxy-disable
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_CORE_AVAILABLE_PATH/proxy/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 source "$PLUGIN_CORE_AVAILABLE_PATH/ps/functions"
 
 nginx_proxy_disable() {

--- a/plugins/nginx-vhosts/proxy-enable
+++ b/plugins/nginx-vhosts/proxy-enable
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_CORE_AVAILABLE_PATH/proxy/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 source "$PLUGIN_CORE_AVAILABLE_PATH/ps/functions"
 
 nginx_proxy_enable() {

--- a/plugins/proxy/functions
+++ b/plugins/proxy/functions
@@ -40,3 +40,63 @@ list_app_proxy_ports() {
     dokku_log_fail "No port mappings configured for app ($APP)"
   fi
 }
+
+filter_app_proxy_ports() {
+  declare desc="list proxy port mappings for an app that start with a particular scheme and a host port"
+  local APP="$1"; verify_app_name "$APP"
+  local SCHEME="$2" HOST_PORT="$3"
+  local PROXY_PORT_MAP="$(config_get "$APP" DOKKU_PROXY_PORT_MAP || true)"
+
+  if [[ -n "$PROXY_PORT_MAP" ]]; then
+    local port_map
+    for port_map in $PROXY_PORT_MAP; do
+      local scheme="$(cut -d ':' -f1 <<< "$port_map")"
+      local host_port="$(cut -d ':' -f2 <<< "$port_map")"
+      if [[ "$scheme" == "$SCHEME" ]] && [[ "$host_port" == "$HOST_PORT" ]]; then
+        echo "$port_map"
+      fi
+    done
+  fi
+}
+
+add_proxy_ports() {
+  declare desc="add proxy port mappings from an app"
+  local APP="$1"
+  local PROXY_PORT_MAP="$(config_get "$APP" DOKKU_PROXY_PORT_MAP || true)"
+  shift 1
+
+  local INPUT_PORTS="$*"
+  if [[ -n "$INPUT_PORTS" ]]; then
+    PROXY_PORT_MAP="$(merge_dedupe_list "$PROXY_PORT_MAP $INPUT_PORTS" " ")"
+    config_set --no-restart "$APP" DOKKU_PROXY_PORT_MAP="$PROXY_PORT_MAP"
+  else
+    dokku proxy:help
+    dokku_log_fail "No port mapping specified. Exiting..."
+  fi
+}
+
+remove_proxy_ports() {
+  declare desc="remove specific proxy port mappings from an app"
+  local APP="$1"
+  local PROXY_PORT_MAP="$(config_get "$APP" DOKKU_PROXY_PORT_MAP || true)"
+  local RE_PORT='^[0-9]+$'
+  shift 1
+
+  local INPUT_PORTS="$*"
+  local port
+  PROXY_PORT_MAP=" $PROXY_PORT_MAP "
+  for port in $INPUT_PORTS; do
+    if [[ "$port" =~ $RE_PORT ]]; then
+      PROXY_PORT_MAP="$(sed -r "s/[[:alnum:]]+:$port:[[:alnum:]]+//g" <<< "$PROXY_PORT_MAP")"
+    else
+      PROXY_PORT_MAP="$(sed -r "s/ $port / /g" <<< "$PROXY_PORT_MAP")"
+    fi
+  done
+  PROXY_PORT_MAP="$(echo "$PROXY_PORT_MAP" | xargs)"
+  PROXY_PORT_MAP="$(merge_dedupe_list "$PROXY_PORT_MAP" " ")"
+  if [[ -n "$PROXY_PORT_MAP" ]]; then
+    config_set --no-restart "$APP" DOKKU_PROXY_PORT_MAP="$PROXY_PORT_MAP"
+  else
+    config_unset --no-restart "$APP" DOKKU_PROXY_PORT_MAP
+  fi
+}

--- a/plugins/proxy/subcommands/ports
+++ b/plugins/proxy/subcommands/ports
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_CORE_AVAILABLE_PATH/proxy/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 proxy_ports_cmd() {

--- a/plugins/proxy/subcommands/ports-add
+++ b/plugins/proxy/subcommands/ports-add
@@ -2,22 +2,15 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/config/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 
 proxy_ports_add_cmd() {
   declare desc="add proxy port mappings from an app"
   local cmd="proxy:add"
   local APP="$2"; verify_app_name "$APP"
-  local PROXY_PORT_MAP="$(config_get "$APP" DOKKU_PROXY_PORT_MAP || true)"
   shift 2
 
-  local INPUT_PORTS="$*"
-  if [[ -n "$INPUT_PORTS" ]]; then
-    PROXY_PORT_MAP="$(merge_dedupe_list "$PROXY_PORT_MAP $INPUT_PORTS" " ")"
-    config_set --no-restart "$APP" DOKKU_PROXY_PORT_MAP="$PROXY_PORT_MAP"
-  else
-    dokku proxy:help
-    dokku_log_fail "No port mapping specified. Exiting..."
-  fi
+  add_proxy_ports "$APP" "$@"
   plugn trigger post-proxy-ports-update "$APP" "add"
 }
 

--- a/plugins/proxy/subcommands/ports-remove
+++ b/plugins/proxy/subcommands/ports-remove
@@ -1,41 +1,24 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_CORE_AVAILABLE_PATH/proxy/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 proxy_ports_remove_cmd() {
   declare desc="remove specific proxy port mappings from an app"
   local cmd="proxy:ports-remove"
   local APP="$2"; verify_app_name "$APP"
-  local PROXY_PORT_MAP="$(config_get "$APP" DOKKU_PROXY_PORT_MAP || true)"
-  local RE_PORT='^[0-9]+$'
   shift 2
 
   local INPUT_PORTS="$*"
-  if [[ -n "$INPUT_PORTS" ]]; then
-    local port
-    PROXY_PORT_MAP=" $PROXY_PORT_MAP "
-    for port in $INPUT_PORTS; do
-      if [[ "$port" =~ $RE_PORT ]]; then
-        PROXY_PORT_MAP="$(sed -r "s/[[:alnum:]]+:$port:[[:alnum:]]+//g" <<< "$PROXY_PORT_MAP")"
-      else
-        PROXY_PORT_MAP="$(sed -r "s/ $port / /g" <<< "$PROXY_PORT_MAP")"
-      fi
-    done
-    PROXY_PORT_MAP="$(echo "$PROXY_PORT_MAP" | xargs)"
-    PROXY_PORT_MAP="$(merge_dedupe_list "$PROXY_PORT_MAP" " ")"
-    if [[ -n "$PROXY_PORT_MAP" ]]; then
-      config_set --no-restart "$APP" DOKKU_PROXY_PORT_MAP="$PROXY_PORT_MAP"
-    else
-      config_unset --no-restart "$APP" DOKKU_PROXY_PORT_MAP
-    fi
-    plugn trigger post-proxy-ports-update "$APP" "remove"
-  else
+  if [[ -z "$INPUT_PORTS" ]]; then
     dokku_log_warn "No port mapping specified. Please supply a valid configured host port"
     list_app_proxy_ports "$APP"
     dokku_log_fail "exiting..."
   fi
+
+  remove_proxy_ports "$APP" "$@"
+  plugn trigger post-proxy-ports-update "$APP" "remove"
 }
 
 proxy_ports_remove_cmd "$@"

--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -135,7 +135,7 @@ ps_restart() {
   local APP="$1"; verify_app_name "$APP"
   local IMAGE_TAG=$(get_running_image_tag "$APP")
 
-  if is_deployed "$APP"; then
+  if (is_deployed "$APP"); then
     release_and_deploy "$APP" "$IMAGE_TAG"
   else
     echo "App $APP has not been deployed"

--- a/plugins/ps/subcommands/rebuildall
+++ b/plugins/ps/subcommands/rebuildall
@@ -7,7 +7,7 @@ ps_rebuildall_cmd() {
   declare desc="rebuilds all deployed apps via command line"
   local cmd="ps:rebuildall"
   for app in $(dokku_apps); do
-    is_deployed "$app" && ps_rebuild "$app"
+    (is_deployed "$app") && ps_rebuild "$app"
   done
 }
 


### PR DESCRIPTION
Rather than removing all port mappings, we simply remap port 80 mappings to 443. The previous behavior would remove custom port mappings for all applications and reset them on any certificate change, preventing automation from plugins such as letsencrypt. While this behavior doesn't matter for buildpack deploys - which only expose a single port on container port 5000 - Dockerfile deploys would frequently be affected by such a change, requiring a remapping of all custom ports.

/cc @sseemayer, as this should simplify the usage of letsencrypt with Dokku a bit :)