### PR TITLE
Detect nginx versions that support HTTP/2 well

### DIFF
--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -148,7 +148,7 @@ get_custom_nginx_template() {
 }
 
 is_spdy_enabled() {
-  declare desc="detects whether the installed nginx version has spdy or http2 support"
+  declare desc="detects whether the installed nginx version has spdy support"
   local NGINX_VERSION="$1"
   local MAJOR_VERSION MINOR_VERSION PATCH_VERSION
   local HAS_SUPPORT=true
@@ -168,6 +168,33 @@ is_spdy_enabled() {
       HAS_SUPPORT=false
     elif [[ "$MINOR_VERSION" -ge "9" ]] && [[ "$PATCH_VERSION" -ge "5" ]]; then
       HAS_SUPPORT=false
+    fi
+  fi
+
+  echo $HAS_SUPPORT
+}
+
+is_http2_enabled() {
+  declare desc="detects whether the installed nginx version has http2 support"
+  local NGINX_VERSION="$1"
+  local MAJOR_VERSION MINOR_VERSION PATCH_VERSION
+  local HAS_SUPPORT=false
+
+  if ! which nginx > /dev/null 2>&1; then
+    echo $HAS_SUPPORT
+    return
+  fi
+
+  MAJOR_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[1]}')
+  MINOR_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[2]}')
+  PATCH_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[3]}')
+  if [[ "$MAJOR_VERSION" -ge "2" ]]; then
+    HAS_SUPPORT=true
+  elif [[ "$MAJOR_VERSION" -eq "1" ]]; then
+    if [[ "$MINOR_VERSION" -eq "11" ]] && [[ "$PATCH_VERSION" -ge "5" ]]; then
+      HAS_SUPPORT=true
+    elif [[ "$MINOR_VERSION" -ge "12" ]]; then
+      HAS_SUPPORT=true
     fi
   fi
 
@@ -250,6 +277,7 @@ nginx_build_config() {
 
     local NGINX_VERSION="$(nginx -v 2>&1 | cut -d'/' -f 2)"
     local SPDY_SUPPORTED="$(is_spdy_enabled "$NGINX_VERSION")"
+    local HTTP2_SUPPORTED="$(is_http2_enabled "$NGINX_VERSION")"
 
     eval "$(config_export app "$APP")"
     local SIGIL_PARAMS=(-f $NGINX_TEMPLATE APP="$APP" DOKKU_ROOT="$DOKKU_ROOT"
@@ -257,6 +285,7 @@ nginx_build_config() {
           DOKKU_APP_LISTENERS="$DOKKU_APP_LISTENERS"
           PASSED_LISTEN_IP_PORT="$PASSED_LISTEN_IP_PORT"
           SPDY_SUPPORTED="$SPDY_SUPPORTED"
+          HTTP2_SUPPORTED="$HTTP2_SUPPORTED"
           DOKKU_APP_LISTEN_PORT="$DOKKU_APP_LISTEN_PORT" DOKKU_APP_LISTEN_IP="$DOKKU_APP_LISTEN_IP"
           APP_SSL_PATH="$APP_SSL_PATH" SSL_INUSE="$SSL_INUSE" SSL_SERVER_NAME="$SSL_SERVER_NAME"
           NGINX_PORT="$NGINX_PORT" NGINX_SSL_PORT="$NGINX_SSL_PORT" RAW_TCP_PORTS="$RAW_TCP_PORTS"

--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -38,8 +38,8 @@ server {
 }
 {{ else if eq $scheme "https"}}
 server {
-  listen      [::]:{{ $listen_port }} ssl {{ if eq $.SPDY_SUPPORTED "true" }}spdy{{ else }}http2{{ end }};
-  listen      {{ $listen_port }} ssl {{ if eq $.SPDY_SUPPORTED "true" }}spdy{{ else }}http2{{ end }};
+  listen      [::]:{{ $listen_port }} ssl {{ if eq $.SPDY_SUPPORTED "true" }}spdy{{ else if eq $.HTTP2_SUPPORTED "true" }}http2{{ end }};
+  listen      {{ $listen_port }} ssl {{ if eq $.SPDY_SUPPORTED "true" }}spdy{{ else if eq $.HTTP2_SUPPORTED "true" }}http2{{ end }};
   {{ if $.SSL_SERVER_NAME }}server_name {{ $.SSL_SERVER_NAME }}; {{ end }}
   {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
   access_log  /var/log/nginx/{{ $.APP }}-access.log;


### PR DESCRIPTION
Certain versions of nginx have bugs that prevent HTTP/2 from properly responding to all clients, thus causing applications to be unavailable.

Closes #2435