### PR TITLE
Docs: Bump font size

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,7 +1,6 @@
 body {
   font-family: 'Open Sans', sans-serif;
   font-weight: 400;
-  font-size: 12px;
   padding-bottom: 40px;
   color: #5a5a5a;
   -webkit-font-smoothing: antialiased;
@@ -21,7 +20,7 @@ h1 {
 .header .heading {
   color: #fff;
   font-size: 23px;
-  margin: 0;
+  margin: 7px 0 0 0;
   padding: 0 0 0 1em;
 }
 .header a {
@@ -67,7 +66,6 @@ h1 {
   color: #444;
   display: block;
   font-weight: 400;
-  font-size: 14px;
   margin: 0 20px;
   padding: 3px 0;
   text-align: center;
@@ -246,7 +244,6 @@ a.list-group-item {
   -webkit-font-smoothing: antialiased;
   box-sizing: border-box;
   color: rgb(71, 74, 84);
-  font-size: 14px;
   font-weight: normal;
   height: 20px;
   line-height: 20px;


### PR DESCRIPTION
Font size is a little small and makes it hard to read, this PR removes the font-size and lets the reset font-size take over making it more legible and re-aligns logo. 

Before: 
![](https://i.imgur.com/KFI2Qvi.png)

After:
![](https://i.imgur.com/kP9suOa.png)