### PR TITLE
Add exceptions back to dokku_client.sh

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -93,6 +93,7 @@ if [[ ! -z $DOKKU_HOST ]]; then
       ;;
     esac
 
+    [[ $1 =~ domains|help|plugins*|ps:restartall|trace|version|ssh-keys* ]] && unset appname
     [[ -n "$@" ]] && [[ -n "$appname" ]] && app_arg="--app $appname"
     # echo "ssh -o LogLevel=QUIET -p $DOKKU_PORT -t dokku@$DOKKU_HOST -- $app_arg $@"
     # shellcheck disable=SC2068,SC2086


### PR DESCRIPTION
Add exceptions back to dokku_client.sh for plugins that should not be passed an app name implicitly. This addresses a regression from commit https://github.com/dokku/dokku/commit/4204d210c1e78bae2280e1b76858cdbccba64df1

Discovered here (note that issue is marked wontfix): #2368
