### PR TITLE
Use pushd/popd to handle find warnings

### DIFF
--- a/plugins/00_dokku-standard/post-deploy
+++ b/plugins/00_dokku-standard/post-deploy
@@ -16,7 +16,7 @@ cleanup_container_state() {
   declare desc="core post-deploy state cleanup"
   local trigger="post-deploy cleanup_container_state"
   local APP="$1"; local PROCTYPES="$(egrep -v "^#" "$DOKKU_ROOT/$APP/DOKKU_SCALE" | awk -F '=' '{ print $1 }' | xargs)"
-  local CONTAINER_FILES="$(find "$DOKKU_ROOT/$APP" -maxdepth 1 -name "CONTAINER.*" -printf "%f\n" | sort -t . -k 3 -n | xargs)"
+  local CONTAINER_FILES="$(find "$DOKKU_ROOT/$APP" -maxdepth 1 -name "CONTAINER.*" -printf "%f\n" 2>/dev/null | sort -t . -k 3 -n | xargs)"
 
   local CONTAINER_FILE
   for CONTAINER_FILE in $CONTAINER_FILES; do

--- a/plugins/20_events/subcommands/list
+++ b/plugins/20_events/subcommands/list
@@ -8,7 +8,7 @@ events_list_cmd() {
   local PLUGIN_DIR="$(dirname "$0")/.."
 
   if [[ "$DOKKU_EVENTS" ]]; then
-    local logged="$(find "$PLUGIN_DIR" -type l -printf '%f ' | sort)"
+    local logged="$(find "$PLUGIN_DIR" -type l -printf '%f ' 2>/dev/null | sort)"
     dokku_col_log_info2_quiet "Events currently logged"
 
     local hook

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -12,7 +12,7 @@ has_tty() {
 
 dokku_apps() {
   declare desc="prints list of all local apps"
-  local INSTALLED_APPS=$(find "$DOKKU_ROOT" -follow -maxdepth 1 -mindepth 1 -type d ! -name 'tls' ! -name '.*' -printf "%f\n" | sort) || (dokku_log_fail "You haven't deployed any applications yet")
+  local INSTALLED_APPS=$(find "$DOKKU_ROOT" -follow -maxdepth 1 -mindepth 1 -type d ! -name 'tls' ! -name '.*' -printf "%f\n" 2>/dev/null | sort) || (dokku_log_fail "You haven't deployed any applications yet")
   [[ $INSTALLED_APPS ]] && echo "$INSTALLED_APPS"
 }
 
@@ -341,7 +341,7 @@ get_app_running_container_types() {
 
   ! (is_deployed "$APP") && dokku_log_fail "App $APP has not been deployed"
 
-  CONTAINER_TYPES="$(find "$DOKKU_ROOT/$APP" -maxdepth 1 -name "CONTAINER.*" -print0 | xargs -0)"
+  CONTAINER_TYPES="$(find "$DOKKU_ROOT/$APP" -maxdepth 1 -name "CONTAINER.*" -print0 2>/dev/null | xargs -0)"
   if [[ -n "$CONTAINER_TYPES" ]]; then
     CONTAINER_TYPES="${CONTAINER_TYPES//$DOKKU_ROOT\/$APP\//}"
     CONTAINER_TYPES="$(tr " " $'\n' <<< "$CONTAINER_TYPES" | awk -F. '{ print $2 }' | sort | uniq | xargs)"


### PR DESCRIPTION
16.04 issues a warning if the directory that is being
"restored" from $PWD is not owned by the current user.
We can work around this by using simple pushd/popd calls
that ensure the find calls can restore PWD.

Closes #2379