### PR TITLE
fix: explicitly chown data and data/storage directories

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -35,7 +35,7 @@ case "$1" in
 
     echo "Setting up storage directories"
     mkdir -p ${DOKKU_LIB_ROOT}/data ${DOKKU_LIB_ROOT}/data/storage
-    chown dokku:dokku -R ${DOKKU_LIB_ROOT}/data
+    chown dokku:dokku ${DOKKU_LIB_ROOT}/data ${DOKKU_LIB_ROOT}/data/storage
 
     echo "Setting up plugin directories"
     # should be replaced by `plugn init`


### PR DESCRIPTION
Doing a recursive chown will otherwise screw up dockerfile-based app storage when the uid does not map to herokuish or similar.

Example: CakePHP's jenkins server has this issue :(