### PR TITLE
Remove duplicate SSL hostnames

### DIFF
--- a/plugins/certs/functions
+++ b/plugins/certs/functions
@@ -26,6 +26,6 @@ get_ssl_hostnames() {
   else
     local SSL_HOSTNAMES=$SSL_HOSTNAME
   fi
-  echo -e "$SSL_HOSTNAMES"
+  echo -e "$SSL_HOSTNAMES" | sort -u
   return 0
 }


### PR DESCRIPTION
Ref dokku/dokku-letsencrypt#76

Certificates provided by Let's Encrypt can have the domain provided in
the Subject Name field listed again in the Subject Alt Name fields,
leading to the same domain getting listed twice by get_ssl_hostnames()
that in turn leads to a duplicate server_name field in the nginx
configuration.

This patch adds a sort -u to get_ssl_hostnames() to ensure that every 
SSL hostname will only be listed once.
