### PR TITLE
Fix logrotate on Debian

### DIFF
--- a/plugins/20_events/install
+++ b/plugins/20_events/install
@@ -59,7 +59,7 @@ $DOKKU_LOGS_DIR/*.log {
 EOF
 
   if [[ "$DOKKU_DISTRO" = "debian" ]]; then
-    sed -i '/\s*su syslog dokku/d; s/\(create [0-7][0-7][0-7]\) syslog dokku/\1 root dokku/g' $DOKKU_LOGROTATE_FILE
+    sed -i 's/ syslog dokku$/root dokku/g' $DOKKU_LOGROTATE_FILE
   fi
 
   flag_rsyslog_needs_restart=y


### PR DESCRIPTION
Since we're creating logs as `root:dokku`, the logrotate configuration
needs an `su root dokku` line, just like `su syslog dokku` on ubuntu.

Otherwise, I get nightly emails along the lines of:

> /etc/cron.daily/logrotate:
> error: skipping "/var/log/dokku/events.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
> run-parts: /etc/cron.daily/logrotate exited with return code 1
