### PR TITLE
Spelling

### DIFF
--- a/docs/advanced-usage/repository-management.md
+++ b/docs/advanced-usage/repository-management.md
@@ -3,7 +3,7 @@
 > New as of 0.6.0
 
 ```
-repo:gc <app>                            # Runs 'git gc --agressive' against the application's repo
+repo:gc <app>                            # Runs 'git gc --aggressive' against the application's repo
 repo:purge-cache <app>                   # Deletes the contents of the build cache stored in the repository
 ```
 
@@ -13,7 +13,7 @@ The repository plugin is meant to allow users to perform management commands aga
 
 ### Git Garbage Collection
 
-This will run a git gc --agressive against the applications repo. This is performed on the Dokku host, and not within an application container.
+This will run a git gc --aggressive against the applications repo. This is performed on the Dokku host, and not within an application container.
 
 ```shell
 dokku repo:gc node-js-app

--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -50,7 +50,7 @@ Note that with the default nginx template, requests will be redirected to the `h
 
 The `certs:generate` command will walk you through the correct `openssl` commands to create a key, csr and a self-signed cert for a given app/domain. We automatically put the self-signed cert in place as well as add the specified domain to the application configuration.
 
-If you decide to obtain a CA signed certficate, you can import that certificate using the aformentioned `dokku certs:add` command.
+If you decide to obtain a CA signed certificate, you can import that certificate using the aforementioned `dokku certs:add` command.
 
 ### Certificate information
 

--- a/docs/deployment/process-management.md
+++ b/docs/deployment/process-management.md
@@ -31,7 +31,7 @@ dokku ps node-js-app
 
 ### Rebuilding applications
 
-There are some Dokku commands which will not automatically rebuild an application's environment, or which can be told to skip a rebuild.  For instance, you may wish to run mulitple `config:set` commands without a restart so as to speed up configuration. In these cases, you can ultimately trigger an application rebuild using `ps:rebuild`
+There are some Dokku commands which will not automatically rebuild an application's environment, or which can be told to skip a rebuild.  For instance, you may wish to run multiple `config:set` commands without a restart so as to speed up configuration. In these cases, you can ultimately trigger an application rebuild using `ps:rebuild`
 
 ```shell
 dokku ps:rebuild node-js-app
@@ -92,7 +92,7 @@ dokku ps:scale node-js-app
 
 ### Stopping applications
 
-Deployed applications can be stopped using the `ps:stop` command. This turns all running containers for an application, and will result in a `502 Bad Gateway` reponse for the default nginx proxy implementation.
+Deployed applications can be stopped using the `ps:stop` command. This turns all running containers for an application, and will result in a `502 Bad Gateway` response for the default nginx proxy implementation.
 
 ```shell
 dokku ps:stop node-js-app

--- a/plugins/checks/commands
+++ b/plugins/checks/commands
@@ -16,7 +16,7 @@ help_content
     }
 
     if [[ $1 = "checks:help" ]] ; then
-        echo -e 'Usage: dokku checks[:COMAND]'
+        echo -e 'Usage: dokku checks[:COMMAND]'
         echo ''
         echo 'Manage zero-downtime settings.'
         echo ''

--- a/plugins/repo/commands
+++ b/plugins/repo/commands
@@ -7,7 +7,7 @@ case "$1" in
     help_content_func () {
       declare desc="return repo plugin help content"
       cat<<help_content
-    repo:gc <app>, Runs 'git gc --agressive' against the application's repo
+    repo:gc <app>, Runs 'git gc --aggressive' against the application's repo
     repo:purge-cache <app>, Deletes the contents of the build cache stored in the repository
 help_content
     }

--- a/plugins/repo/subcommands/gc
+++ b/plugins/repo/subcommands/gc
@@ -3,7 +3,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 
 repo_gc() {
-  declare desc="runs 'git gc --agressive' against the application's repo"
+  declare desc="runs 'git gc --aggressive' against the application's repo"
   local cmd="repo:gc"
   [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
   local APP="$2"; local APP_DIR="$DOKKU_ROOT/$APP"

--- a/tests/apps/multi/static/styles/main.scss
+++ b/tests/apps/multi/static/styles/main.scss
@@ -1,4 +1,4 @@
-// override scss variables within bootsrap by delaring them
+// override scss variables within bootsrap by declaring them
 // before importing bootstrap
 
 $brand-primary:         #428bca !default;


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer )

plus: according to 'man git-gc' it's 'git gc --aggressive' not 'git gc --agressive'