### PR TITLE
wait for /var/lib/dokku and /home/dokku on boot

### DIFF
--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -31,6 +31,7 @@ if [[ $(systemctl 2> /dev/null) =~ -\.mount ]]; then
 [Unit]
 Description=Dokku app redeploy service
 Requires=docker.service
+RequiresMountsFor=$DOKKU_ROOT $DOKKU_LIB_ROOT
 After=docker.service
 
 [Service]


### PR DESCRIPTION
fixes containers not starting back up when /var/lib/dokku is mounted somewhere else