### PR TITLE
Use $DOKKU_VHOST_ENABLE instead of $VHOST_ENABLE

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -109,7 +109,7 @@ install-dokku-from-package() {
   echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ trusty main" | tee /etc/apt/sources.list.d/dokku.list
   apt-get update -qq > /dev/null
 
-  [[ -n $DOKKU_VHOST_ENABLE ]]  && echo "dokku dokku/vhost_enable boolean $VHOST_ENABLE"         | sudo debconf-set-selections
+  [[ -n $DOKKU_VHOST_ENABLE ]]  && echo "dokku dokku/vhost_enable boolean $DOKKU_VHOST_ENABLE"   | sudo debconf-set-selections
   [[ -n $DOKKU_WEB_CONFIG ]]    && echo "dokku dokku/web_config boolean $DOKKU_WEB_CONFIG"       | sudo debconf-set-selections
   [[ -n $DOKKU_HOSTNAME ]]      && echo "dokku dokku/hostname string $DOKKU_HOSTNAME"            | sudo debconf-set-selections
   [[ -n $DOKKU_SKIP_KEY_FILE ]] && echo "dokku dokku/skip_key_file boolean $DOKKU_SKIP_KEY_FILE" | sudo debconf-set-selections


### PR DESCRIPTION
Given a user wants to manually override the `vhost_enable` debian config, a user has to specify both `$DOKKU_VHOST_ENABLE` and `$VHOST_ENABLE`. This patch makes it rely on `$DOKKU_VHOST_ENABLE` like the others which use the `$DOKKU_` prefix