### PR TITLE
Support for CentOS 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.deb
+*.rpm
 .DS_Store
 .ruby-version
 .vagrant

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ doesn't already include that problem or suggestion before submitting an issue.
 If you find a match, add a quick "+1" or "I have this problem too." Doing this
 helps prioritize the most common problems and requests.
 
-When reporting issues, please include your host OS (Ubuntu 14.04, Fedora 19,
+When reporting issues, please include your host OS (Ubuntu 14.04, CentOS 7,
 etc). Please include:
 
 * The output of `uname -a`.

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ endif
 
 include tests.mk
 include deb.mk
+include rpm.mk
 include arch.mk
 
 all:
@@ -34,13 +35,17 @@ all:
 
 install: dependencies version copyfiles plugin-dependencies plugins
 
-release: deb-all package_cloud packer
+release: deb-all rpm-all package_cloud packer
 
 package_cloud:
 	package_cloud push dokku/dokku/ubuntu/trusty herokuish*.deb
 	package_cloud push dokku/dokku/ubuntu/trusty sshcommand*.deb
 	package_cloud push dokku/dokku/ubuntu/trusty plugn*.deb
 	package_cloud push dokku/dokku/ubuntu/trusty dokku*.deb
+	package_cloud push dokku/dokku/el/7 herokuish*.rpm
+	package_cloud push dokku/dokku/el/7 sshcommand*.rpm
+	package_cloud push dokku/dokku/el/7 plugn*.rpm
+	package_cloud push dokku/dokku/el/7 dokku*.rpm
 
 packer:
 	packer build contrib/packer.json

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,6 +76,15 @@ Vagrant::configure("2") do |config|
     vm.vm.provision :shell, :inline => "cd /root/dokku && make install-from-deb"
   end
 
+  config.vm.define "dokku-rpm", autostart: false do |vm|
+    vm.vm.box = "centos/7"
+    vm.vm.synced_folder File.dirname(__FILE__), "/root/dokku"
+    vm.vm.network :forwarded_port, guest: 80, host: FORWARDED_PORT
+    vm.vm.hostname = "#{DOKKU_DOMAIN}"
+    vm.vm.network :private_network, ip: DOKKU_IP
+    vm.vm.provision :shell, :inline => "cd /root/dokku && bash bootstrap.sh"
+  end
+
   config.vm.define "build", autostart: false do |vm|
     vm.vm.synced_folder File.dirname(__FILE__), "/root/dokku"
     vm.vm.network :forwarded_port, guest: 80, host: FORWARDED_PORT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,7 +82,7 @@ Vagrant::configure("2") do |config|
     vm.vm.hostname = "#{DOKKU_DOMAIN}"
     vm.vm.network :private_network, ip: DOKKU_IP
     vm.vm.provision :shell, :inline => "export DEBIAN_FRONTEND=noninteractive && apt-get update > /dev/null && apt-get -qq -y install git > /dev/null && cd /root/dokku && #{make_cmd}"
-    vm.vm.provision :shell, :inline => "export IS_RELEASE=true && cd /root/dokku && make deb-all"
+    vm.vm.provision :shell, :inline => "export IS_RELEASE=true && cd /root/dokku && make deb-all rpm-all"
   end
 
   config.vm.define "build-arch", autostart: false do |vm|

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -51,6 +51,7 @@ git tag v0.9.9
 vagrant up build
 export PACKAGECLOUD_TOKEN=SOME_TOKEN
 package_cloud push dokku/dokku/ubuntu/trusty dokku_0.9.9_amd64.deb
+package_cloud push dokku/dokku/el/7 dokku-0.9.9-1.x86_64.rpm
 ```
 
 If new versions of other packages were created, these should also be pushed at this time.

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -39,7 +39,7 @@ At the moment, tags need not be signed, though that may change in the future.
 
 ## Debian and RPM packages
 
-The `build` target in the Dokku `Vagrantfile` creates debian packages for Dokku at a point in time. The version will be based upon the latest local tag - you may create your own, internal tags/releases if that is so desired.
+The `build` target in the Dokku `Vagrantfile` creates debian and rpm packages for Dokku at a point in time. The version will be based upon the latest local tag - you may create your own, internal tags/releases if that is so desired.
 
 Debian package information is held in the `debian` directory of the Dokku project.
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -20,7 +20,7 @@ To propose a release, the following tasks need to be performed:
 - The versioned links should be updated or added to the `docs/assets/versions.json` file.
 - A list of changes must be made in the `HISTORY.md`.
 - A tag must be created locally with your release version
-- Debian packages *must* be created via `vagrant up build`
+- Debian and RPM packages *must* be created via `vagrant up build`
 - The packages should be uploaded to packagecloud.io
 - All changes are pushed to master and the tag should be turned into a release which will contain the changelog.
 - ArchLinux package description *must* be updated via `vagrant up build-arch` (needs to be done after the tag is pushed to GitHub, because it is based on that)
@@ -37,7 +37,7 @@ git tag v0.9.9
 
 At the moment, tags need not be signed, though that may change in the future.
 
-## Debian Packages
+## Debian and RPM packages
 
 The `build` target in the Dokku `Vagrantfile` creates debian packages for Dokku at a point in time. The version will be based upon the latest local tag - you may create your own, internal tags/releases if that is so desired.
 

--- a/docs/getting-started/install/rpm.md
+++ b/docs/getting-started/install/rpm.md
@@ -1,5 +1,7 @@
 # RPM Package Installation Notes
 
+> New as of 0.8.0
+
 Dokku defaults to being installed via RPM package on CentOS 7. While certain hosts may require extra work to get running, you may optionally wish to automate the installation of Dokku without the use of our `bootstrap.sh` bash script. The following are the steps run by said script:
 
 ```shell

--- a/docs/getting-started/install/rpm.md
+++ b/docs/getting-started/install/rpm.md
@@ -1,0 +1,16 @@
+# RPM Package Installation Notes
+
+Dokku defaults to being installed via RPM package. While certain hosts may require extra work to get running, you may optionally wish to automate the installation of Dokku without the use of our `bootstrap.sh` bash script. The following are the steps run by said script:
+
+```shell
+# install docker
+curl -fsSL https://get.docker.com/ | sh
+
+# install epel for nginx packages to be available
+sudo yum install -y epel-release
+
+# install dokku
+curl -s https://packagecloud.io/install/repositories/dokku/dokku/script.rpm.sh | sudo bash
+sudo yum install -y herokuish dokku
+sudo dokku plugin:install-dependencies --core
+```

--- a/docs/getting-started/install/rpm.md
+++ b/docs/getting-started/install/rpm.md
@@ -1,6 +1,6 @@
 # RPM Package Installation Notes
 
-Dokku defaults to being installed via RPM package. While certain hosts may require extra work to get running, you may optionally wish to automate the installation of Dokku without the use of our `bootstrap.sh` bash script. The following are the steps run by said script:
+Dokku defaults to being installed via RPM package on CentOS 7. While certain hosts may require extra work to get running, you may optionally wish to automate the installation of Dokku without the use of our `bootstrap.sh` bash script. The following are the steps run by said script:
 
 ```shell
 # install docker

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,6 +48,7 @@ For various reasons, certain hosting providers may have other steps that should 
 As well, you may wish to customize your installation in some other fashion. or experiment with vagrant. The guides below should get you started:
 
 - [Debian Package Installation Notes](/dokku/getting-started/install/debian/)
+- [RPM Package Installation Notes](/dokku/getting-started/install/rpm/)
 - [Vagrant Installation Notes](/dokku/getting-started/install/vagrant/)
 - [Advanced Install Customization](/dokku/getting-started/advanced-installation/)
 

--- a/dokku
+++ b/dokku
@@ -14,6 +14,9 @@ case "$(lsb_release -si)" in
   Debian)
     export DOKKU_DISTRO=${DOKKU_DISTRO:="debian"}
     ;;
+  CentOS)
+    export DOKKU_DISTRO=${DOKKU_DISTRO:="centos"}
+    ;;
   *)
     export DOKKU_DISTRO=${DOKKU_DISTRO:="ubuntu"}
     ;;

--- a/dokku
+++ b/dokku
@@ -7,20 +7,9 @@ export DOKKU_ROOT=${DOKKU_ROOT:=~dokku}
 [[ -d $DOKKU_ROOT/.dokkurc ]] && for f in $DOKKU_ROOT/.dokkurc/*; do source "$f"; done
 [[ $DOKKU_TRACE ]] && set -x
 
-case "$(lsb_release -si)" in
-  Arch)
-    export DOKKU_DISTRO=${DOKKU_DISTRO:="arch"}
-    ;;
-  Debian)
-    export DOKKU_DISTRO=${DOKKU_DISTRO:="debian"}
-    ;;
-  CentOS)
-    export DOKKU_DISTRO=${DOKKU_DISTRO:="centos"}
-    ;;
-  *)
-    export DOKKU_DISTRO=${DOKKU_DISTRO:="ubuntu"}
-    ;;
-esac
+export DOKKU_DISTRO
+# shellcheck disable=SC1091
+DOKKU_DISTRO=$(. /etc/os-release && echo "$ID")
 
 export DOKKU_IMAGE=${DOKKU_IMAGE:="gliderlabs/herokuish"}
 export DOKKU_LIB_ROOT=${DOKKU_LIB_PATH:="/var/lib/dokku"}

--- a/plugins/20_events/install
+++ b/plugins/20_events/install
@@ -12,7 +12,7 @@ flag_rsyslog_needs_restart=n
 # exits gracefully if the path already exists
 mkdir -m 775 -p "$DOKKU_LOGS_DIR"
 case "$DOKKU_DISTRO" in
-  arch|debian)
+  arch|debian|centos)
     chgrp dokku "$DOKKU_LOGS_DIR"
     ;;
   *)
@@ -23,7 +23,7 @@ esac
 if [[ ! -f  "$DOKKU_EVENTS_LOGFILE" ]]; then
   touch "$DOKKU_EVENTS_LOGFILE"
   case "$DOKKU_DISTRO" in
-    arch|debian)
+    arch|debian|centos)
       chgrp dokku "$DOKKU_EVENTS_LOGFILE"
       ;;
     *)

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -39,9 +39,9 @@ restart_nginx() {
       sudo /sbin/service nginx reload > /dev/null
       ;;
 
-    arch)
+    arch|centos)
       sudo /usr/bin/systemctl reload nginx
-	  ;;
+      ;;
   esac
 }
 

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -17,6 +17,11 @@ case "$DOKKU_DISTRO" in
   arch)
     echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl reload nginx, /usr/sbin/nginx -t" > /etc/sudoers.d/dokku-nginx
     ;;
+
+  centos)
+    echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl reload nginx, /usr/sbin/nginx -t" > /etc/sudoers.d/dokku-nginx
+    echo "Defaults:dokku !requiretty" >> /etc/sudoers.d/dokku-nginx
+    ;;
 esac
 
 chmod 0440 /etc/sudoers.d/dokku-nginx
@@ -66,10 +71,8 @@ case "$DOKKU_DISTRO" in
     "$NGINX_INIT" nginx start || "$NGINX_INIT" nginx reload
     ;;
 
-  arch)
+  arch|centos)
     NGINX_INIT="/usr/bin/systemctl"
     "$NGINX_INIT" start nginx || "$NGINX_INIT" reload nginx
     ;;
 esac
-
-

--- a/rpm.mk
+++ b/rpm.mk
@@ -1,0 +1,171 @@
+RPM_ARCHITECTURE = x86_64
+HEROKUISH_RPM_PACKAGE_NAME = herokuish-$(HEROKUISH_VERSION)-1.$(RPM_ARCHITECTURE).rpm
+PLUGN_RPM_PACKAGE_NAME = plugn-$(PLUGN_VERSION)-1.$(RPM_ARCHITECTURE).rpm
+SSHCOMMAND_RPM_PACKAGE_NAME = sshcommand-$(SSHCOMMAND_VERSION)-1.$(RPM_ARCHITECTURE).rpm
+SIGIL_RPM_PACKAGE_NAME = gliderlabs-sigil-$(SIGIL_VERSION)-1.$(RPM_ARCHITECTURE).rpm
+
+.PHONY: rpm-all
+
+rpm-all: rpm-setup rpm-herokuish rpm-dokku rpm-plugn rpm-sshcommand rpm-sigil
+	mv /tmp/*.rpm .
+	@echo "Done"
+
+rpm-setup:
+	@echo "-> Installing rpm build requirements"
+	@sudo apt-get update -qq > /dev/null
+	@sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y gcc git build-essential wget ruby-dev ruby1.9.1 rpm > /dev/null 2>&1
+	@command -v fpm > /dev/null || sudo gem install fpm --no-ri --no-rdoc
+	@ssh -o StrictHostKeyChecking=no git@github.com || true
+
+rpm-herokuish:
+	rm -rf /tmp/tmp /tmp/build $(HEROKUISH_RPM_PACKAGE_NAME)
+	mkdir -p /tmp/tmp /tmp/build
+
+	@echo "-> Cloning repository"
+	git clone -q "https://github.com/$(HEROKUISH_REPO_NAME).git" \
+		--branch "v$(HEROKUISH_VERSION)" /tmp/tmp/herokuish > /dev/null
+	rm -rf /tmp/tmp/herokuish/.git /tmp/tmp/herokuish/.gitignore
+
+	@echo "-> Copying files into place"
+	mkdir -p "/tmp/build/var/lib"
+	cp -rf /tmp/tmp/herokuish /tmp/build/var/lib/herokuish
+
+	@echo "-> Creating $(HEROKUISH_RPM_PACKAGE_NAME)"
+	sudo fpm -t rpm -s dir -C /tmp/build -n herokuish \
+		-v $(HEROKUISH_VERSION) \
+		-a $(RPM_ARCHITECTURE) \
+		-p $(HEROKUISH_RPM_PACKAGE_NAME) \
+		--depends 'docker-engine >= 1.9.1' \
+		--depends 'sudo' \
+		--after-install rpm/herokuish.postinst \
+		--url "https://github.com/$(HEROKUISH_REPO_NAME)" \
+		--description $(HEROKUISH_DESCRIPTION) \
+		--license 'MIT License' \
+		.
+	mv *.rpm /tmp
+
+rpm-dokku:
+	rm -rf /tmp/tmp /tmp/build dokku_*_$(RPM_ARCHITECTURE).rpm
+	mkdir -p /tmp/tmp /tmp/build
+
+	mkdir -p /tmp/build/usr/bin
+	mkdir -p /tmp/build/usr/share/doc/dokku
+	mkdir -p /tmp/build/usr/share/dokku/contrib
+	mkdir -p /tmp/build/usr/share/lintian/overrides
+	mkdir -p /tmp/build/usr/share/man/man1
+	mkdir -p /tmp/build/var/lib/dokku/core-plugins/available
+
+	cp dokku /tmp/build/usr/bin
+	cp LICENSE /tmp/build/usr/share/doc/dokku/copyright
+	find . -name ".DS_Store" -depth -exec rm {} \;
+	cp -r plugins/* /tmp/build/var/lib/dokku/core-plugins/available
+	find plugins/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read plugin; do touch /tmp/build/var/lib/dokku/core-plugins/available/$$plugin/.core; done
+	$(MAKE) help2man
+	$(MAKE) addman
+	cp /usr/local/share/man/man1/dokku.1 /tmp/build/usr/share/man/man1/dokku.1
+	gzip -9 /tmp/build/usr/share/man/man1/dokku.1
+	cp contrib/dokku-installer.py /tmp/build/usr/share/dokku/contrib
+	git describe --tags > /tmp/build/var/lib/dokku/VERSION
+	cat /tmp/build/var/lib/dokku/VERSION | cut -d '-' -f 1 | cut -d 'v' -f 2 > /tmp/build/var/lib/dokku/STABLE_VERSION
+ifneq (,$(findstring false,$(IS_RELEASE)))
+	sed -i.bak -e "s/^/`date +%s`:/" /tmp/build/var/lib/dokku/STABLE_VERSION && rm /tmp/build/var/lib/dokku/STABLE_VERSION.bak
+endif
+	git rev-parse HEAD > /tmp/build/var/lib/dokku/GIT_REV
+
+	@echo "-> Creating rpm package"
+	VERSION=$$(cat /tmp/build/var/lib/dokku/STABLE_VERSION); \
+	sudo fpm -t rpm -s dir -C /tmp/build -n dokku \
+		-v "$$VERSION" \
+		-a $(RPM_ARCHITECTURE) \
+		-p "dokku-$$VERSION-1.x86_64.rpm" \
+		--depends 'git' \
+		--depends 'make' \
+		--depends 'curl' \
+		--depends 'gcc' \
+		--depends 'man-db' \
+		--depends 'sshcommand' \
+		--depends 'gliderlabs-sigil' \
+		--depends 'docker-engine >= 1.9.1' \
+		--depends 'bind-utils' \
+		--depends 'nginx' \
+		--depends 'plugn' \
+		--depends 'sudo' \
+		--depends 'python' \
+		--depends 'nc' \
+		--depends 'redhat-lsb-core' \
+		--after-install rpm/dokku.postinst \
+		--url "https://github.com/$(DOKKU_REPO_NAME)" \
+		--description $(DOKKU_DESCRIPTION) \
+		--license 'MIT License' \
+		.
+	mv *.rpm /tmp
+
+rpm-plugn:
+	rm -rf /tmp/tmp /tmp/build $(PLUGN_RPM_PACKAGE_NAME)
+	mkdir -p /tmp/tmp /tmp/build /tmp/build/usr/bin
+
+	@echo "-> Downloading package"
+	wget -q -O /tmp/tmp/plugn-$(PLUGN_VERSION).tgz $(PLUGN_URL)
+	cd /tmp/tmp/ && tar zxf /tmp/tmp/plugn-$(PLUGN_VERSION).tgz
+
+	@echo "-> Copying files into place"
+	cp /tmp/tmp/plugn /tmp/build/usr/bin/plugn && chmod +x /tmp/build/usr/bin/plugn
+
+	@echo "-> Creating $(PLUGN_RPM_PACKAGE_NAME)"
+	sudo fpm -t rpm -s dir -C /tmp/build -n plugn \
+		--version $(PLUGN_VERSION) \
+		-a $(RPM_ARCHITECTURE) \
+		--package $(PLUGN_RPM_PACKAGE_NAME) \
+		--url "https://github.com/$(PLUGN_REPO_NAME)" \
+		--category utils \
+		--description "$$PLUGN_DESCRIPTION" \
+		--license 'MIT License' \
+		.
+	mv *.rpm /tmp
+
+rpm-sshcommand:
+	rm -rf /tmp/tmp /tmp/build $(SSHCOMMAND_RPM_PACKAGE_NAME)
+	mkdir -p /tmp/tmp /tmp/build /tmp/build/usr/local/bin
+
+	@echo "-> Downloading package"
+	wget -q -O /tmp/tmp/sshcommand-$(SSHCOMMAND_VERSION) $(SSHCOMMAND_URL)
+
+	@echo "-> Copying files into place"
+	mkdir -p "/tmp/build/usr/local/bin"
+	cp /tmp/tmp/sshcommand-$(SSHCOMMAND_VERSION) /tmp/build/usr/local/bin/sshcommand
+	chmod +x /tmp/build/usr/local/bin/sshcommand
+
+	@echo "-> Creating $(SSHCOMMAND_RPM_PACKAGE_NAME)"
+	sudo fpm -t rpm -s dir -C /tmp/build -n sshcommand \
+		--version $(SSHCOMMAND_VERSION) \
+		-a $(RPM_ARCHITECTURE) \
+		--package $(SSHCOMMAND_RPM_PACKAGE_NAME) \
+		--url "https://github.com/$(SSHCOMMAND_REPO_NAME)" \
+		--category admin \
+		--description "$$SSHCOMMAND_DESCRIPTION" \
+		--license 'MIT License' \
+		.
+	mv *.rpm /tmp
+
+rpm-sigil:
+	rm -rf /tmp/tmp /tmp/build $(SIGIL_PACKAGE_NAME)
+	mkdir -p /tmp/tmp /tmp/build /tmp/build/usr/bin
+
+	@echo "-> Downloading package"
+	wget -q -O /tmp/tmp/sigil-$(SIGIL_VERSION).tgz $(SIGIL_URL)
+	cd /tmp/tmp/ && tar zxf /tmp/tmp/sigil-$(SIGIL_VERSION).tgz
+
+	@echo "-> Copying files into place"
+	cp /tmp/tmp/sigil /tmp/build/usr/bin/sigil && chmod +x /tmp/build/usr/bin/sigil
+
+	@echo "-> Creating $(SIGIL_RPM_PACKAGE_NAME)"
+	sudo fpm -t rpm -s dir -C /tmp/build -n gliderlabs-sigil \
+		--version $(SIGIL_VERSION) \
+		-a $(RPM_ARCHITECTURE) \
+		--package $(SIGIL_RPM_PACKAGE_NAME) \
+		--url "https://github.com/$(SIGIL_REPO_NAME)" \
+		--category utils \
+		--description "$$SIGIL_DESCRIPTION" \
+		--license 'MIT License' \
+		.
+	mv *.rpm /tmp

--- a/rpm.mk
+++ b/rpm.mk
@@ -124,15 +124,15 @@ rpm-plugn:
 
 rpm-sshcommand:
 	rm -rf /tmp/tmp /tmp/build $(SSHCOMMAND_RPM_PACKAGE_NAME)
-	mkdir -p /tmp/tmp /tmp/build /tmp/build/usr/local/bin
+	mkdir -p /tmp/tmp /tmp/build /tmp/build/usr/bin
 
 	@echo "-> Downloading package"
 	wget -q -O /tmp/tmp/sshcommand-$(SSHCOMMAND_VERSION) $(SSHCOMMAND_URL)
 
 	@echo "-> Copying files into place"
-	mkdir -p "/tmp/build/usr/local/bin"
-	cp /tmp/tmp/sshcommand-$(SSHCOMMAND_VERSION) /tmp/build/usr/local/bin/sshcommand
-	chmod +x /tmp/build/usr/local/bin/sshcommand
+	mkdir -p "/tmp/build/usr/bin"
+	cp /tmp/tmp/sshcommand-$(SSHCOMMAND_VERSION) /tmp/build/usr/bin/sshcommand
+	chmod +x /tmp/build/usr/bin/sshcommand
 
 	@echo "-> Creating $(SSHCOMMAND_RPM_PACKAGE_NAME)"
 	sudo fpm -t rpm -s dir -C /tmp/build -n sshcommand \

--- a/rpm.mk
+++ b/rpm.mk
@@ -92,7 +92,6 @@ endif
 		--depends 'sudo' \
 		--depends 'python' \
 		--depends 'nc' \
-		--depends 'redhat-lsb-core' \
 		--after-install rpm/dokku.postinst \
 		--url "https://github.com/$(DOKKU_REPO_NAME)" \
 		--description $(DOKKU_DESCRIPTION) \

--- a/rpm/dokku.postinst
+++ b/rpm/dokku.postinst
@@ -1,60 +1,63 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set +o posix # rpm uses /bin/sh that forces bash in posix mode
 set -eo pipefail; [[ $TRACE ]] && set -x
 
-readonly DOKKU_ROOT="${DOKKU_ROOT:-/home/dokku}"
-readonly DOKKU_LIB_ROOT="${DOKKU_LIB_PATH:-/var/lib/dokku}"
-
-call-sshcommand() {
-  if [[ -x /usr/local/bin/sshcommand ]]; then
-    /usr/local/bin/sshcommand "$@"
-  elif [[ -x /usr/bin/sshcommand ]]; then
-    /usr/bin/sshcommand "$@"
-  else
-    echo "Unable to find sshcommand binary" 1>&2
-    exit 1
-  fi
+setup-user() {
+  echo "Setting up dokku user"
+  getent passwd dokku >/dev/null || useradd -m -s /bin/bash dokku
+  mkdir -p "$DOKKU_ROOT/.ssh"
+  touch "$DOKKU_ROOT/.ssh/authorized_keys"
+  chown -R dokku:dokku "$DOKKU_ROOT/.ssh"
+  usermod -aG docker dokku
 }
 
-echo "Setting up dokku user"
-getent passwd dokku >/dev/null || useradd -m -s /bin/bash dokku
-mkdir -p $DOKKU_ROOT/.ssh
-touch $DOKKU_ROOT/.ssh/authorized_keys
-chown -R dokku:dokku $DOKKU_ROOT/.ssh
-usermod -aG docker dokku
+setup-storage() {
+  echo "Setting up storage directories"
+  mkdir -p "${DOKKU_LIB_ROOT}/data" "${DOKKU_LIB_ROOT}/data/storage"
+  chown dokku:dokku -R "${DOKKU_LIB_ROOT}/data"
+}
 
-echo "Setting up storage directories"
-mkdir -p ${DOKKU_LIB_ROOT}/data ${DOKKU_LIB_ROOT}/data/storage
-chown dokku:dokku -R ${DOKKU_LIB_ROOT}/data
+setup-plugins() {
+  echo "Setting up plugin directories"
+  # should be replaced by `plugn init`
+  mkdir -p "${DOKKU_LIB_ROOT}/core-plugins/available" "${DOKKU_LIB_ROOT}/plugins/available"
+  mkdir -p "${DOKKU_LIB_ROOT}/core-plugins/enabled" "${DOKKU_LIB_ROOT}/plugins/enabled"
+  touch "${DOKKU_LIB_ROOT}/core-plugins/config.toml" "${DOKKU_LIB_ROOT}/plugins/config.toml"
 
-echo "Setting up plugin directories"
-# should be replaced by `plugn init`
-mkdir -p ${DOKKU_LIB_ROOT}/core-plugins/available ${DOKKU_LIB_ROOT}/plugins/available
-mkdir -p ${DOKKU_LIB_ROOT}/core-plugins/enabled ${DOKKU_LIB_ROOT}/plugins/enabled
-touch ${DOKKU_LIB_ROOT}/core-plugins/config.toml ${DOKKU_LIB_ROOT}/plugins/config.toml
+  echo "Enabling all core plugins"
+  find "${DOKKU_LIB_ROOT}/core-plugins/available" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
+    if [ ! -d "${DOKKU_LIB_ROOT}/plugins/available/$plugin" ]; then
+      ln -s "${DOKKU_LIB_ROOT}/core-plugins/available/$plugin" "${DOKKU_LIB_ROOT}/plugins/available/$plugin"
+      PLUGIN_PATH="${DOKKU_LIB_ROOT}/core-plugins" plugn enable "$plugin"
+      PLUGIN_PATH="${DOKKU_LIB_ROOT}/plugins" plugn enable "$plugin"
+    fi
+  done
+  find -L "${DOKKU_LIB_ROOT}" -type l -delete
+  chown dokku:dokku -R "${DOKKU_LIB_ROOT}/plugins" "${DOKKU_LIB_ROOT}/core-plugins"
 
-echo "Enabling all core plugins"
-find ${DOKKU_LIB_ROOT}/core-plugins/available -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
-  if [ ! -d ${DOKKU_LIB_ROOT}/plugins/available/$plugin ]; then
-    ln -s ${DOKKU_LIB_ROOT}/core-plugins/available/$plugin ${DOKKU_LIB_ROOT}/plugins/available/$plugin;
-    PLUGIN_PATH=${DOKKU_LIB_ROOT}/core-plugins plugn enable $plugin
-    PLUGIN_PATH=${DOKKU_LIB_ROOT}/plugins plugn enable $plugin
-  fi
-done
-find -L ${DOKKU_LIB_ROOT} -type l -delete
-chown dokku:dokku -R ${DOKKU_LIB_ROOT}/plugins ${DOKKU_LIB_ROOT}/core-plugins
+  echo "Install all core plugins"
+  dokku plugin:install --core
+}
 
-echo "Ensure proper sshcommand path"
-echo '/usr/bin/dokku' > "${DOKKU_ROOT}/.sshcommand"
-if [[ -f .ssh/authorized_keys ]]; then
-  sed -i.bak 's#/usr/local/bin/dokku#/usr/bin/dokku#' "${DOKKU_ROOT}/.ssh/authorized_keys"
-  rm "${DOKKU_ROOT}/.ssh/authorized_keys"
-fi
+setup-sshcommand() {
+  echo "Ensure proper sshcommand path"
+  echo '/usr/bin/dokku' > "${DOKKU_ROOT}/.sshcommand"
+}
 
-echo "Install all core plugins"
-dokku plugin:install --core
+setup-version() {
+  rm -f "${DOKKU_ROOT}/VERSION"
+  cp "${DOKKU_LIB_ROOT}/STABLE_VERSION" "${DOKKU_ROOT}/VERSION"
+}
 
-rm -f ${DOKKU_ROOT}/VERSION
-cp ${DOKKU_LIB_ROOT}/STABLE_VERSION ${DOKKU_ROOT}/VERSION
+main() {
+  readonly DOKKU_ROOT="${DOKKU_ROOT:-/home/dokku}"
+  readonly DOKKU_LIB_ROOT="${DOKKU_LIB_PATH:-/var/lib/dokku}"
 
-exit 0
+  setup-user
+  setup-storage
+  setup-plugins
+  setup-sshcommand
+  setup-version
+}
+
+main

--- a/rpm/dokku.postinst
+++ b/rpm/dokku.postinst
@@ -1,0 +1,71 @@
+#!/bin/bash
+set +o posix # rpm uses /bin/sh that forces bash in posix mode
+set -eo pipefail; [[ $TRACE ]] && set -x
+
+readonly DOKKU_ROOT="${DOKKU_ROOT:-/home/dokku}"
+readonly DOKKU_LIB_ROOT="${DOKKU_LIB_PATH:-/var/lib/dokku}"
+
+call-sshcommand() {
+  if [[ -x /usr/local/bin/sshcommand ]]; then
+    /usr/local/bin/sshcommand "$@"
+  elif [[ -x /usr/bin/sshcommand ]]; then
+    /usr/bin/sshcommand "$@"
+  else
+    echo "Unable to find sshcommand binary" 1>&2
+    exit 1
+  fi
+}
+
+echo "Setting up dokku user"
+getent passwd dokku >/dev/null || useradd -m -s /bin/bash dokku
+mkdir -p $DOKKU_ROOT/.ssh
+touch $DOKKU_ROOT/.ssh/authorized_keys
+chown -R dokku:dokku $DOKKU_ROOT/.ssh
+usermod -aG docker dokku
+
+echo "Setting up storage directories"
+mkdir -p ${DOKKU_LIB_ROOT}/data ${DOKKU_LIB_ROOT}/data/storage
+chown dokku:dokku -R ${DOKKU_LIB_ROOT}/data
+
+echo "Setting up plugin directories"
+# should be replaced by `plugn init`
+mkdir -p ${DOKKU_LIB_ROOT}/core-plugins/available ${DOKKU_LIB_ROOT}/plugins/available
+mkdir -p ${DOKKU_LIB_ROOT}/core-plugins/enabled ${DOKKU_LIB_ROOT}/plugins/enabled
+touch ${DOKKU_LIB_ROOT}/core-plugins/config.toml ${DOKKU_LIB_ROOT}/plugins/config.toml
+
+echo "Migrating old plugins"
+find ${DOKKU_LIB_ROOT}/plugins/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
+  if [ "$plugin" = "available" ] || [ "$plugin" = "enabled" ]; then
+    continue
+  elif [ -f ${DOKKU_LIB_ROOT}/plugins/$plugin/.core ]; then
+    rm -rf ${DOKKU_LIB_ROOT}/plugins/$plugin
+  elif [ ! -d ${DOKKU_LIB_ROOT}/plugins/available/$plugin ]; then
+    mv ${DOKKU_LIB_ROOT}/plugins/$plugin ${DOKKU_LIB_ROOT}/plugins/available;
+  fi
+done
+
+echo "Enabling all core plugins"
+find ${DOKKU_LIB_ROOT}/core-plugins/available -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
+  if [ ! -d ${DOKKU_LIB_ROOT}/plugins/available/$plugin ]; then
+    ln -s ${DOKKU_LIB_ROOT}/core-plugins/available/$plugin ${DOKKU_LIB_ROOT}/plugins/available/$plugin;
+    PLUGIN_PATH=${DOKKU_LIB_ROOT}/core-plugins plugn enable $plugin
+    PLUGIN_PATH=${DOKKU_LIB_ROOT}/plugins plugn enable $plugin
+  fi
+done
+find -L ${DOKKU_LIB_ROOT} -type l -delete
+chown dokku:dokku -R ${DOKKU_LIB_ROOT}/plugins ${DOKKU_LIB_ROOT}/core-plugins
+
+echo "Ensure proper sshcommand path"
+echo '/usr/bin/dokku' > "${DOKKU_ROOT}/.sshcommand"
+if [[ -f .ssh/authorized_keys ]]; then
+  sed -i.bak 's#/usr/local/bin/dokku#/usr/bin/dokku#' "${DOKKU_ROOT}/.ssh/authorized_keys"
+  rm "${DOKKU_ROOT}/.ssh/authorized_keys"
+fi
+
+echo "Install all core plugins"
+dokku plugin:install --core
+
+rm -f ${DOKKU_ROOT}/VERSION
+cp ${DOKKU_LIB_ROOT}/STABLE_VERSION ${DOKKU_ROOT}/VERSION
+
+exit 0

--- a/rpm/dokku.postinst
+++ b/rpm/dokku.postinst
@@ -33,17 +33,6 @@ mkdir -p ${DOKKU_LIB_ROOT}/core-plugins/available ${DOKKU_LIB_ROOT}/plugins/avai
 mkdir -p ${DOKKU_LIB_ROOT}/core-plugins/enabled ${DOKKU_LIB_ROOT}/plugins/enabled
 touch ${DOKKU_LIB_ROOT}/core-plugins/config.toml ${DOKKU_LIB_ROOT}/plugins/config.toml
 
-echo "Migrating old plugins"
-find ${DOKKU_LIB_ROOT}/plugins/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
-  if [ "$plugin" = "available" ] || [ "$plugin" = "enabled" ]; then
-    continue
-  elif [ -f ${DOKKU_LIB_ROOT}/plugins/$plugin/.core ]; then
-    rm -rf ${DOKKU_LIB_ROOT}/plugins/$plugin
-  elif [ ! -d ${DOKKU_LIB_ROOT}/plugins/available/$plugin ]; then
-    mv ${DOKKU_LIB_ROOT}/plugins/$plugin ${DOKKU_LIB_ROOT}/plugins/available;
-  fi
-done
-
 echo "Enabling all core plugins"
 find ${DOKKU_LIB_ROOT}/core-plugins/available -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
   if [ ! -d ${DOKKU_LIB_ROOT}/plugins/available/$plugin ]; then

--- a/rpm/herokuish.postinst
+++ b/rpm/herokuish.postinst
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 set +o posix # rpm uses /bin/sh that forces bash in posix mode
 
-echo 'Starting docker'
-systemctl start docker
+main() {
+  echo 'Starting docker'
+  systemctl start docker
 
-sleep 5
+  sleep 5
 
-count=`sudo docker images | grep gliderlabs/herokuish | wc -l`
-if [ "$count" -ne 0 ]; then
-  echo 'Removing old herokuish image'
-  sudo docker rmi gliderlabs/herokuish
-fi
+  count=$(sudo docker images | grep -c gliderlabs/herokuish)
+  if [ "$count" -ne 0 ]; then
+    echo 'Removing old herokuish image'
+    sudo docker rmi gliderlabs/herokuish
+  fi
 
-echo 'Importing herokuish into docker (around 5 minutes)'
-sudo docker build -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null
+  echo 'Importing herokuish into docker (around 5 minutes)'
+  sudo docker build -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null
+}
+
+main

--- a/rpm/herokuish.postinst
+++ b/rpm/herokuish.postinst
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set +o posix # rpm uses /bin/sh that forces bash in posix mode
+
+echo 'Starting docker'
+systemctl start docker
+
+sleep 5
+
+count=`sudo docker images | grep gliderlabs/herokuish | wc -l`
+if [ "$count" -ne 0 ]; then
+  echo 'Removing old herokuish image'
+  sudo docker rmi gliderlabs/herokuish
+fi
+
+echo 'Importing herokuish into docker (around 5 minutes)'
+sudo docker build -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null

--- a/tests.mk
+++ b/tests.mk
@@ -71,7 +71,7 @@ lint:
 	# these are disabled due to their expansive existence in the codebase. we should clean it up though
 	# SC2034: VAR appears unused - https://github.com/koalaman/shellcheck/wiki/SC2034
 	@echo linting...
-	@$(QUIET) find . -not -path '*/\.*' -not -path './debian/*' -not -path './rpm/*' -type f | xargs file | grep text | awk -F ':' '{ print $$1 }' | xargs head -n1 | egrep -B1 "bash" | grep "==>" | awk '{ print $$2 }' | xargs shellcheck -e SC2034
+	@$(QUIET) find . -not -path '*/\.*' -not -path './debian/*' -type f | xargs file | grep text | awk -F ':' '{ print $$1 }' | xargs head -n1 | egrep -B1 "bash" | grep "==>" | awk '{ print $$2 }' | xargs shellcheck -e SC2034
 
 unit-tests:
 	@echo running unit tests...

--- a/tests.mk
+++ b/tests.mk
@@ -71,7 +71,7 @@ lint:
 	# these are disabled due to their expansive existence in the codebase. we should clean it up though
 	# SC2034: VAR appears unused - https://github.com/koalaman/shellcheck/wiki/SC2034
 	@echo linting...
-	@$(QUIET) find . -not -path '*/\.*' -not -path './debian/*' -type f | xargs file | grep text | awk -F ':' '{ print $$1 }' | xargs head -n1 | egrep -B1 "bash" | grep "==>" | awk '{ print $$2 }' | xargs shellcheck -e SC2034
+	@$(QUIET) find . -not -path '*/\.*' -not -path './debian/*' -not -path './rpm/*' -type f | xargs file | grep text | awk -F ':' '{ print $$1 }' | xargs head -n1 | egrep -B1 "bash" | grep "==>" | awk '{ print $$2 }' | xargs shellcheck -e SC2034
 
 unit-tests:
 	@echo running unit tests...


### PR DESCRIPTION
This pull request adds support for CentOS 7 and also builds RPM packages. Fixes #478.

Currently `rpm.mk` looks very similar to `deb.mk`, maybe this could be refactored in the future to reuse code more effectively.

Installation and testing using DigitalOcean with Centos 7.2:

```
package_cloud push ebeigarts/dokku/el/7 *.rpm

wget https://raw.githubusercontent.com/ebeigarts/dokku/centos/bootstrap.sh
sed -i "s/dokku\/dokku/ebeigarts\/dokku/" bootstrap.sh
DOKKU_TAG=v0.7.2 bash bootstrap.sh

ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''

dokku apps:create node-js-sample
dokku ssh-keys:add node-js-sample ~/.ssh/id_rsa.pub
dokku domains:add node-js-sample localhost

git clone https://github.com/heroku/node-js-sample
cd node-js-sample/
git remote add dokku dokku@localhost:node-js-sample
git push dokku master

curl http://localhost/ # => Hello World!
```