### PR TITLE
Add dokku-monit to community plugin list

### DIFF
--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -91,6 +91,7 @@ Note: The following plugins have been supplied by our community and may not have
 [luxifer]: https://github.com/luxifer
 [Maciej Łebkowski]: https://github.com/mlebkowski
 [matto1990]: https://github.com/matto1990
+[mbreit]: https://github.com/mbreit
 [mbriskar]: https://github.com/mbriskar
 [michaelshobbs]: https://github.com/michaelshobbs
 [mikecsh]: https://github.com/mikecsh
@@ -180,6 +181,7 @@ Note: The following plugins have been supplied by our community and may not have
 | [Haproxy tcp load balancer](https://github.com/256dpi/dokku-haproxy)                              | [256dpi][]            | 0.4.0+                |
 | [Hostname](https://github.com/michaelshobbs/dokku-hostname)                                       | [michaelshobbs][]     | 0.4.0+                |
 | [HTTP Auth Secure Apps](https://github.com/matto1990/dokku-secure-apps)                           | [matto1990][]         | 0.4.0+                |
+| [Monit (Health Checks)](https://github.com/mbreit/dokku-monit)                                    | [mbreit][]            | 0.8.0+                |
 | [Nuke Containers](https://github.com/josegonzalez/dokku-nuke)                                     | [josegonzalez][]      | 0.4.0+                |
 | [Open App Ports](https://github.com/josegonzalez/dokku-ports)                                     | [josegonzalez][]      | 0.3.x                 |
 | [Proctype Filter](https://github.com/michaelshobbs/dokku-proctype-filter)                         | [michaelshobbs][]     | 0.4.0+                |


### PR DESCRIPTION
This plugin adds health checks for Dokku apps with [Monit](https://mmonit.com/monit/documentation/monit.html). The motivation was having a workaround for the Docker IP address issues discussed in #2403, but of course works in other cases as well.

URL to the plugin is https://github.com/mbreit/dokku-monit.