### PR TITLE
Fix dokku-redeploy systemd script to start only after docker

### DIFF
--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -30,7 +30,8 @@ if [[ $(systemctl 2> /dev/null) =~ -\.mount ]]; then
   cat<<EOF > /etc/systemd/system/dokku-redeploy.service
 [Unit]
 Description=Dokku app redeploy service
-After=docker.target
+Requires=docker.service
+After=docker.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
According to https://docs.docker.com/engine/admin/host_integration/#/systemd
it should use `After=docker.service` and it works at least on CentOS 7.