### PR TITLE
Fix `is_tag_force_available` bug when docker major version up

### DIFF
--- a/plugins/tags/functions
+++ b/plugins/tags/functions
@@ -9,7 +9,9 @@ is_tag_force_available() {
   PATCH_VERSION=$(echo "$CLIENT_VERSION_STRING" | awk '{split($0,a,"."); print a[3]}')
 
   # docker tag -f was dropped in 1.12.0
-  if [[ "$MAJOR_VERSION" -ge 1 ]] && [[ "$MINOR_VERSION" -ge 12 ]]; then
+  if [[ "$MAJOR_VERSION" -gt 1 ]]; then
+    return 1
+  elif [[ "$MAJOR_VERSION" -eq 1 ]] && [[ "$MINOR_VERSION" -ge 12 ]]; then
     return 1
   else
     return 0


### PR DESCRIPTION
before:

```
% bash -c 'PLUGIN_CORE_AVAILABLE_PATH=plugins; . plugins/tags/functions; get_docker_version() { echo 1.11.0; }; if is_tag_force_available; then echo true; else echo false; fi'
true
% bash -c 'PLUGIN_CORE_AVAILABLE_PATH=plugins; . plugins/tags/functions; get_docker_version() { echo 1.12.1; }; if is_tag_force_available; then echo true; else echo false; fi'
false
% bash -c 'PLUGIN_CORE_AVAILABLE_PATH=plugins; . plugins/tags/functions; get_docker_version() { echo 2.0.0; }; if is_tag_force_available; then echo true; else echo false; fi'
true
```

after:

```
% bash -c 'PLUGIN_CORE_AVAILABLE_PATH=plugins; . plugins/tags/functions; get_docker_version() { echo 1.11.0; }; if is_tag_force_available; then echo true; else echo false; fi'
true
% bash -c 'PLUGIN_CORE_AVAILABLE_PATH=plugins; . plugins/tags/functions; get_docker_version() { echo 1.12.1; }; if is_tag_force_available; then echo true; else echo false; fi'
false
% bash -c 'PLUGIN_CORE_AVAILABLE_PATH=plugins; . plugins/tags/functions; get_docker_version() { echo 2.0.0; }; if is_tag_force_available; then echo true; else echo false; fi'
false
```
