### PR TITLE
Implement certs:report

### DIFF
--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -9,6 +9,7 @@ certs:add <app> CRT KEY                  # Add an ssl endpoint to an app. Can al
 certs:generate <app> DOMAIN              # Generate a key and certificate signing request (and self-signed certificate)
 certs:info <app>                         # Show certificate information for an ssl endpoint.
 certs:remove <app>                       # Remove an SSL Endpoint from an app.
+certs:report [<app>] [<flag>]            # Displays an ssl report for one or more apps
 certs:update <app> CRT KEY               # Update an SSL Endpoint on an app. Can also import from a tarball on stdin
 ```
 
@@ -76,6 +77,60 @@ dokku certs:info node-js-app
 
 The `certs:remove` command only works on app-specific certificates. It will `rm` the app-specific tls directory, rebuild the nginx configuration, and reload nginx.
 
+### Displaying ssl reports about an app
+
+> New as of 0.8.1
+
+You can get a report about the apps ssl status using the `certs:report` command:
+
+```shell
+dokku certs:report
+```
+
+```
+=====> node-js-sample
+       Ssl dir:             /home/dokku/node-js-sample/tls
+       Ssl enabled:         true
+       Ssl hostnames:       *.node-js-sample.org node-js-sample.org
+       Ssl expires at:      Oct  5 23:59:59 2019 GMT
+       Ssl issuer:          C=GB, ST=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO RSA Domain Validation Secure Server CA
+       Ssl starts at:       Oct  5 00:00:00 2016 GMT
+       Ssl subject:         OU=Domain Control Validated; OU=PositiveSSL Wildcard; CN=*.node-js-sample.org
+       Ssl verified:        self signed.
+=====> python-sample
+       Ssl dir:             /home/dokku/python-sample/tls
+       Ssl enabled:         false
+       Ssl hostnames:
+       Ssl expires at:
+       Ssl issuer:
+       Ssl starts at:
+       Ssl subject:
+       Ssl verified:
+```
+
+You can run the command for a specific app also.
+
+```shell
+dokku certs:report node-js-sample
+```
+
+```
+=====> node-js-sample ssl information
+       Ssl dir:             /home/dokku/node-js-sample/tls
+       Ssl enabled:         true
+       Ssl hostnames:       *.example.org example.org
+       Ssl expires at:      Oct  5 23:59:59 2019 GMT
+       Ssl issuer:          C=GB, ST=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO RSA Domain Validation Secure Server CA
+       Ssl starts at:       Oct  5 00:00:00 2016 GMT
+       Ssl subject:         OU=Domain Control Validated; OU=PositiveSSL Wildcard; CN=*.example.org
+       Ssl verified:        self signed.
+```
+
+You can pass flags which will output only the value of the specific information you want. For example:
+
+```shell
+dokku certs:report node-js-sample --ssl-enabled
+```
 
 ## HSTS Header
 

--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -7,7 +7,6 @@ Dokku supports SSL/TLS certificate inspection and CSR/Self-signed certificate ge
 ```
 certs:add <app> CRT KEY                  # Add an ssl endpoint to an app. Can also import from a tarball on stdin.
 certs:generate <app> DOMAIN              # Generate a key and certificate signing request (and self-signed certificate)
-certs:info <app>                         # Show certificate information for an ssl endpoint.
 certs:remove <app>                       # Remove an SSL Endpoint from an app.
 certs:report [<app>] [<flag>]            # Displays an ssl report for one or more apps
 certs:update <app> CRT KEY               # Update an SSL Endpoint on an app. Can also import from a tarball on stdin
@@ -53,31 +52,11 @@ The `certs:generate` command will walk you through the correct `openssl` command
 
 If you decide to obtain a CA signed certificate, you can import that certificate using the aforementioned `dokku certs:add` command.
 
-### Certificate information
-
-The `certs:info` command will simply inspect the install SSL cert and print out details. NOTE: The server-wide certificate will be inspect if installed and no app-specific certificate exists.
-
-```shell
-dokku certs:info node-js-app
-```
-
-```
------> Fetching SSL Endpoint info for node-js-app...
------> Certificate details:
-=====> Common Name(s):
-=====>    test.dokku.me
-=====> Expires At: Aug 24 23:32:59 2016 GMT
-=====> Issuer: C=US, ST=California, L=San Francisco, O=dokku.me, CN=test.dokku.me
-=====> Starts At: Aug 25 23:32:59 2015 GMT
-=====> Subject: C=US; ST=California; L=San Francisco; O=dokku.me; CN=test.dokku.me
-=====> SSL certificate is self signed.
-```
-
 ### Certificate removal
 
 The `certs:remove` command only works on app-specific certificates. It will `rm` the app-specific tls directory, rebuild the nginx configuration, and reload nginx.
 
-### Displaying ssl reports about an app
+### Displaying certificate reports about an app
 
 > New as of 0.8.1
 

--- a/plugins/certs/commands
+++ b/plugins/certs/commands
@@ -1,39 +1,11 @@
 #!/usr/bin/env bash
 [[ " help certs:help " == *" $1 "* ]] || exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
+source "$PLUGIN_AVAILABLE_PATH/certs/internal-functions"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 case "$1" in
   help | certs:help)
-    help_content_func () {
-      declare desc="return certs plugin help content"
-      cat<<help_content
-    certs, [DEPRECATED] Alternative for certs:report
-    certs:add <app> CRT KEY, Add an ssl endpoint to an app. Can also import from a tarball on stdin
-    certs:chain CRT [CRT ...], [NOT IMPLEMENTED] Print the ordered and complete chain for the given certificate
-    certs:generate <app> DOMAIN, Generate a key and certificate signing request (and self-signed certificate)
-    certs:info <app>, [DEPRECATED] Alternative for certs:report
-    certs:key <app> CRT KEY [KEY ...], [NOT IMPLEMENTED] Print the correct key for the given certificate
-    certs:remove <app>, Remove an SSL Endpoint from an app
-    certs:report [<app>] [<flag>], Displays an ssl report for one or more apps
-    certs:rollback <app>, [NOT IMPLEMENTED] Rollback an SSL Endpoint for an app
-    certs:update <app> CRT KEY, Update an SSL Endpoint on an app. Can also import from a tarball on stdin
-help_content
-    }
-
-    if [[ $1 = "certs:help" ]] ; then
-      echo -e 'Usage: dokku certs:COMMAND'
-      echo ''
-      echo 'Manage Dokku apps SSL (TLS) certs.'
-      echo ''
-      echo 'Additional commands:'
-      help_content_func | sort | column -c2 -t -s,
-    elif [[ $(ps -o command= $PPID) == *"--all"* ]]; then
-      help_content_func
-    else
-    cat<<help_desc
-    certs, Manage Dokku apps SSL (TLS) certs
-help_desc
-    fi
+    certs_help_cmd "$@"
     ;;
 
   *)

--- a/plugins/certs/commands
+++ b/plugins/certs/commands
@@ -14,6 +14,7 @@ case "$1" in
     certs:info <app>, Show certificate information for an ssl endpoint
     certs:key <app> CRT KEY [KEY ...], [NOT IMPLEMENTED] Print the correct key for the given certificate
     certs:remove <app>, Remove an SSL Endpoint from an app
+    certs:report [<app>] [<flag>], Displays an ssl report for one or more apps
     certs:rollback <app>, [NOT IMPLEMENTED] Rollback an SSL Endpoint for an app
     certs:update <app> CRT KEY, Update an SSL Endpoint on an app. Can also import from a tarball on stdin
 help_content

--- a/plugins/certs/commands
+++ b/plugins/certs/commands
@@ -7,11 +7,11 @@ case "$1" in
     help_content_func () {
       declare desc="return certs plugin help content"
       cat<<help_content
-    certs, Manage Dokku apps SSL (TLS) certs
+    certs, [DEPRECATED] Alternative for certs:report
     certs:add <app> CRT KEY, Add an ssl endpoint to an app. Can also import from a tarball on stdin
     certs:chain CRT [CRT ...], [NOT IMPLEMENTED] Print the ordered and complete chain for the given certificate
     certs:generate <app> DOMAIN, Generate a key and certificate signing request (and self-signed certificate)
-    certs:info <app>, Show certificate information for an ssl endpoint
+    certs:info <app>, [DEPRECATED] Alternative for certs:report
     certs:key <app> CRT KEY [KEY ...], [NOT IMPLEMENTED] Print the correct key for the given certificate
     certs:remove <app>, Remove an SSL Endpoint from an app
     certs:report [<app>] [<flag>], Displays an ssl report for one or more apps
@@ -21,14 +21,18 @@ help_content
     }
 
     if [[ $1 = "certs:help" ]] ; then
-        echo -e 'Usage: dokku certs:COMMAND'
-        echo ''
-        echo 'Manage Dokku apps SSL (TLS) certs.'
-        echo ''
-        echo 'Additional commands:'
-        help_content_func | sort | column -c2 -t -s,
+      echo -e 'Usage: dokku certs:COMMAND'
+      echo ''
+      echo 'Manage Dokku apps SSL (TLS) certs.'
+      echo ''
+      echo 'Additional commands:'
+      help_content_func | sort | column -c2 -t -s,
+    elif [[ $(ps -o command= $PPID) == *"--all"* ]]; then
+      help_content_func
     else
-        help_content_func
+    cat<<help_desc
+    certs, Manage Dokku apps SSL (TLS) certs
+help_desc
     fi
     ;;
 

--- a/plugins/certs/functions
+++ b/plugins/certs/functions
@@ -2,39 +2,6 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 
-certs_info_cmd() {
-  # This is here because it's used in both the info and the default
-  declare desc="prints SSL certificate info for app"
-  local cmd="certs:info"
-  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
-  verify_app_name "$2"
-  local APP="$2"; local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
-
-  if [[ -n "$APP_SSL_PATH" ]]; then
-    dokku_log_info1 "Fetching SSL Endpoint info for $APP..."
-    dokku_log_info1 "Certificate details:"
-    dokku_log_info2 "Common Name(s): "
-
-    for domain in $(get_ssl_hostnames "$APP" | xargs); do
-      dokku_log_info2 "   $domain"
-    done
-
-    dokku_log_info2 "Expires At: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not After :" | awk -F " : " '{ print $2 }')"
-    dokku_log_info2 "Issuer: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Issuer:" | xargs | sed -e "s/Issuer: //g")"
-    dokku_log_info2 "Starts At: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not Before:" | awk -F ": " '{ print $2 }')"
-    dokku_log_info2 "Subject: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -subject | sed -e "s:subject= ::g"| sed -e "s:^/::g" | sed -e "s:/:; :g")"
-    local SSL_VERIFY_OUTPUT="$(openssl verify -verbose -purpose sslserver "$APP_SSL_PATH/server.crt" | awk -F ':' '{ print $2 }' | tail -1 | xargs || true)"
-    if [[ "$SSL_VERIFY_OUTPUT" == "OK" ]]; then
-      local SSL_SELF_SIGNED="verified by a certificate authority."
-    else
-      local SSL_SELF_SIGNED="self signed."
-    fi
-    dokku_log_info2 "SSL certificate is $SSL_SELF_SIGNED"
-  else
-    dokku_log_info1 "$APP does not have an SSL endpoint"
-  fi
-}
-
 is_ssl_enabled() {
   declare desc="returns 0 if ssl is enabled for given app"
   local APP=$1; verify_app_name "$APP"

--- a/plugins/certs/internal-functions
+++ b/plugins/certs/internal-functions
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/certs/functions"
+
+certs_info_cmd() {
+  # This is here because it's used in both the info and the default
+  declare desc="prints SSL certificate info for app"
+  local cmd="certs:info"
+  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$2"
+  local APP="$2"
+  local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
+
+  if [[ -n "$APP_SSL_PATH" ]]; then
+    dokku_log_info1 "Fetching SSL Endpoint info for $APP..."
+    dokku_log_info1 "Certificate details:"
+    dokku_log_info2 "Common Name(s): "
+
+    for domain in $(get_ssl_hostnames "$APP" | xargs); do
+      dokku_log_info2 "   $domain"
+    done
+
+    dokku_log_info2 "Expires At: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not After :" | awk -F " : " '{ print $2 }')"
+    dokku_log_info2 "Issuer: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Issuer:" | xargs | sed -e "s/Issuer: //g")"
+    dokku_log_info2 "Starts At: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not Before:" | awk -F ": " '{ print $2 }')"
+    dokku_log_info2 "Subject: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -subject | sed -e "s:subject= ::g"| sed -e "s:^/::g" | sed -e "s:/:; :g")"
+    local SSL_VERIFY_OUTPUT="$(openssl verify -verbose -purpose sslserver "$APP_SSL_PATH/server.crt" | awk -F ':' '{ print $2 }' | tail -1 | xargs || true)"
+    if [[ "$SSL_VERIFY_OUTPUT" == "OK" ]]; then
+      local SSL_SELF_SIGNED="verified by a certificate authority."
+    else
+      local SSL_SELF_SIGNED="self signed."
+    fi
+    dokku_log_info2 "SSL certificate is $SSL_SELF_SIGNED"
+  else
+    dokku_log_info1 "$APP does not have an SSL endpoint"
+  fi
+}

--- a/plugins/certs/internal-functions
+++ b/plugins/certs/internal-functions
@@ -12,7 +12,7 @@ certs_info_cmd() {
   local APP="$2"
   local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
 
-  if [[ -n "$APP_SSL_PATH" ]]; then
+  if is_ssl_enabled "$APP"; then
     dokku_log_info1 "Fetching SSL Endpoint info for $APP..."
     dokku_log_info1 "Certificate details:"
     dokku_log_info2 "Common Name(s): "

--- a/plugins/certs/internal-functions
+++ b/plugins/certs/internal-functions
@@ -3,6 +3,39 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/certs/functions"
 
+certs_help_content_func() {
+  declare desc="return certs plugin help content"
+  cat<<help_content
+    certs, [DEPRECATED] Alternative for certs:report
+    certs:add <app> CRT KEY, Add an ssl endpoint to an app. Can also import from a tarball on stdin
+    certs:chain CRT [CRT ...], [NOT IMPLEMENTED] Print the ordered and complete chain for the given certificate
+    certs:generate <app> DOMAIN, Generate a key and certificate signing request (and self-signed certificate)
+    certs:info <app>, [DEPRECATED] Alternative for certs:report
+    certs:key <app> CRT KEY [KEY ...], [NOT IMPLEMENTED] Print the correct key for the given certificate
+    certs:remove <app>, Remove an SSL Endpoint from an app
+    certs:report [<app>] [<flag>], Displays an ssl report for one or more apps
+    certs:rollback <app>, [NOT IMPLEMENTED] Rollback an SSL Endpoint for an app
+    certs:update <app> CRT KEY, Update an SSL Endpoint on an app. Can also import from a tarball on stdin
+help_content
+}
+
+certs_help_cmd() {
+  if [[ $1 = "certs:help" ]] ; then
+    echo -e 'Usage: dokku certs[:COMMAND]'
+    echo ''
+    echo 'Manage Dokku apps SSL (TLS) certs.'
+    echo ''
+    echo 'Additional commands:'
+    certs_help_content_func | sort | column -c2 -t -s,
+  elif [[ $(ps -o command= $PPID) == *"--all"* ]]; then
+    certs_help_content_func
+  else
+    cat<<help_desc
+    certs, Manage Dokku apps SSL (TLS) certs
+help_desc
+  fi
+}
+
 certs_info_cmd() {
   # This is here because it's used in both the info and the default
   declare desc="prints SSL certificate info for app"

--- a/plugins/certs/subcommands/default
+++ b/plugins/certs/subcommands/default
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_AVAILABLE_PATH/certs/functions"
+source "$PLUGIN_AVAILABLE_PATH/certs/internal-functions"
 
-certs_main_cmd() {
-  declare desc="an alias for certs:info"
-  local cmd="certs"
-  certs_info_cmd "$@"
-}
-
-certs_main_cmd "$@"
+dokku_log_warn "Deprecated: Please use certs:report"
+certs_info_cmd "$@"

--- a/plugins/certs/subcommands/info
+++ b/plugins/certs/subcommands/info
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_AVAILABLE_PATH/certs/functions"
+source "$PLUGIN_AVAILABLE_PATH/certs/internal-functions"
 
+dokku_log_warn "Deprecated: Please use certs:report"
 certs_info_cmd "$@"

--- a/plugins/certs/subcommands/report
+++ b/plugins/certs/subcommands/report
@@ -18,7 +18,7 @@ fn-ssl-expires-at() {
   local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls" 
 
   if is_ssl_enabled "$APP"; then
-    echo "$(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not After :" | awk -F " : " '{ print $2 }')"
+    openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not After :" | awk -F " : " '{ print $2 }'
   fi
 }
 
@@ -35,7 +35,7 @@ fn-ssl-issuer() {
   local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls" 
 
   if is_ssl_enabled "$APP"; then
-    echo "$(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Issuer:" | xargs | sed -e "s/Issuer: //g")"
+    openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Issuer:" | xargs | sed -e "s/Issuer: //g"
   fi
 }
 
@@ -44,7 +44,7 @@ fn-ssl-starts-at() {
   local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls" 
 
   if is_ssl_enabled "$APP"; then
-    echo "$(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not Before:" | awk -F ": " '{ print $2 }')"
+    openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not Before:" | awk -F ": " '{ print $2 }'
   fi
 }
 
@@ -53,7 +53,7 @@ fn-ssl-subject() {
   local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls" 
 
   if is_ssl_enabled "$APP"; then
-    echo "$(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -subject | sed -e "s:subject= ::g"| sed -e "s:^/::g" | sed -e "s:/:; :g")"
+    openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -subject | sed -e "s:subject= ::g"| sed -e "s:^/::g" | sed -e "s:/:; :g"
   fi
 }
 

--- a/plugins/certs/subcommands/report
+++ b/plugins/certs/subcommands/report
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/certs/functions"
+
+fn-ssl-enabled() {
+  declare APP="$1"
+  local SSL_ENABLED=false
+
+  if is_ssl_enabled "$APP"; then
+    SSL_ENABLED=true
+  fi
+  echo "$SSL_ENABLED" 
+}
+
+fn-ssl-expires-at() {
+  declare APP="$1"
+  local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls" 
+
+  if is_ssl_enabled "$APP"; then
+    echo "$(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not After :" | awk -F " : " '{ print $2 }')"
+  fi
+}
+
+fn-ssl-hostnames() {
+  declare APP="$1"
+
+  if is_ssl_enabled "$APP"; then
+    get_ssl_hostnames "$APP" | xargs
+  fi
+}
+
+fn-ssl-issuer() {
+  declare APP="$1"
+  local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls" 
+
+  if is_ssl_enabled "$APP"; then
+    echo "$(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Issuer:" | xargs | sed -e "s/Issuer: //g")"
+  fi
+}
+
+fn-ssl-starts-at() {
+  declare APP="$1"
+  local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls" 
+
+  if is_ssl_enabled "$APP"; then
+    echo "$(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not Before:" | awk -F ": " '{ print $2 }')"
+  fi
+}
+
+fn-ssl-subject() {
+  declare APP="$1"
+  local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls" 
+
+  if is_ssl_enabled "$APP"; then
+    echo "$(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -subject | sed -e "s:subject= ::g"| sed -e "s:^/::g" | sed -e "s:/:; :g")"
+  fi
+}
+
+fn-ssl-verified() {
+  declare APP="$1"
+  local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
+  local SSL_VERIFY_OUTPUT=false SSL_SELF_SIGNED="self signed"
+
+  if ! is_ssl_enabled "$APP"; then
+    return
+  fi
+
+  SSL_VERIFY_OUTPUT="$(openssl verify -verbose -purpose sslserver "$APP_SSL_PATH/server.crt" | awk -F ':' '{ print $2 }' | tail -1 | xargs || true)"
+  if [[ "$SSL_VERIFY_OUTPUT" == "OK" ]]; then
+    SSL_SELF_SIGNED="verified by a certificate authority"
+  fi
+
+  echo "$SSL_SELF_SIGNED"
+}
+
+certs_report_single_app() {
+  local APP="$1"; local APP_DIR="$DOKKU_ROOT/$APP"; local INFO_FLAG="$2"
+  if [[ "$INFO_FLAG" == "true" ]]; then
+    INFO_FLAG=""
+  fi
+  verify_app_name "$APP"
+  local flag_map=(
+    "--ssl-dir: $APP_DIR/tls"
+    "--ssl-enabled: $(fn-ssl-enabled "$APP")"
+    "--ssl-hostnames: $(fn-ssl-hostnames "$APP")"
+    "--ssl-expires-at: $(fn-ssl-expires-at "$APP")"
+    "--ssl-issuer: $(fn-ssl-issuer "$APP")"
+    "--ssl-starts-at: $(fn-ssl-starts-at "$APP")"
+    "--ssl-subject: $(fn-ssl-subject "$APP")"
+    "--ssl-verified: $(fn-ssl-verified "$APP")"
+  )
+
+  if [[ -z "$INFO_FLAG" ]]; then
+    dokku_log_info2 "$APP ssl information"
+    for flag in "${flag_map[@]}"; do
+      key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
+      dokku_log_verbose "$(printf "%-20s %-25s" "${key^}" "${flag#*: }")"
+    done
+  else
+    local match=false; local value_exists=false
+    for flag in "${flag_map[@]}"; do
+      valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
+      if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
+        value=${flag#*: }
+        size="${#value}"
+        if [[ "$size" -ne 0 ]]; then
+          echo "$value" && match=true && value_exists=true
+        else
+          match=true
+        fi
+      fi
+    done
+    if [[ "$match" == "true" ]]; then
+      [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
+    else
+      dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
+    fi
+  fi
+}
+
+certs_report_cmd() {
+  declare desc="displays an ssl report for one or more apps"
+  local cmd="certs:report"
+  local INSTALLED_APPS=$(dokku_apps); local APP
+
+  if [[ -z $2 ]]; then
+    for APP in $INSTALLED_APPS; do
+      certs_report_single_app "$APP" "true"
+    done
+  else
+    certs_report_single_app "$2" "$3"
+  fi
+}
+
+certs_report_cmd "$@"


### PR DESCRIPTION
This also deprecates `certs:default` and `certs:info`, as well as cleans up the output of `certs:help`.

Refs #2356.