### PR TITLE
Clarify when the `~/.ssh/config` settings need to match `vagrant ssh-config output`

### DIFF
--- a/docs/getting-started/install/vagrant.md
+++ b/docs/getting-started/install/vagrant.md
@@ -21,12 +21,14 @@
     cd path/to/dokku
     vagrant up
     ```
-- Setup SSH Config in `~/.ssh/config`. The port listed here is usually correct, though you may want to verify that it is the same as the one listed in the output of `vagrant ssh-config dokku`
+- Setup SSH Config in `~/.ssh/config`.
 
     ```ini
     Host dokku.me
         Port 22
     ```
+
+    > For users that have customized the IP address of their VM - either in a custom `Vagrantfile` or via the `DOKKU_IP` environment variable - and are not using `10.0.0.2` for the Vagrant IP, you'll need to instead use the output of `vagrant ssh-config dokku` for your ~/.ssh/config entry. 
 
 - Copy your SSH key via `cat ~/.ssh/id_rsa.pub | pbcopy` and paste it into the dokku-installer at http://dokku.me . Change the `Hostname` field on the Dokku Setup screen to your domain and then check the box that says `Use virtualhost naming`. Then click *Finish Setup* to install your key. You'll be directed to application deployment instructions from here.
 


### PR DESCRIPTION
Closes #2466

[ci skip]