### PR TITLE
Fixing typo & broken link in docs

### DIFF
--- a/docs/advanced-usage/docker-options.md
+++ b/docs/advanced-usage/docker-options.md
@@ -77,4 +77,4 @@ The above example will result in the following options being passed to Docker du
 
 You may also include comments (lines beginning with a #) and blank lines in the DOCKER_OPTIONS file.
 
-More information on Docker options can be found here: http://docs.docker.io/en/latest/reference/run/ .
+More information on Docker options can be found here: https://docs.docker.com/engine/reference/commandline/run/.

--- a/docs/advanced-usage/docker-options.md
+++ b/docs/advanced-usage/docker-options.md
@@ -77,4 +77,4 @@ The above example will result in the following options being passed to Docker du
 
 You may also include comments (lines beginning with a #) and blank lines in the DOCKER_OPTIONS file.
 
-Move information on Docker options can be found here: http://docs.docker.io/en/latest/reference/run/ .
+More information on Docker options can be found here: http://docs.docker.io/en/latest/reference/run/ .


### PR DESCRIPTION
The last line of the docs on this page:

http://dokku.viewdocs.io/dokku/advanced-usage/docker-options/

Have a typo "Move" instead of "More" and a broken link. 