### PR TITLE
Adds a mention of manually adding nginx entry

### DIFF
--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -126,3 +126,7 @@ Only use this option if:
 If it's possible to make HTTP/S requests directly to Nginx, bypassing the load balancer, or if the load balancer is not configured to set these headers, then it becomes possible for a client to set these headers to arbitrary values.
 
 This could result in security issue, for example, if your application looks at the value of the `X-Forwarded-Proto` to determine if the request was made over HTTPS.
+
+### SSL Port Exposure
+
+When your app is served from port `80` then the `/home/dokku/APP/nginx.conf` file will automatically be updated to instruct nginx to respond to ssl on port 443 as a new cert is added.  If your app uses a non-standard port (perhaps you have a dockerfile deploy exposing port `99999`) you may need to manually expose an ssl port via `dokku proxy:ports-add <APP> https:443:99999`.  


### PR DESCRIPTION
I was working on a Dockerfile deploy that was setup to listen on port 8844.  I wanted to add ssl and couldn't figure out why adding the ssl cert didn't making things 'just work'.  Since the `proxy:ports-add` step I discuss in this commit is run both `under the hood` and `sometimes`, I thought it might be worth issuing a PR for.