### PR TITLE
Fixes links to getting-started documentation

### DIFF
--- a/docs/configuration/dns.md
+++ b/docs/configuration/dns.md
@@ -70,7 +70,7 @@ If everything is working correctly, you should also be able to query for any oth
 
 If they all return your IP address, you have set DNS up properly for dokku.  You should also be able to `ssh root@myserver.example.tld` and access your server.
 
-Proceed with the setup instructions in the [installation documentation](/dokku/getting-started/installation/)
+Proceed with the setup instructions in the [installation documentation](/docs/getting-started/installation/)
 
 #### Using the root of your domain (myapp.example.tld)
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -17,7 +17,7 @@ While we do provide official packages for a variety of platforms, as our test su
 
 ## Local Test Execution
 
-- Setup Dokku in a [vagrant vm](/dokku/getting-started/install/vagrant)
+- Setup Dokku in a [vagrant vm](/docs/getting-started/install/vagrant)
 - Run the following to setup tests and execute them:
 
   ```shell

--- a/docs/getting-started/install/digitalocean.md
+++ b/docs/getting-started/install/digitalocean.md
@@ -8,4 +8,4 @@ If you would like to run Dokku on an IPv6 Digital Ocean Droplet, please consult 
 
 Once Dokku is installed, you can then proceed to the ip address or domain name associated with your server to complete the web-based installation.
 
-If you wish for a more unattended installation method, see [these](http://dokku.viewdocs.io/dokku/getting-started/install/debian/#unattended-installation) docs.
+If you wish for a more unattended installation method, see [these](http://dokku.viewdocs.io/docs/getting-started/install/debian/#unattended-installation) docs.

--- a/docs/getting-started/install/linode.md
+++ b/docs/getting-started/install/linode.md
@@ -38,4 +38,4 @@ __Warning__: These steps will delete *everything* on your Linode.
 
 9. Lastly, reboot the Linode.
 
-Once your server comes back online, you'll be running Ubuntu's default kernel. You can now follow Dokku's [normal installation instructions](/dokku/getting-started/installation/) and `bootstrap.sh` will take care of everything else.
+Once your server comes back online, you'll be running Ubuntu's default kernel. You can now follow Dokku's [normal installation instructions](/docs/getting-started/installation/) and `bootstrap.sh` will take care of everything else.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -40,18 +40,18 @@ Once you save your settings, the web admin will self-terminate and you should be
 
 For various reasons, certain hosting providers may have other steps that should be preferred to the above. If hosted on any of the following popular hosts, please follow the linked to instructions:
 
-- [Digital Ocean Installation Notes](/dokku/getting-started/install/digitalocean)
-- [DreamHost Cloud Installation Notes](/dokku/getting-started/install/dreamhost/)
-- [Linode Installation Notes](/dokku/getting-started/install/linode/)
-- [Microsoft Azure Installation Notes](/dokku/getting-started/install/azure/)
+- [Digital Ocean Installation Notes](/docs/getting-started/install/digitalocean)
+- [DreamHost Cloud Installation Notes](/docs/getting-started/install/dreamhost/)
+- [Linode Installation Notes](/docs/getting-started/install/linode/)
+- [Microsoft Azure Installation Notes](/docs/getting-started/install/azure/)
 
 As well, you may wish to customize your installation in some other fashion. or experiment with vagrant. The guides below should get you started:
 
-- [Debian Package Installation Notes](/dokku/getting-started/install/debian/)
-- [Vagrant Installation Notes](/dokku/getting-started/install/vagrant/)
-- [Advanced Install Customization](/dokku/getting-started/advanced-installation/)
+- [Debian Package Installation Notes](/docs/getting-started/install/debian/)
+- [Vagrant Installation Notes](/docs/getting-started/install/vagrant/)
+- [Advanced Install Customization](/docs/getting-started/advanced-installation/)
 
 ---
 
 - <sup>[1]: To check whether your system has an fqdn set, run `sudo hostname -f`</sup>
-- <sup>[2]: If your system has less than 1GB of memory, you can use [this workaround](/dokku/getting-started/advanced-installation/#vms-with-less-than-1gb-of-memory).</sup>
+- <sup>[2]: If your system has less than 1GB of memory, you can use [this workaround](/docs/getting-started/advanced-installation/#vms-with-less-than-1gb-of-memory).</sup>

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -1,6 +1,6 @@
 # Upgrading
 
-If your version of Dokku is pre 0.3.0 (check with `dokku version`), we recommend [a fresh install](/dokku/getting-started/installation/) on a new server.
+If your version of Dokku is pre 0.3.0 (check with `dokku version`), we recommend [a fresh install](/docs/getting-started/installation/) on a new server.
 
 ## Migration Guides
 


### PR DESCRIPTION
Links in edited files were pointing to `/dokku/getting-started`
instead of `/docs/getting-started`.  Files were updated to point
to the correct links.