### PR TITLE
Document the logs plugin

### DIFF
--- a/docs/deployment/logs.md
+++ b/docs/deployment/logs.md
@@ -1,0 +1,38 @@
+# Log Management
+
+```
+logs <app>           # display recent log output
+```
+
+## Usage
+
+### Application Logs
+You can easily get logs of an application using the `logs` command:
+
+```shell
+dokku logs node-js-app
+```
+
+## Behavioral modifiers
+
+Dokku also supports certain command-line arguments that augment the `log` command's behavior.
+
+```
+-n, --num NUM        # the number of lines to display
+-p, --ps PS          # only display logs from the given process
+-t, --tail           # continually stream logs
+-q, --quiet          # display raw logs without colors, time and names
+```
+
+You can use these modifiers as
+
+```shell
+dokku logs <app> <modifiers>
+```
+
+For example,
+
+```shell
+dokku logs node-js-app -t -p web
+```
+will show logs continually from the web process.

--- a/docs/template.html
+++ b/docs/template.html
@@ -198,6 +198,7 @@
 
             <a href="/{{NAME}}/deployment/application-deployment/" class="list-group-item">Deploying an Application</a>
             <a href="/{{NAME}}/deployment/application-management/" class="list-group-item">Application Management</a>
+            <a href="/{{NAME}}/deployment/logs/" class="list-group-item">Application Logs</a>
             <a href="/{{NAME}}/deployment/remote-commands/" class="list-group-item">Remote Commands</a>
             <a href="/{{NAME}}/deployment/one-off-processes/" class="list-group-item">One Off Processes/Cron</a>
             <a href="/{{NAME}}/deployment/process-management/" class="list-group-item">Process Scaling</a>


### PR DESCRIPTION
Solves issue #2424.

> - [x] Link on the sidebar after [this](https://github.com/dokku/dokku/blob/master/docs/template.html#L200) line
> - [x] A section at the top with the help output for the log output like [this](https://github.com/dokku/dokku/blob/master/docs/deployment/application-management.md)
> - [x] A section on behavioral modifiers [like so](https://github.com/dokku/dokku/blob/master/docs/deployment/remote-commands.md#behavioral-modifiers)
> - [x] It needs to be a new document called `docs/deployment/logs.md`

Suggestions are welcome if further changes are required.