### PR TITLE
Upgrade sshcommand to improve ssh-keys:list output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOKKU_VERSION = master
 
-SSHCOMMAND_URL ?= https://raw.githubusercontent.com/dokku/sshcommand/v0.5.0/sshcommand
+SSHCOMMAND_URL ?= https://raw.githubusercontent.com/dokku/sshcommand/v0.6.0/sshcommand
 PLUGN_URL ?= https://github.com/dokku/plugn/releases/download/v0.2.1/plugn_0.2.1_linux_x86_64.tgz
 SIGIL_URL ?= https://github.com/gliderlabs/sigil/releases/download/v0.4.0/sigil_0.4.0_Linux_x86_64.tgz
 STACK_URL ?= https://github.com/gliderlabs/herokuish.git

--- a/deb.mk
+++ b/deb.mk
@@ -26,7 +26,7 @@ Simplifies running a single command over SSH, and
 manages authorized keys (ACL) and users in order to do so.
 endef
 SSHCOMMAND_REPO_NAME ?= dokku/sshcommand
-SSHCOMMAND_VERSION ?= 0.5.0
+SSHCOMMAND_VERSION ?= 0.6.0
 SSHCOMMAND_ARCHITECTURE = amd64
 SSHCOMMAND_PACKAGE_NAME = sshcommand_$(SSHCOMMAND_VERSION)_$(SSHCOMMAND_ARCHITECTURE).deb
 SSHCOMMAND_URL ?= https://raw.githubusercontent.com/dokku/sshcommand/v$(SSHCOMMAND_VERSION)/sshcommand


### PR DESCRIPTION
This adds support for SHA256 ssh key fingerprints as done in newer operating systems.

Closes #2343 