### PR TITLE
Refactor ssh-keys:default

### DIFF
--- a/plugins/ssh-keys/commands
+++ b/plugins/ssh-keys/commands
@@ -1,29 +1,11 @@
 #!/usr/bin/env bash
 [[ " help ssh-keys:help " == *" $1 "* ]] || exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
+source "$PLUGIN_AVAILABLE_PATH/ssh-keys/internal-functions"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 case "$1" in
   help | ssh-keys:help)
-    help_content_func () {
-      declare desc="return ssh-keys plugin help content"
-      cat<<help_content
-    ssh-keys, Manage public ssh keys that are allowed to connect to Dokku
-    ssh-keys:list, List of all authorized dokku public ssh keys
-    ssh-keys:add <name> [/path/to/key], Add a new public key by pipe or path
-    ssh-keys:remove <name>, Remove SSH public key by name
-help_content
-    }
-
-    if [[ $1 = "ssh-keys:help" ]] ; then
-        echo -e 'Usage: dokku ssh-keys[:COMMAND]'
-        echo ''
-        echo 'Manage public ssh keys that are allowed to connect to Dokku'
-        echo ''
-        echo 'Additional commands:'
-        help_content_func | sort | column -c2 -t -s,
-    else
-        help_content_func
-    fi
+    ssh_keys_help_cmd "$@"
     ;;
 
   *)

--- a/plugins/ssh-keys/internal-functions
+++ b/plugins/ssh-keys/internal-functions
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+ssh_keys_help_content_func() {
+    declare desc="return ssh-keys plugin help content"
+    cat<<help_content
+    ssh-keys:list, List of all authorized dokku public ssh keys
+    ssh-keys:add <name> [/path/to/key], Add a new public key by pipe or path
+    ssh-keys:remove <name>, Remove SSH public key by name
+help_content
+}
+
+ssh_keys_help_cmd() {
+  if [[ $1 = "ssh-keys:help" ]] ; then
+    echo -e 'Usage: dokku ssh-keys[:COMMAND]'
+    echo ''
+    echo 'Manage public ssh keys that are allowed to connect to Dokku'
+    echo ''
+    echo 'Additional commands:'
+    ssh_keys_help_content_func | sort | column -c2 -t -s,
+  elif [[ $(ps -o command= $PPID) == *"--all"* ]]; then
+    ssh_keys_help_content_func
+  else
+    cat<<help_desc
+    ssh-keys, Manage public ssh keys that are allowed to connect to Dokku
+help_desc
+  fi
+}

--- a/plugins/ssh-keys/subcommands/default
+++ b/plugins/ssh-keys/subcommands/default
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_AVAILABLE_PATH/ssh-keys/functions"
+source "$PLUGIN_AVAILABLE_PATH/ssh-keys/internal-functions"
 
-ssh_keys_main_cmd() {
-  declare desc="an alias for ssh-keys:list"
-  local cmd="ssh-keys"
-  list_ssh_keys
-}
-
-ssh_keys_main_cmd "$@"
+ssh_keys_help_cmd "$@"


### PR DESCRIPTION
It now calls `ssh-keys:help` by default.