### PR TITLE
Fixed double quotations in 'plugins/common/functions' dokku_deploy_cm…

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -560,7 +560,7 @@ dokku_deploy_cmd() {
 
       # start the app
       local DOCKER_ARGS="$DOKKU_DEFAULT_DOCKER_ARGS"
-      local DOCKER_ARGS+=" -e DYNO='$PROC_TYPE.$CONTAINER_INDEX' "
+      local DOCKER_ARGS+=" -e DYNO=$PROC_TYPE.$CONTAINER_INDEX "
       [[ "$DOKKU_TRACE" ]] && local DOCKER_ARGS+=" -e TRACE=true "
 
       [[ -n "$DOKKU_HEROKUISH" ]] && local START_CMD="/start $PROC_TYPE"


### PR DESCRIPTION
…dwhere DYNO environment variable is set

When the dokku_deploy_cmd is called, the intended value of the DYNO environment variable was being double quoted, so that when accessed within an application it would be seen as _'env_variable'_ rather than _env_variable_ . This fixes that issue by removing the quotations during the declaration of the DYNO environment variable.