### PR TITLE
Skip container finish processing when zero downtime is disabled

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -549,6 +549,8 @@ dokku_deploy_cmd() {
         dokku_log_info2 "stopping $APP.$PROC_TYPE ($cid)"
         # shellcheck disable=SC2086
         docker stop $DOCKER_STOP_TIME_ARG "$cid" &> /dev/null
+        # remove cid from oldids to skip the old container finish processing
+        oldids="$(remove_val_from_list "$cid" "$oldids" " ")"
       done
     fi
 


### PR DESCRIPTION
- Skip unnecessary container finish processing when zero downtime is disabled

Even when zero downtime is disabled, unnecessary container finish process is working.
This pull request skips this unnecessary process.

example working output:

before

```
$ dokku deploy ruby-rails-sample
-----> Attempting to run scripts.dokku.predeploy from app.json (if defined)
-----> App Procfile file found (/home/dokku/ruby-rails-sample/DOKKU_PROCFILE)
-----> DOKKU_SCALE file found (/home/dokku/ruby-rails-sample/DOKKU_SCALE)
=====> web=1
-----> zero downtime is disabled for app (ruby-rails-sample.web). stopping currently running containers
=====> stopping ruby-rails-sample.web (c38ab49331ee6460b1cf16ef266cd9215c2409ea4281821d254df34b7e8f1335)

.....

-----> Setting config vars
       DOKKU_APP_RESTORE: 1
-----> Shutting down old containers in 60 seconds
=====> c38ab49331ee6460b1cf16ef266cd9215c2409ea4281821d254df34b7e8f1335
```

after (this pull request)

```
$ dokku deploy ruby-rails-sample
-----> Attempting to run scripts.dokku.predeploy from app.json (if defined)
-----> App Procfile file found (/home/dokku/ruby-rails-sample/DOKKU_PROCFILE)
-----> DOKKU_SCALE file found (/home/dokku/ruby-rails-sample/DOKKU_SCALE)
=====> web=1
-----> zero downtime is disabled for app (ruby-rails-sample.web). stopping currently running containers
=====> stopping ruby-rails-sample.web (3fc7e1fa23cf1b3bcdde026f03b9a75b27bb72446b5b201a9118dd5d9c14bb7b)

.....

-----> Setting config vars
       DOKKU_APP_RESTORE: 1
```
