### PR TITLE
Prefer HTTP2 to SPDY in nginx-vhosts

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -38,8 +38,8 @@ server {
 }
 {{ else if eq $scheme "https"}}
 server {
-  listen      [::]:{{ $listen_port }} ssl {{ if eq $.SPDY_SUPPORTED "true" }}spdy{{ else if eq $.HTTP2_SUPPORTED "true" }}http2{{ end }};
-  listen      {{ $listen_port }} ssl {{ if eq $.SPDY_SUPPORTED "true" }}spdy{{ else if eq $.HTTP2_SUPPORTED "true" }}http2{{ end }};
+  listen      [::]:{{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ else if eq $.SPDY_SUPPORTED "true" }}spdy{{ end }};
+  listen      {{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ else if eq $.SPDY_SUPPORTED "true" }}spdy{{ end }};
   {{ if $.SSL_SERVER_NAME }}server_name {{ $.SSL_SERVER_NAME }}; {{ end }}
   {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
   access_log  /var/log/nginx/{{ $.APP }}-access.log;
@@ -50,7 +50,7 @@ server {
   ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
 
   keepalive_timeout   70;
-  {{ if eq $.SPDY_SUPPORTED "true" }}add_header          Alternate-Protocol  {{ $.NGINX_SSL_PORT }}:npn-spdy/2;{{ end }}
+  {{ if and (eq $.SPDY_SUPPORTED "true") (ne $.HTTP2_SUPPORTED "true") }}add_header          Alternate-Protocol  {{ $.NGINX_SSL_PORT }}:npn-spdy/2;{{ end }}
 
   location    / {
 


### PR DESCRIPTION
1.  SPDY has been deprecated and removed from modern browsers:
    http://caniuse.com/#feat=spdy

2.  HTTP/2 is present in all modern browsers:
    http://caniuse.com/#feat=http2

3.  SPDY and HTTP/2 are mutually exclusive in port-based `listen` directives:
    http://nginx.org/en/docs/http/ngx_http_core_module.html#listen

Caniuse suggests that 74% of global users have a browser that supports HTTP/2, while only 27% have a browser that supports SPDY. Only IE11 and Safari support both.

Therefore, when both are available, Dokku should choose HTTP/2 to maximize the benefit to users.