### PR TITLE
Fix for #2474

### DIFF
--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -272,7 +272,14 @@ nginx_build_config() {
       else
         local SSL_VHOSTS=$(< "$DOKKU_ROOT/HOSTNAME")
       fi
-      local SSL_SERVER_NAME=$(echo "$SSL_VHOSTS" | xargs)
+      local SSL_SERVER_NAME
+      local host
+      for host in $SSL_VHOSTS; do
+        # SSL_SERVER_NAME should only contain items not in NOSSL_SERVER_NAME
+        if [[ ! $NOSSL_SERVER_NAME =~ (^|[[:space:]])$host($|[[:space:]]) ]]; then
+          SSL_SERVER_NAME="${host}${SSL_SERVER_NAME:+ $SSL_SERVER_NAME}"
+        fi
+      done
     fi
 
     local NGINX_VERSION="$(nginx -v 2>&1 | cut -d'/' -f 2)"


### PR DESCRIPTION
I'm seeing similar issues to the one @mirkogeest cited in #2474 and I suspect PR #2464 won't fix it.

From the looks of it, it's an interaction in [nginx-vhosts/nginx.conf.sigil:43-44](https://github.com/dokku/dokku/blob/master/plugins/nginx-vhosts/templates/nginx.conf.sigil#L43-L44) where there are duplicate entries among `SSL_SERVER_NAME` and  `NOSSL_SERVER_NAME`.

If I'm interpreting the intent of `nginx.conf.sigil` correctly, `SSL_SERVER_NAME` should contain entries found in the ssl cert, but not _already_ in the `NOSSL_SERVER_NAME` list. That will avoid the dups in the `nginx.conf` and kill the nginx warnings cited in the bug.

This fix assumes bash-4.x and is a little ugly, but it is confirmed to work.

I'm happy to update this PR if anybody has guidance for:
- How `dokku` would otherwise-stylistically do a `for x in b: { if x not in a, then c.append(x) }`
- How I might test this corner-case.