### PR TITLE
Add post-extract plugin trigger

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -481,6 +481,28 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 sudo service haproxy reload
 ```
 
+### `post-extract`
+
+- Description: Allows you to modify the contents of an application *after* it has been extracted from git/tarball but *before* the image source type is detected.
+- Invoked by: `dokku tar:in`, `dokku tar:from` and the `receive-app` plugin trigger
+- Arguments: `$APP` `$TMP_WORK_DIR` `$REV`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+# Adds a clock process to an app's Procfile
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+APP="$1"; verify_app_name "$APP"
+TMP_WORK_DIR="$2"
+REV="$3" # optional, may not be sent for tar-based builds
+
+pushd "$TMP_WORK_DIR" > /dev/null
+touch Procfile
+echo "clock: some-command" >> Procfile
+```
+
 ### `post-proxy-ports-update`
 
 - Description: Allows you to run commands once the proxy port mappings for an application have been updated. It also sends the invoking command. This can be "add", "clear" or "remove".

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -32,6 +32,8 @@ git_build_app_repo() {
   GIT_DIR="$DOKKU_ROOT/$APP" git tag -d "$TMP_TAG" &> /dev/null || true
   find -name .git -prune -exec rm -rf {} \; > /dev/null
 
+  plugn trigger post-extract "$APP" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV"
+
   if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && [[ -z $(config_get "$APP" BUILDPACK_URL || true) ]]; then
     plugn trigger pre-receive-app "$APP" "dockerfile" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV"
     dokku_receive "$APP" "dockerfile" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"

--- a/plugins/tar/functions
+++ b/plugins/tar/functions
@@ -24,6 +24,8 @@ tar_build() {
   tar -x -C "$TAR_BUILD_TMP_WORK_DIR" -f "$DOKKU_ROOT/$APP/src.tar" --strip-components="$BOGUS_PARTS"
   chmod -R u+r "$TAR_BUILD_TMP_WORK_DIR"
 
+  plugn trigger post-extract "$APP" "$TAR_BUILD_TMP_WORK_DIR"
+
   if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && [[ -z $(config_get "$APP" BUILDPACK_URL || true) ]]; then
     plugn trigger pre-receive-app "$APP" "dockerfile" "$TAR_BUILD_TMP_WORK_DIR"
     dokku_receive "$APP" "dockerfile" "$TAR_BUILD_TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"


### PR DESCRIPTION
This trigger allows you to modify the contents of an application *after* it has been extracted from git/tarball but *before* the image source type is detected. For example, you may wish to autogenerate a Dockerfile based on some other application contents before detecting what type of build process - herokuish or docker file - to use.