### PR TITLE
Clarify domains help, improve domains unit tests

### DIFF
--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -3,14 +3,14 @@
 > New as of 0.3.10
 
 ```
-domains:add <app> DOMAIN                 # Add a domain to app
-domains:add-global <domain>              # Add global domain name
-domains [<app>]                          # List domains
-domains:clear <app>                      # Clear all domains for app
-domains:disable <app>                    # Disable VHOST support
-domains:enable <app>                     # Enable VHOST support
-domains:remove <app> DOMAIN              # Remove a domain from app
-domains:remove-global <domain>           # Remove global domain name
+domains:add <app> <domain> [<domain> ...]      # Add domains to app
+domains:add-global <domain> [<domain> ...]     # Add global domain names
+domains [<app>]                                # List domains
+domains:clear <app>                            # Clear all domains for app
+domains:disable <app>                          # Disable VHOST support
+domains:enable <app>                           # Enable VHOST support
+domains:remove <app> <domain> [<domain> ...]   # Remove domains from app
+domains:remove-global <domain> [<domain> ...]  # Remove global domain names
 ```
 
 > Adding a domain before deploying an application will result in port mappings being set. This may cause issues for applications that use non-standard ports, as those will not be automatically detected. Please refer to the [proxy documentation](/dokku/advanced-usage/proxy-management/) for information as to how to reconfigure the mappings.

--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -8,13 +8,13 @@ case "$1" in
       declare desc="return domains plugin help content"
       cat<<help_content
     domains [<app>], List domains
-    domains:add <app> DOMAIN, Add a domain to app
-    domains:add-global DOMAIN, Add global domain name
+    domains:add <app> <domain> [<domain>...], Add domain(s) to app
+    domains:add-global <domain> [<domain>...], Add global domain name(s)
     domains:clear <app>, Clear all domains for app
     domains:disable <app>, Disable VHOST support
     domains:enable <app>, Enable VHOST support
-    domains:remove <app> DOMAIN, Remove a domain from app
-    domains:remove-global DOMAIN, Remove global domain name
+    domains:remove <app> <domain> [<domain>...], Remove domain(s) from app
+    domains:remove-global <domain> [<domain>...], Remove global domain name(s)
 help_content
     }
 

--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -8,13 +8,13 @@ case "$1" in
       declare desc="return domains plugin help content"
       cat<<help_content
     domains [<app>], List domains
-    domains:add <app> <domain> [<domain>...], Add domain(s) to app
-    domains:add-global <domain> [<domain>...], Add global domain name(s)
+    domains:add <app> <domain> [<domain> ...], Add domains to app
+    domains:add-global <domain> [<domain> ...], Add global domain names
     domains:clear <app>, Clear all domains for app
     domains:disable <app>, Disable VHOST support
     domains:enable <app>, Enable VHOST support
-    domains:remove <app> <domain> [<domain>...], Remove domain(s) from app
-    domains:remove-global <domain> [<domain>...], Remove global domain name(s)
+    domains:remove <app> <domain> [<domain> ...], Remove domains from app
+    domains:remove-global <domain> [<domain> ...], Remove global domain names
 help_content
     }
 

--- a/plugins/domains/subcommands/add
+++ b/plugins/domains/subcommands/add
@@ -4,15 +4,11 @@ source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/domains/functions"
 
 domains_add_cmd() {
-  declare desc="adds domain to app via command line"
+  declare desc="adds domains to app via command line"
   local cmd="domains:add"
   [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
+  [[ -z $3 ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 $2 <domain> [<domain> ...]"
 
-  if [[ -z "${*:3}" ]]; then
-    echo "Usage: dokku $1 $2 DOMAIN [DOMAIN ...]"
-    echo "Must specify DOMAIN."
-    exit 1
-  fi
   shift 1
   domains_add "$@"
 }

--- a/plugins/domains/subcommands/add-global
+++ b/plugins/domains/subcommands/add-global
@@ -4,9 +4,9 @@ source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/domains/functions"
 
 domains_add_global_cmd() {
-  declare desc="add global domain name via command line"
+  declare desc="add global domain names via command line"
   local cmd="domains:add-global"
-  [[ -z $2 ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 DOMAIN [DOMAIN ...]"
+  [[ -z $2 ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 <domain> [<domain> ...]"
 
   shift 1
   domains_add_global "$@"

--- a/plugins/domains/subcommands/remove
+++ b/plugins/domains/subcommands/remove
@@ -7,12 +7,7 @@ domains_remove_cmd() {
   declare desc="removes domains from app via command line"
   local cmd="domains:remove"
   [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
-
-  if [[ -z "${*:3}" ]]; then
-    echo "Usage: dokku $1 $2 DOMAIN [DOMAIN ...]"
-    echo "Must specify DOMAIN."
-    exit 1
-  fi
+  [[ -z $3 ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 $2 <domain> [<domain> ...]"
 
   shift 1
   domains_remove "$@"

--- a/plugins/domains/subcommands/remove-global
+++ b/plugins/domains/subcommands/remove-global
@@ -4,9 +4,9 @@ source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/domains/functions"
 
 domains_remove_global_cmd() {
-  declare desc="remove global domain name via command line"
+  declare desc="remove global domain names via command line"
   local cmd="domains:remove-global"
-  [[ -z $2 ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 DOMAIN [DOMAIN ...]"
+  [[ -z $2 ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 <domain> [<domain> ...]"
 
   shift 1
   domains_remove_global "$@"

--- a/tests/unit/20_domains.bats
+++ b/tests/unit/20_domains.bats
@@ -29,25 +29,46 @@ teardown() {
   echo "output: "$output
   echo "status: "$status
   assert_success
+
   run dokku domains:add $TEST_APP test.app.dokku.me
   echo "output: "$output
   echo "status: "$status
   assert_success
+
   run dokku domains:add $TEST_APP 2.app.dokku.me
   echo "output: "$output
   echo "status: "$status
   assert_success
+
   run dokku domains:add $TEST_APP a--domain.with--hyphens
   echo "output: "$output
   echo "status: "$status
   assert_success
-}
 
-@test "(domains) domains:add (multiple)" {
-  run dokku domains:add $TEST_APP 2.app.dokku.me www.test.app.dokku.me test.app.dokku.me
+  run dokku domains $TEST_APP
   echo "output: "$output
   echo "status: "$status
   assert_success
+  assert_line www.test.app.dokku.me
+  assert_line test.app.dokku.me
+  assert_line 2.app.dokku.me
+  assert_line a--domain.with--hyphens
+}
+
+@test "(domains) domains:add (multiple)" {
+  run dokku domains:add $TEST_APP www.test.app.dokku.me test.app.dokku.me 2.app.dokku.me a--domain.with--hyphens
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run dokku domains $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  assert_line www.test.app.dokku.me
+  assert_line test.app.dokku.me
+  assert_line 2.app.dokku.me
+  assert_line a--domain.with--hyphens
 }
 
 @test "(domains) domains:add (duplicate)" {
@@ -74,10 +95,37 @@ teardown() {
   echo "output: "$output
   echo "status: "$status
   assert_success
+
   run dokku domains:remove $TEST_APP test.app.dokku.me
   echo "output: "$output
   echo "status: "$status
-  refute_line "test.app.dokku.me"
+  assert_success
+
+  run dokku domains $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  refute_line test.app.dokku.me
+}
+
+@test "(domains) domains:remove (multiple)" {
+  run dokku domains:add $TEST_APP www.test.app.dokku.me test.app.dokku.me 2.app.dokku.me
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run dokku domains:remove $TEST_APP www.test.app.dokku.me test.app.dokku.me
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run dokku domains $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  refute_line www.test.app.dokku.me
+  refute_line test.app.dokku.me
+  assert_line 2.app.dokku.me
 }
 
 @test "(domains) domains:remove (wildcard domain)" {
@@ -85,10 +133,17 @@ teardown() {
   echo "output: "$output
   echo "status: "$status
   assert_success
+
   run dokku domains:remove $TEST_APP *.dokku.me
   echo "output: "$output
   echo "status: "$status
-  refute_line "*.dokku.me"
+  assert_success
+
+  run dokku domains $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  refute_line *.dokku.me
 }
 
 @test "(domains) domains:clear" {
@@ -96,10 +151,17 @@ teardown() {
   echo "output: "$output
   echo "status: "$status
   assert_success
+
   run dokku domains:clear $TEST_APP
   echo "output: "$output
   echo "status: "$status
   assert_success
+
+  run dokku domains $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  refute_line test.app.dokku.me
 }
 
 @test "(domains) domains:add-global" {


### PR DESCRIPTION
1) This clarifies that `domains:add` and `domains:remove` support multiple domains, and removes `<app>` vs. ` DOMAIN` inconsistency.

2) This fixes `tests/unit/20_domains.bats` unit tests which didn't actually test anything other than the commands didn't crash. Even `refute_line` tests in `domains:remove` never worked as `domains:remove` didn't print the new domains set.