### PR TITLE
Fix `certs:help`

### DIFF
--- a/plugins/certs/internal-functions
+++ b/plugins/certs/internal-functions
@@ -6,7 +6,7 @@ source "$PLUGIN_AVAILABLE_PATH/certs/functions"
 certs_help_content_func() {
   declare desc="return certs plugin help content"
   cat<<help_content
-    certs, [DEPRECATED] Alternative for certs:report
+    certs <app>, [DEPRECATED] Alternative for certs:report
     certs:add <app> CRT KEY, Add an ssl endpoint to an app. Can also import from a tarball on stdin
     certs:chain CRT [CRT ...], [NOT IMPLEMENTED] Print the ordered and complete chain for the given certificate
     certs:generate <app> DOMAIN, Generate a key and certificate signing request (and self-signed certificate)


### PR DESCRIPTION
`certs` requires `app` argument like `certs:info`.