### PR TITLE
Add domains:set and domains:set-global commands

### DIFF
--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -3,14 +3,16 @@
 > New as of 0.3.10
 
 ```
+domains [<app>]                                # List domains
 domains:add <app> <domain> [<domain> ...]      # Add domains to app
 domains:add-global <domain> [<domain> ...]     # Add global domain names
-domains [<app>]                                # List domains
 domains:clear <app>                            # Clear all domains for app
 domains:disable <app>                          # Disable VHOST support
 domains:enable <app>                           # Enable VHOST support
 domains:remove <app> <domain> [<domain> ...]   # Remove domains from app
 domains:remove-global <domain> [<domain> ...]  # Remove global domain names
+domains:set <app> <domain> [<domain> ...]      # Set domains for app
+domains:set-global <domain> [<domain> ...]     # Set global domain names
 ```
 
 > Adding a domain before deploying an application will result in port mappings being set. This may cause issues for applications that use non-standard ports, as those will not be automatically detected. Please refer to the [proxy documentation](/dokku/advanced-usage/proxy-management/) for information as to how to reconfigure the mappings.
@@ -68,6 +70,9 @@ dokku domains:clear myapp
 
 # remove a custom domain from app
 dokku domains:remove myapp example.com
+
+# set all custom domains for app
+dokku domains:set myapp example.com example.org
 ```
 
 ## Default site

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -467,7 +467,7 @@ curl "http://httpstat.us/200"
 ### `post-domains-update`
 
 - Description: Allows you to run commands once the domain for an application has been updated. It also sends in the command that has been used. This can be "add", "clear" or "remove". The third argument will be the optional list of domains
-- Invoked by: `dokku domains:add`, `dokku domains:clear`, `dokku domains:remove`
+- Invoked by: `dokku domains:add`, `dokku domains:clear`, `dokku domains:remove`, `dokku domains:set`
 - Arguments: `$APP` `action name` `domains`
 - Example:
 

--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -15,6 +15,8 @@ case "$1" in
     domains:enable <app>, Enable VHOST support
     domains:remove <app> <domain> [<domain> ...], Remove domains from app
     domains:remove-global <domain> [<domain> ...], Remove global domain names
+    domains:set <app> <domain> [<domain> ...], Set domains for app
+    domains:set-global <domain> [<domain> ...], Set global domain names
 help_content
     }
 

--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -85,7 +85,7 @@ domains_add() {
     fi
   done
 
-  if [[ "$(is_app_vhost_enabled "$APP")" == "false" ]];then
+  if [[ "$(is_app_vhost_enabled "$APP")" == "false" ]]; then
     domains_enable "$APP" --no-restart
   fi
 
@@ -105,12 +105,34 @@ domains_remove() {
   plugn trigger post-domains-update "$APP" "remove" "$@"
 }
 
+domains_set() {
+  declare desc="set list of domains for app"
+  verify_app_name "$1"
+  local APP="$1"; local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
+
+  shift 1
+  for DOMAIN in "$@"; do
+    if ! (is_valid_hostname "$DOMAIN"); then
+      dokku_log_fail "$DOMAIN is invalid. exiting..."
+    fi
+  done
+
+  echo "$*" | tr " " "\n" > "$APP_VHOST_PATH"
+  dokku_log_info1 "Set $* for $APP"
+
+  if [[ "$(is_app_vhost_enabled "$APP")" == "false" ]]; then
+    domains_enable "$APP" --no-restart
+  fi
+
+  plugn trigger post-domains-update "$APP" "set" "$@"
+}
+
 domains_disable() {
   declare desc="disable domains/VHOST support"
   verify_app_name "$1"
   local APP="$1"; local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
 
-  if [[ "$(is_app_vhost_enabled "$APP")" == "true" ]];then
+  if [[ "$(is_app_vhost_enabled "$APP")" == "true" ]]; then
     disable_app_vhost "$APP"
   else
     dokku_log_info1 "domains (VHOST) support is already disabled for app ($APP)"
@@ -123,7 +145,7 @@ domains_enable() {
   local APP="$1"; local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
   local DEFAULT_VHOSTS="$(get_default_vhosts "$APP")"
 
-  if [[ "$(is_app_vhost_enabled "$APP")" == "false" ]];then
+  if [[ "$(is_app_vhost_enabled "$APP")" == "false" ]]; then
     if [[ -n "$DEFAULT_VHOSTS" ]]; then
       echo "$DEFAULT_VHOSTS" > "$APP_VHOST_PATH"
     fi
@@ -162,4 +184,18 @@ domains_remove_global() {
     sed -i "\|^$DOMAIN\$|d" "$GLOBAL_VHOST_PATH"
     dokku_log_info1 "Removed $DOMAIN"
   done
+}
+
+domains_set_global() {
+  declare desc="set list of global domains"
+  local GLOBAL_VHOST_PATH="$DOKKU_ROOT/VHOST"
+
+  for DOMAIN in "$@"; do
+    if ! (is_valid_hostname "$DOMAIN"); then
+      dokku_log_fail "$DOMAIN is invalid. exiting..."
+    fi
+  done
+
+  echo "$*" | tr " " "\n" > "$GLOBAL_VHOST_PATH"
+  dokku_log_info1 "Set $*"
 }

--- a/plugins/domains/subcommands/set
+++ b/plugins/domains/subcommands/set
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/domains/functions"
+
+domains_set_cmd() {
+  declare desc="set domains for app via command line"
+  local cmd="domains:set"
+  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
+  [[ -z $3 ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 $2 <domain> [<domain> ...]"
+
+  shift 1
+  domains_set "$@"
+}
+
+domains_set_cmd "$@"

--- a/plugins/domains/subcommands/set-global
+++ b/plugins/domains/subcommands/set-global
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/domains/functions"
+
+domains_set_global_cmd() {
+  declare desc="set global domain names via command line"
+  local cmd="domains:set-global"
+  [[ -z $2 ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 <domain> [<domain> ...]"
+
+  shift 1
+  domains_set_global "$@"
+}
+
+domains_set_global_cmd "$@"

--- a/tests/unit/20_domains.bats
+++ b/tests/unit/20_domains.bats
@@ -146,6 +146,27 @@ teardown() {
   refute_line *.dokku.me
 }
 
+@test "(domains) domains:set" {
+  run dokku domains:add $TEST_APP www.test.app.dokku.me test.app.dokku.me
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run dokku domains:set $TEST_APP 2.app.dokku.me a--domain.with--hyphens
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run dokku domains $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  refute_line www.test.app.dokku.me
+  refute_line test.app.dokku.me
+  assert_line 2.app.dokku.me
+  assert_line a--domain.with--hyphens
+}
+
 @test "(domains) domains:clear" {
   run dokku domains:add $TEST_APP test.app.dokku.me
   echo "output: "$output
@@ -217,13 +238,34 @@ teardown() {
   assert_success
 
   dokku domains:setup $TEST_APP
-  run bash -c "dokku domains $TEST_APP | grep -q ${TEST_APP}.global1.dokku.me"
+
+  run dokku domains $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  assert_line ${TEST_APP}.global1.dokku.me
+  assert_line ${TEST_APP}.global2.dokku.me
+}
+
+@test "(domains) domains:set-global" {
+  run dokku domains:add-global global1.dokku.me global2.dokku.me
   echo "output: "$output
   echo "status: "$status
   assert_success
 
-  run bash -c "dokku domains $TEST_APP | grep -q ${TEST_APP}.global2.dokku.me"
+  run dokku domains:set-global global3.dokku.me global4.dokku.me
   echo "output: "$output
   echo "status: "$status
   assert_success
+
+  dokku domains:setup $TEST_APP
+
+  run dokku domains $TEST_APP
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  refute_line ${TEST_APP}.global1.dokku.me
+  refute_line ${TEST_APP}.global2.dokku.me
+  assert_line ${TEST_APP}.global3.dokku.me
+  assert_line ${TEST_APP}.global4.dokku.me
 }


### PR DESCRIPTION
As discussed in #2410, this adds `domains:set` and `domains:set-global`, along with tests and documentation updates.

I am indeed missing this feature. 90% of the time we install the new app and we immediately get rid of *app.dokku.me* domain name in favour of *app.com* or *staging.app.com*. Currently that involves running three commands every time instead of one.