### PR TITLE
Skip failing applications when running ps:restore on boot

### DIFF
--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -11,7 +11,11 @@ ps_restore_cmd() {
     local DOKKU_APP_RESTORE=$(config_get "$app" DOKKU_APP_RESTORE || true)
     if [[ $DOKKU_APP_RESTORE != 0 ]]; then
       echo "Restoring app $app ..."
-      ps_start "$app"
+      if ps_start "$app"; then
+        continue
+      fi
+
+      dokku_log_warn "dokku ps:restore ${app} failed"
     fi
   done
 }

--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -7,6 +7,12 @@ source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 ps_restore_cmd() {
   declare desc="starts all apps with DOKKU_APP_RESTORE not set to 0 via command line"
   local cmd="ps:restore"
+
+  if which parallel > /dev/null 2>&1; then
+    dokku_apps | parallel dokku ps:start
+    return
+  fi
+
   for app in $(dokku_apps); do
     local DOKKU_APP_RESTORE=$(config_get "$app" DOKKU_APP_RESTORE || true)
     if [[ $DOKKU_APP_RESTORE != 0 ]]; then

--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -20,7 +20,6 @@ ps_restore_cmd() {
       if ps_start "$app"; then
         continue
       fi
-
       dokku_log_warn "dokku ps:restore ${app} failed"
     fi
   done


### PR DESCRIPTION
Also adds support for using parallel for restoring apps.

@ebeigarts mind checking this out to see if it works for you? My limited testing shows that it should work.

@michaelshobbs had to use the `dokku` bin directly instead of `ps_start` as `parallel` starts it's own shell and doesn't have access to all functions (exporting them all would be a pita).

Closes #2463