### PR TITLE
Typo which prevented `docker-options` to pass args

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -534,7 +534,7 @@ dokku_deploy_cmd() {
   local DOKKU_SCALE_FILE="$DOKKU_ROOT/$APP/DOKKU_SCALE"
   local oldids=$(get_app_container_ids "$APP")
 
-  local DOKKU_DEFAULT_DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG")
+  local DOKKU_DEFAULT_DOCKER_ARGS=$(: | plugin trigger docker-args-deploy "$APP" "$IMAGE_TAG")
   local DOKKU_IS_APP_PROXY_ENABLED="$(is_app_proxy_enabled "$APP")"
   local DOKKU_DOCKER_STOP_TIMEOUT="$(config_get "$APP" DOKKU_DOCKER_STOP_TIMEOUT || true)"
   [[ $DOKKU_DOCKER_STOP_TIMEOUT ]] && DOCKER_STOP_TIME_ARG="--time=${DOKKU_DOCKER_STOP_TIMEOUT}"


### PR DESCRIPTION
Actually, `docker-options` is not working as intended. All new options passed are ignored.

Most likely due to this `typo` which prevent the `docker-options` plugin to pass the args.