### PR TITLE
actually merge dokku-app-user into core

### DIFF
--- a/docs/advanced-usage/persistent-storage.md
+++ b/docs/advanced-usage/persistent-storage.md
@@ -75,4 +75,15 @@ You cannot use mounted volumes during the build phase of a Dockerfile deploy. Th
 
 ## Docker-Options Note
 
-The storage plugins is compatible with storage mounts created with the docker-options. The storage plugin will only list mounts from the deploy phase.
+The storage plugin is compatible with storage mounts created with the docker-options. The storage plugin will only list mounts from the deploy phase.
+
+
+> New as of 0.7.1
+
+## Application User and Persistent Storage file ownership (buildpack apps only)
+
+By default, dokku will execute your buildpack application processes as the `herokuishuser` user. You may override this by setting the `DOKKU_APP_USER` config variable.
+
+> NOTE: this user must exist in your herokuish image.
+
+Additionally, dokku will ensure your storage mounts are owned by either `herokuishuser` or the overridden value you have set in `DOKKU_APP_USER`.

--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -256,7 +256,7 @@ The following plugins have been removed as their functionality is now in Dokku C
 
 | Plugin                                                                                            | Author                | In Dokku Since                  |
 | ------------------------------------------------------------------------------------------------- | --------------------- | ------------------------------- |
-| [App User](https://github.com/michaelshobbs/dokku-app-user)                                       | [michaelshobbs][]     | v0.7.0 (herokuish 0.3.18)       |
+| [App User](https://github.com/michaelshobbs/dokku-app-user)                                       | [michaelshobbs][]     | v0.7.1 (herokuish 0.3.18)       |
 | [Custom Domains](https://github.com/neam/dokku-custom-domains)                                    | [motin][]             | v0.3.10 (domains plugin)        |
 | [Debug](https://github.com/heichblatt/dokku-debug)                                                | [heichblatt][]        | v0.3.9 (trace command)          |
 | [Docker Options](https://github.com/dyson/dokku-docker-options)                                   | [dyson][]             | v0.3.17 (docker-options plugin) |

--- a/dokku
+++ b/dokku
@@ -37,7 +37,7 @@ export DOKKU_LOGS_DIR=${DOKKU_LOGS_DIR:="/var/log/dokku"}
 export DOKKU_EVENTS_LOGFILE=${DOKKU_EVENTS_LOGFILE:="$DOKKU_LOGS_DIR/events.log"}
 
 export DOKKU_CONTAINER_LABEL=dokku
-export DOKKU_GLOBAL_RUN_ARGS="--label=$DOKKU_CONTAINER_LABEL --env=USER=herokuishuser"
+export DOKKU_GLOBAL_RUN_ARGS="--label=$DOKKU_CONTAINER_LABEL"
 
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 

--- a/plugins/00_dokku-standard/docker-args-build
+++ b/plugins/00_dokku-standard/docker-args-build
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+
+app_user_docker_args() {
+  local APP="$1"
+  local STDIN
+  local DOKKU_APP_TYPE
+  local DOKKU_APP_USER
+
+  STDIN=$(cat)
+  DOKKU_APP_TYPE=$(config_get "$APP" DOKKU_APP_TYPE || true)
+  DOKKU_APP_USER=$(config_get "$APP" DOKKU_APP_USER || true)
+  DOKKU_APP_USER=${DOKKU_APP_USER:="herokuishuser"}
+
+  if [[ "$DOKKU_APP_TYPE" == "herokuish" ]]; then
+    local docker_args="$STDIN --env=USER=${DOKKU_APP_USER}"
+  else
+    local docker_args="$STDIN"
+  fi
+
+  echo -n "$docker_args"
+}
+
+app_user_docker_args "$@"

--- a/plugins/00_dokku-standard/docker-args-deploy
+++ b/plugins/00_dokku-standard/docker-args-deploy
@@ -1,0 +1,1 @@
+docker-args-build

--- a/plugins/00_dokku-standard/docker-args-run
+++ b/plugins/00_dokku-standard/docker-args-run
@@ -1,0 +1,1 @@
+docker-args-build

--- a/plugins/00_dokku-standard/pre-deploy
+++ b/plugins/00_dokku-standard/pre-deploy
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/config/functions"
 source "$PLUGIN_CORE_AVAILABLE_PATH/00_dokku-standard/exec-app-json-scripts"
 
 exec_app_json_scripts() {
@@ -12,4 +13,23 @@ exec_app_json_scripts() {
   execute_script "$APP" "$IMAGE_TAG" "$PHASE_SCRIPT_KEY"
 }
 
+app_user_pre_deploy_trigger() {
+  local desc="app user pre-deploy trigger"
+  local APP="$1"; local IMAGE_TAG="$2"; local IMAGE; local DOCKER_ARGS
+  local DOKKU_APP_USER; local APP_PATHS; local CONTAINER_PATHS
+  IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
+  DOKKU_APP_USER=$(config_get "$APP" DOKKU_APP_USER || true)
+  APP_PATHS=$(dokku --quiet storage:list "$APP" || true)
+  if [[ -n "$APP_PATHS" ]]; then
+    CONTAINER_PATHS=$(echo "$APP_PATHS" | awk -F ':' '{ print $2 }' | xargs)
+    DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG" | xargs)
+  fi
+
+  if [[ -n "$DOKKU_APP_USER" ]] && [[ -n "$CONTAINER_PATHS" ]]; then
+    # shellcheck disable=SC2086
+    docker run $DOKKU_GLOBAL_RUN_ARGS $DOCKER_ARGS $IMAGE /bin/bash -c "find $CONTAINER_PATHS -not -user $DOKKU_APP_USER -print0 | xargs -0 -r chown -R $DOKKU_APP_USER" || true
+  fi
+}
+
 exec_app_json_scripts "$@"
+app_user_pre_deploy_trigger "$@"

--- a/plugins/00_dokku-standard/pre-deploy
+++ b/plugins/00_dokku-standard/pre-deploy
@@ -16,16 +16,21 @@ exec_app_json_scripts() {
 app_user_pre_deploy_trigger() {
   local desc="app user pre-deploy trigger"
   local APP="$1"; local IMAGE_TAG="$2"; local IMAGE; local DOCKER_ARGS
-  local DOKKU_APP_USER; local APP_PATHS; local CONTAINER_PATHS
+  local DOKKU_APP_TYPE DOKKU_APP_USER APP_PATHS CONTAINER_PATHS
+
   IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
+
+  DOKKU_APP_TYPE=$(config_get "$APP" DOKKU_APP_TYPE || true)
   DOKKU_APP_USER=$(config_get "$APP" DOKKU_APP_USER || true)
+  DOKKU_APP_USER=${DOKKU_APP_USER:="herokuishuser"}
   APP_PATHS=$(dokku --quiet storage:list "$APP" || true)
+
   if [[ -n "$APP_PATHS" ]]; then
     CONTAINER_PATHS=$(echo "$APP_PATHS" | awk -F ':' '{ print $2 }' | xargs)
     DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG" | xargs)
   fi
 
-  if [[ -n "$DOKKU_APP_USER" ]] && [[ -n "$CONTAINER_PATHS" ]]; then
+  if [[ "$DOKKU_APP_TYPE" == "herokuish" ]] && [[ -n "$CONTAINER_PATHS" ]]; then
     # shellcheck disable=SC2086
     docker run $DOKKU_GLOBAL_RUN_ARGS $DOCKER_ARGS $IMAGE /bin/bash -c "find $CONTAINER_PATHS -not -user $DOKKU_APP_USER -print0 | xargs -0 -r chown -R $DOKKU_APP_USER" || true
   fi


### PR DESCRIPTION
my initial pass at this was, well, lazy to say the least. this allows a user to set `DOKKU_APP_USER` as a config variable to override the default `herokuishuser`. the `pre-deploy` trigger will inspect the app's storage mounts and ensure the container user has ownership.