### PR TITLE
Plugin-triggers typo: dokkku -> dokku

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -27,7 +27,7 @@ There are a number of plugin-related triggers. These can be optionally implement
 
 The following plugin triggers describe those available to a Dokku installation. As well, there is an example for each trigger that you can use as templates for your own plugin development.
 
-> The example plugin trigger code is not guaranteed to be implemented as in within dokkku, and are merely simplified examples. Please look at the Dokku source for larger, more in-depth examples.
+> The example plugin trigger code is not guaranteed to be implemented as in within dokku, and are merely simplified examples. Please look at the Dokku source for larger, more in-depth examples.
 
 ### `post-config-update`
 


### PR DESCRIPTION
Just fixing a small typo.