### PR TITLE
Set SSH_USER for root commands

### DIFF
--- a/dokku
+++ b/dokku
@@ -56,8 +56,12 @@ if [[ $(id -un) != "dokku" ]] && [[ ! $1 =~ plugin:* ]] && [[ ! $1 == "ssh-keys:
   exit $?
 fi
 
-if [[ $(id -un) != "root" && $1 =~ ^plugin:.* && $1 != "plugin:help" && $1 != "plugin:list" ]] || [[ $(id -un) != "root" && $1 == "ssh-keys:add" ]]; then
-  dokku_log_fail "This command must be run as root"
+if [[ $1 =~ ^plugin:.* && $1 != "plugin:help" && $1 != "plugin:list" ]] || [[ $1 == "ssh-keys:add" ]]; then
+  if [[ $(id -un) != "root" ]]; then
+    dokku_log_fail "This command must be run as root"
+  else
+    export SSH_USER=root
+  fi
 fi
 
 if [[ -n "$SSH_ORIGINAL_COMMAND" ]]; then


### PR DESCRIPTION
Previously, SSH_USER was not set for plugin:* or ssh-keys:add, which contradicts the user-auth trigger documentation.

Fixes #2700

* [x] Integration test with `dokku-acl` to make sure this fixes the issue