### PR TITLE
Use apps_create method when renaming an application. Closes #2252

### DIFF
--- a/plugins/apps/subcommands/rename
+++ b/plugins/apps/subcommands/rename
@@ -13,11 +13,11 @@ apps_rename_cmd() {
   local NEW_APP="$3"
   local OLD_CACHE_DIR="$DOKKU_ROOT/$OLD_APP/cache"
 
-  mkdir -p "$DOKKU_ROOT/$NEW_APP"
   if [[ -d "$OLD_CACHE_DIR" ]] && ! rmdir "$OLD_CACHE_DIR"; then
     docker run "$DOKKU_GLOBAL_RUN_ARGS" --rm -v "$OLD_CACHE_DIR:/cache" "dokku/$OLD_APP" chmod 777 -R /cache
   fi
   rm -rf "$OLD_CACHE_DIR"
+  apps_create "$NEW_APP"
   cp -a "$DOKKU_ROOT/$OLD_APP/." "$DOKKU_ROOT/$NEW_APP"
   DOKKU_APPS_FORCE_DELETE=1 apps_destroy "$OLD_APP"
   [[ -f "$DOKKU_ROOT/$NEW_APP/URLS" ]] && sed -i -e "s/$OLD_APP/$NEW_APP/g" "$DOKKU_ROOT/$NEW_APP/URLS"


### PR DESCRIPTION
Since they are separate resources, triggering the normal app creation flow makes the most sense.

We still remove the cache directory because we want the correct cache permissions for the new application.