### PR TITLE
Docs: Fix #2521

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Docker powered mini-Heroku. The smallest PaaS implementation you've ever seen.
 
 To install the latest stable release, you can run the following commands as a user that has access to `sudo`:
 
-    wget https://raw.githubusercontent.com/dokku/dokku/v0.7.2/bootstrap.sh
+    wget https://raw.githubusercontent.com/dokku/dokku/v0.7.2/bootstrap.sh;
     sudo DOKKU_TAG=v0.7.2 bash bootstrap.sh
 
 You can then proceed to the ip address or domain name associated with your server to complete the web-based installation.

--- a/docs/getting-started/advanced-installation.md
+++ b/docs/getting-started/advanced-installation.md
@@ -4,7 +4,7 @@ You can always install Dokku straight from the latest - potentially unstable - m
 
 ```shell
 # using a branch results in installing from source
-wget https://raw.githubusercontent.com/dokku/dokku/master/bootstrap.sh
+wget https://raw.githubusercontent.com/dokku/dokku/master/bootstrap.sh;
 sudo DOKKU_BRANCH=master bash bootstrap.sh
 ```
 
@@ -29,7 +29,7 @@ sudo SSHCOMMAND_URL=https://raw.githubusercontent.com/yourusername/sshcommand/ma
 The bootstrap script allows the Dokku repository URL to be overridden to bootstrap a host from your own clone of Dokku using the `DOKKU_REPO` environment variable. Example:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/master/bootstrap.sh
+wget https://raw.githubusercontent.com/dokku/dokku/master/bootstrap.sh;
 chmod +x bootstrap.sh
 sudo DOKKU_REPO=https://github.com/yourusername/dokku.git DOKKU_BRANCH=master ./bootstrap.sh
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,7 +21,7 @@ To install the latest stable version of dokku, you can run the following shell c
 
 ```shell
 # for debian systems, installs Dokku via apt-get
-wget https://raw.githubusercontent.com/dokku/dokku/v0.7.2/bootstrap.sh
+wget https://raw.githubusercontent.com/dokku/dokku/v0.7.2/bootstrap.sh;
 sudo DOKKU_TAG=v0.7.2 bash bootstrap.sh
 ```
 


### PR DESCRIPTION
Adds semicolon after parts in the documentation where someone can copy and paste both lines instead of them individually.

This fixes #2521 