### PR TITLE
actually fail deploy when app.json script fails

### DIFF
--- a/plugins/00_dokku-standard/exec-app-json-scripts
+++ b/plugins/00_dokku-standard/exec-app-json-scripts
@@ -42,7 +42,7 @@ execute_script() {
     COMMAND+="   rm -rf /tmp/cache ; "
     COMMAND+="   ln -sf /cache /tmp/cache ; "
     COMMAND+=" fi ; "
-    COMMAND+=" $SCRIPT_CMD ;"
+    COMMAND+=" $SCRIPT_CMD || exit 1;"
     COMMAND+=" if [[ -d '/cache' ]]; then "
     COMMAND+="   echo removing installation cache... ; "
     COMMAND+="   rm -f /tmp/cache ; "


### PR DESCRIPTION
Found this bug in our production env. Our asset build was failing but the deployment did not. This makes sure that doesn't happen anymore. I would have expected `set -eo pipefail` to handle this but I think that expectation doesn't hold up when you're doing a massive one-liner like we are here.

Further refactor could be done to do this in an actual script file copied to the image and then executed. This should yield the expected `set -eo pipefail` behavior.