### PR TITLE
Non-zero exit code when ENV file missing/empty

### DIFF
--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -150,7 +150,8 @@ config_get() {
 
   config_create "$ENV_FILE"
   if [[ ! -s $ENV_FILE ]]; then
-    return 0
+    echo "ENV file empty or new."
+    return 1
   fi
 
   local KEY="${*: -1}"


### PR DESCRIPTION
This should fix #2447.