### PR TITLE
use temporary file for `ssh-keygen -lf` commands

### DIFF
--- a/plugins/ssh-keys/functions
+++ b/plugins/ssh-keys/functions
@@ -13,10 +13,12 @@ list_ssh_keys() {
 verify_ssh_key_file() {
   declare desc="Test that public key is valid"
   [[ -s ${DOKKU_ROOT}/.ssh/authorized_keys ]] || dokku_log_fail "No public keys found."
-  local key line=0
+  local key line=0 tmp_key_file="$(mktemp)"
+  trap 'rm -rf "$tmp_key_file" > /dev/null' RETURN INT TERM EXIT
   while read -r key; do
     line=$((line + 1))
-    ssh-keygen -l -f /dev/stdin <<<"$key" &>/dev/null || dokku_log_fail "${DOKKU_ROOT}/.ssh/authorized_keys line $line failed ssh-keygen check."
+    echo "$key" >"$tmp_key_file"
+    ssh-keygen -l -f "$tmp_key_file" &>/dev/null || dokku_log_fail "${DOKKU_ROOT}/.ssh/authorized_keys line $line failed ssh-keygen check."
   done <"${DOKKU_ROOT}/.ssh/authorized_keys"
 }
 

--- a/plugins/ssh-keys/subcommands/add
+++ b/plugins/ssh-keys/subcommands/add
@@ -8,14 +8,16 @@ add_keys() {
   declare desc="add a new key via sshcommand"
   local cmd="ssh-keys:add"
   shift
-  local name="$1" key_file="$2" key_contents key_from_pipe
+  local name="$1" key_file="$2" key_contents key_from_pipe tmp_key_file
   [[ -p /dev/stdin ]] && read -r key_from_pipe
   if [[ -n "$key_from_pipe" ]]; then
-    ssh-keygen -lf /dev/stdin <<<"$key_from_pipe" &>/dev/null || dokku_log_fail "Key piped in is not a valid ssh public key"
+    tmp_key_file="$(mktemp)" && echo "$key_from_pipe" >"$tmp_key_file"
+    trap 'rm -rf "$tmp_key_file" > /dev/null' RETURN INT TERM EXIT
     key_contents="$key_from_pipe"
+    ssh-keygen -lf "$tmp_key_file" &>/dev/null || dokku_log_fail "Key piped in is not a valid ssh public key"
   elif [[ -n "$key_file" ]]; then
     key_contents="$(cat "$key_file")"
-    ssh-keygen -lf /dev/stdin <<<"$key_contents" &>/dev/null || dokku_log_fail "Key from file is not a valid ssh public key"
+    ssh-keygen -lf "$key_file" &>/dev/null || dokku_log_fail "Key from file is not a valid ssh public key"
   fi
   [[ -n "$name" && -n "$key_contents" ]] || dokku_log_fail "Two arguments are required if not piping, ie: dokku ssh-keys:add <NAME> <KEY_FILE>"
   local count="$(wc -l <<<"$key_contents")"


### PR DESCRIPTION
See also #1076. Fails lint SC2064 (https://circleci.com/gh/sebble/dokku/2) deliberately.

Early expansion of the `$tmp_key_file` is required for cleanup to work outside of the scope of this function.