### PR TITLE
Add documentation note re: git-pre-pull vs. auth

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -321,6 +321,10 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 # TODO
 ```
 
+> WARNING: The `git-pre-pull` trigger should _not_ be used for authentication
+since it does not get called for commands that use `git-upload-archive` such
+as `git archive`. Instead, use the [`user-auth`](#user-auth) trigger.
+
 ### `install`
 
 - Description: Used to setup any files/configuration for a plugin.


### PR DESCRIPTION
As discussed with @josegonzalez on Slack - it's tempting but incorrect to use `git-pre-pull` for authenticating git access. Instead `user-auth` should be used, so document this.