### PR TITLE
Behind-proxy support for herokuish install

### DIFF
--- a/deb.mk
+++ b/deb.mk
@@ -92,7 +92,7 @@ deb-herokuish:
 	@echo "  sudo docker rmi gliderlabs/herokuish" >> /tmp/tmp/post-install
 	@echo "fi" >> /tmp/tmp/post-install
 	@echo "echo 'Importing herokuish into docker (around 5 minutes)'" >> /tmp/tmp/post-install
-	@echo "sudo docker build -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null" >> /tmp/tmp/post-install
+	@echo "sudo docker build --build-args http_proxy=$http_proxy --build-args https_proxy=$https_proxy -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null" >> /tmp/tmp/post-install
 
 	@echo "-> Cloning repository"
 	git clone -q "https://github.com/$(HEROKUISH_REPO_NAME).git" --branch "v$(HEROKUISH_VERSION)" /tmp/tmp/herokuish > /dev/null

--- a/deb.mk
+++ b/deb.mk
@@ -92,7 +92,10 @@ deb-herokuish:
 	@echo "  sudo docker rmi gliderlabs/herokuish" >> /tmp/tmp/post-install
 	@echo "fi" >> /tmp/tmp/post-install
 	@echo "echo 'Importing herokuish into docker (around 5 minutes)'" >> /tmp/tmp/post-install
-	@echo "sudo docker build --build-args http_proxy=$http_proxy --build-args https_proxy=$https_proxy -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null" >> /tmp/tmp/post-install
+	@echo 'if [ ! -z ${http_proxy+x} ]; then BUILDARGS="--build-args http_proxy=$http_proxy"; fi' >> /tmp/tmp/post-install
+	@echo 'if [ ! -z ${https_proxy+x} ]; then BUILDARGS="$BUILDARGS --build-args https_proxy=$https_proxy"; fi' >> /tmp/tmp/post-install
+	@echo 'if [ ! -z ${BUILDARGS+x} ]; then echo Adding proxy settings to docker build: $BUILDARGS; fi' >> /tmp/tmp/post-install
+	@echo "sudo docker build $BUILDARGS -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null" >> /tmp/tmp/post-install
 
 	@echo "-> Cloning repository"
 	git clone -q "https://github.com/$(HEROKUISH_REPO_NAME).git" --branch "v$(HEROKUISH_VERSION)" /tmp/tmp/herokuish > /dev/null

--- a/deb.mk
+++ b/deb.mk
@@ -92,10 +92,10 @@ deb-herokuish:
 	@echo "  sudo docker rmi gliderlabs/herokuish" >> /tmp/tmp/post-install
 	@echo "fi" >> /tmp/tmp/post-install
 	@echo "echo 'Importing herokuish into docker (around 5 minutes)'" >> /tmp/tmp/post-install
-	@echo 'if [ ! -z ${http_proxy+x} ]; then BUILDARGS="--build-args http_proxy=$http_proxy"; fi' >> /tmp/tmp/post-install
-	@echo 'if [ ! -z ${https_proxy+x} ]; then BUILDARGS="$BUILDARGS --build-args https_proxy=$https_proxy"; fi' >> /tmp/tmp/post-install
-	@echo 'if [ ! -z ${BUILDARGS+x} ]; then echo Adding proxy settings to docker build: $BUILDARGS; fi' >> /tmp/tmp/post-install
-	@echo "sudo docker build $BUILDARGS -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null" >> /tmp/tmp/post-install
+	@echo 'if [[ ! -z ${http_proxy+x} ]]; then BUILDARGS="--build-args http_proxy=$http_proxy"; fi' >> /tmp/tmp/post-install
+	@echo 'if [[ ! -z ${https_proxy+x} ]]; then BUILDARGS="$BUILDARGS --build-args https_proxy=$https_proxy"; fi' >> /tmp/tmp/post-install
+	@echo 'if [[ ! -z ${BUILDARGS+x} ]]; then echo Adding proxy settings to docker build: $BUILDARGS; fi' >> /tmp/tmp/post-install
+	@echo 'sudo docker build $BUILDARGS -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null' >> /tmp/tmp/post-install
 
 	@echo "-> Cloning repository"
 	git clone -q "https://github.com/$(HEROKUISH_REPO_NAME).git" --branch "v$(HEROKUISH_VERSION)" /tmp/tmp/herokuish > /dev/null


### PR DESCRIPTION
Inject http proxy envvars to docker build command to allow package installation behind corporate proxies.

These envvars (http_proxy and https_proxy) are standard, and usually configured via system-wide /etc/profile.d files.

In cases where these envvars are not configured, the additions appear to be mute and non-destructive.