### PR TITLE
Extract some scheduler-related functionality into a separate plugin

### DIFF
--- a/plugins/00_dokku-standard/subcommands/run
+++ b/plugins/00_dokku-standard/subcommands/run
@@ -1,50 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_AVAILABLE_PATH/ps/functions"
-source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 dokku_run_cmd() {
   declare desc="runs command in container based on app image"
-  local cmd="run"
-  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
-  local APP="$2"; local IMAGE_TAG=$(get_running_image_tag "$APP"); local IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
-  verify_app_name "$APP"
-
-  shift 2
-
-  if [[ -z "$DOKKU_RM_CONTAINER" ]]; then
-    local DOKKU_APP_RM_CONTAINER=$(config_get "$APP" DOKKU_RM_CONTAINER || true)
-    local DOKKU_GLOBAL_RM_CONTAINER=$(config_get --global DOKKU_RM_CONTAINER || true)
-    local DOKKU_RM_CONTAINER=${DOKKU_APP_RM_CONTAINER:="$DOKKU_GLOBAL_RM_CONTAINER"}
-  fi
-
-  local DOCKER_ARGS=$(: | plugn trigger docker-args-run "$APP" "$IMAGE_TAG")
-  [[ "$DOKKU_TRACE" ]] && local DOCKER_ARGS+=" -e TRACE=true "
-
-  local DOKKU_RUN_OPTS=""
-  if [[ "$DOKKU_RM_CONTAINER" ]]; then
-    DOKKU_RUN_OPTS+=" --rm"
-  elif [[ "$DOKKU_DETACH_CONTAINER" ]]; then
-    DOKKU_RUN_OPTS+=" --detach"
-  fi
-
-  has_tty && DOKKU_RUN_OPTS+=" -i -t"
-  is_image_herokuish_based "$IMAGE" && local EXEC_CMD="/exec"
-
-  DOKKU_QUIET_OUTPUT=1 extract_procfile "$APP"
-
-  POTENTIAL_PROCFILE_KEY="$1"
-  PROC_CMD=$(get_cmd_from_procfile "$APP" "$POTENTIAL_PROCFILE_KEY" || echo '')
-  remove_procfile "$APP"
-
-  if [ ! -z "$PROC_CMD" ]; then
-    dokku_log_info1 "Found '$POTENTIAL_PROCFILE_KEY' in Procfile, running that command"
-    set -- "$PROC_CMD" "${@:2}"
-  fi
-
-  # shellcheck disable=SC2086
-  docker run $DOKKU_GLOBAL_RUN_ARGS $DOKKU_RUN_OPTS $DOCKER_ARGS $IMAGE $EXEC_CMD "$@"
+  plugn trigger scheduler-container-run "$@"
 }
 
 dokku_run_cmd "$@"

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -153,7 +153,7 @@ verify_app_name() {
 verify_image() {
   declare desc="verify image existence"
   local IMAGE="$1"
-  if (docker inspect "$IMAGE" &>/dev/null); then
+  if plugn trigger scheduler-image-verify "$IMAGE"; then
     return 0
   else
     return 1
@@ -207,19 +207,12 @@ get_app_image_name() {
 get_running_image_tag() {
   declare desc="retrieve current image tag for a given app. returns empty string if no deployed containers are found"
   local APP="$1"
-  [[ ! -n "$APP" ]] && dokku_log_fail "(get_running_image_tag) APP must not be null"
-  verify_app_name "$APP"
-
-  local CIDS=( $(get_app_container_ids "$APP") )
-  local RUNNING_IMAGE_TAG=$(docker inspect -f '{{ .Config.Image }}' "${CIDS[0]}" 2>/dev/null | awk -F: '{ print $2 }' || echo '')
-  echo "$RUNNING_IMAGE_TAG"
+  plugn trigger scheduler-container-image-tag "$APP"
 }
 
 is_image_herokuish_based() {
   declare desc="returns true if app image is based on herokuish"
-  # circleci can't support --rm as they run lxc in lxc
-  [[ ! -f "/home/ubuntu/.circlerc" ]] && local DOCKER_ARGS="--rm"
-  docker run "$DOKKU_GLOBAL_RUN_ARGS" --entrypoint="/bin/sh" $DOCKER_ARGS "$@" -c "test -f /exec" &> /dev/null
+  plugn trigger scheduler-image-is-herokuish "$@"
 }
 
 get_docker_version() {
@@ -284,21 +277,8 @@ parse_args() {
 
 copy_from_image() {
   declare desc="copy file from named image to destination"
-  local IMAGE="$1"; local SRC_FILE="$2"; local DST_DIR="$3"
-  verify_app_name "$APP"
 
-  if verify_image "$IMAGE"; then
-    if ! is_abs_path "$SRC_FILE"; then
-      local WORKDIR=$(docker inspect -f '{{.Config.WorkingDir}}' "$IMAGE")
-      [[ -z "$WORKDIR" ]] && local WORKDIR=/app
-      local SRC_FILE="$WORKDIR/$SRC_FILE"
-    fi
-    local CID=$(docker run "$DOKKU_GLOBAL_RUN_ARGS" -d "$IMAGE" bash)
-    docker cp "$CID:$SRC_FILE" "$DST_DIR"
-    docker rm -f "$CID" &> /dev/null
-  else
-    return 1
-  fi
+  plugn trigger scheduler-image-copy "$@"
 }
 
 get_app_container_ids() {
@@ -759,17 +739,8 @@ dokku_receive() {
 
 docker_cleanup() {
   declare desc="cleans up all exited/dead containers and removes all dangling images"
-  # delete all non-running containers
-  # shellcheck disable=SC2046
-  docker rm $(docker ps -a -f "status=exited" -f "label=$DOKKU_CONTAINER_LABEL" -q) &> /dev/null || true
 
-  # delete all dead containers
-  # shellcheck disable=SC2046
-  docker rm $(docker ps -a -f "status=dead" -f "label=$DOKKU_CONTAINER_LABEL" -q) &> /dev/null || true
-
-  # delete unused images
-  # shellcheck disable=SC2046
-  docker rmi $(docker images -f 'dangling=true' -q) &> /dev/null &
+  plugn trigger scheduler-container-cleanup
 }
 
 get_available_port() {

--- a/plugins/scheduler-docker-local/plugin.toml
+++ b/plugins/scheduler-docker-local/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "dokku core scheduler-docker-local plugin"
+version = "0.9.4"
+[plugin.config]

--- a/plugins/scheduler-docker-local/scheduler-container-cleanup
+++ b/plugins/scheduler-docker-local/scheduler-container-cleanup
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/scheduler/functions"
+
+trigger-scheduler-container-cleanup() {
+  declare desc="cleans up all exited/dead containers and removes all dangling images"
+  local SCHEDULER_NAME
+
+  if fn-scheduler-should-use "docker-local"; then
+    return
+  fi
+
+  # delete all non-running containers
+  # shellcheck disable=SC2046
+  docker rm $(docker ps -a -f "status=exited" -f "label=$DOKKU_CONTAINER_LABEL" -q) &> /dev/null || true
+
+  # delete all dead containers
+  # shellcheck disable=SC2046
+  docker rm $(docker ps -a -f "status=dead" -f "label=$DOKKU_CONTAINER_LABEL" -q) &> /dev/null || true
+
+  # delete unused images
+  # shellcheck disable=SC2046
+  docker rmi $(docker images -f 'dangling=true' -q) &> /dev/null &
+}
+
+trigger-scheduler-container-cleanup "$@"

--- a/plugins/scheduler-docker-local/scheduler-container-image-tag
+++ b/plugins/scheduler-docker-local/scheduler-container-image-tag
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/scheduler/functions"
+
+trigger-container-image-tag() {
+  declare desc="retrieve current image tag for a given app. returns empty string if no deployed containers are found"
+  local SCHEDULER_NAME
+
+  if fn-scheduler-should-use "docker-local"; then
+    return
+  fi
+
+  local APP="$1"
+  [[ ! -n "$APP" ]] && dokku_log_fail "(get_running_image_tag) APP must not be null"
+  verify_app_name "$APP"
+
+  local CIDS=( $(get_app_container_ids "$APP") )
+  local RUNNING_IMAGE_TAG=$(docker inspect -f '{{ .Config.Image }}' "${CIDS[0]}" 2>/dev/null | awk -F: '{ print $2 }' || echo '')
+  echo "$RUNNING_IMAGE_TAG"
+}
+
+trigger-container-image-tag "$@"

--- a/plugins/scheduler-docker-local/scheduler-container-run
+++ b/plugins/scheduler-docker-local/scheduler-container-run
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/scheduler/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/ps/functions"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+
+trigger-container-run() {
+  declare desc="runs command in container based on app image"
+  local SCHEDULER_NAME
+
+  if fn-scheduler-should-use "docker-local"; then
+    return
+  fi
+
+  local cmd="run"
+  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
+  local APP="$2"; local IMAGE_TAG=$(get_running_image_tag "$APP"); local IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
+  verify_app_name "$APP"
+
+  shift 2
+
+  if [[ -z "$DOKKU_RM_CONTAINER" ]]; then
+    local DOKKU_APP_RM_CONTAINER=$(config_get "$APP" DOKKU_RM_CONTAINER || true)
+    local DOKKU_GLOBAL_RM_CONTAINER=$(config_get --global DOKKU_RM_CONTAINER || true)
+    local DOKKU_RM_CONTAINER=${DOKKU_APP_RM_CONTAINER:="$DOKKU_GLOBAL_RM_CONTAINER"}
+  fi
+
+  local DOCKER_ARGS=$(: | plugn trigger docker-args-run "$APP" "$IMAGE_TAG")
+  [[ "$DOKKU_TRACE" ]] && local DOCKER_ARGS+=" -e TRACE=true "
+
+  local DOKKU_RUN_OPTS=""
+  if [[ "$DOKKU_RM_CONTAINER" ]]; then
+    DOKKU_RUN_OPTS+=" --rm"
+  elif [[ "$DOKKU_DETACH_CONTAINER" ]]; then
+    DOKKU_RUN_OPTS+=" --detach"
+  fi
+
+  has_tty && DOKKU_RUN_OPTS+=" -i -t"
+  is_image_herokuish_based "$IMAGE" && local EXEC_CMD="/exec"
+
+  DOKKU_QUIET_OUTPUT=1 extract_procfile "$APP"
+
+  POTENTIAL_PROCFILE_KEY="$1"
+  PROC_CMD=$(get_cmd_from_procfile "$APP" "$POTENTIAL_PROCFILE_KEY" || echo '')
+  remove_procfile "$APP"
+
+  if [ ! -z "$PROC_CMD" ]; then
+    dokku_log_info1 "Found '$POTENTIAL_PROCFILE_KEY' in Procfile, running that command"
+    set -- "$PROC_CMD" "${@:2}"
+  fi
+
+  # shellcheck disable=SC2086
+  docker run $DOKKU_GLOBAL_RUN_ARGS $DOKKU_RUN_OPTS $DOCKER_ARGS $IMAGE $EXEC_CMD "$@"
+}
+
+trigger-container-run "$@"

--- a/plugins/scheduler-docker-local/scheduler-image-copy
+++ b/plugins/scheduler-docker-local/scheduler-image-copy
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/scheduler/functions"
+
+trigger-scheduler-image-copy() {
+  declare desc="copy file from named image to destination"
+  local SCHEDULER_NAME
+
+  if fn-scheduler-should-use "docker-local"; then
+    return
+  fi
+
+  local IMAGE="$1"; local SRC_FILE="$2"; local DST_DIR="$3"
+  verify_app_name "$APP"
+
+  if ! verify_image "$IMAGE"; then
+    exit 1
+  fi
+
+  if ! is_abs_path "$SRC_FILE"; then
+    local WORKDIR=$(docker inspect -f '{{.Config.WorkingDir}}' "$IMAGE")
+    [[ -z "$WORKDIR" ]] && local WORKDIR=/app
+    local SRC_FILE="$WORKDIR/$SRC_FILE"
+  fi
+  local CID=$(docker run "$DOKKU_GLOBAL_RUN_ARGS" -d "$IMAGE" bash)
+  docker cp "$CID:$SRC_FILE" "$DST_DIR"
+  docker rm -f "$CID" &> /dev/null
+}
+
+trigger-scheduler-image-copy "$@"

--- a/plugins/scheduler-docker-local/scheduler-image-is-herokuish
+++ b/plugins/scheduler-docker-local/scheduler-image-is-herokuish
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/scheduler/functions"
+
+trigger-scheduler-image-is-herokuish() {
+  declare desc="returns true if app image is based on herokuish"
+  local SCHEDULER_NAME
+
+  if fn-scheduler-should-use "docker-local"; then
+    return
+  fi
+
+  # circleci can't support --rm as they run lxc in lxc
+  [[ ! -f "/home/ubuntu/.circlerc" ]] && local DOCKER_ARGS="--rm"
+  docker run "$DOKKU_GLOBAL_RUN_ARGS" --entrypoint="/bin/sh" $DOCKER_ARGS "$@" -c "test -f /exec" &> /dev/null
+}
+
+trigger-scheduler-image-is-herokuish "$@"

--- a/plugins/scheduler-docker-local/scheduler-image-verify
+++ b/plugins/scheduler-docker-local/scheduler-image-verify
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/scheduler/functions"
+
+trigger-scheduler-image-verify() {
+  declare desc="verify image existence"
+  local SCHEDULER_NAME
+
+  if fn-scheduler-should-use "docker-local"; then
+    return
+  fi
+
+  local IMAGE="$1"
+  if (docker inspect "$IMAGE" &>/dev/null); then
+    return 0
+  else
+    return 1
+  fi
+}
+
+trigger-scheduler-image-verify "$@"

--- a/plugins/scheduler/functions
+++ b/plugins/scheduler/functions
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+fn-schedulers() {
+  echo "docker-local"
+}
+
+fn-scheduler-should-use() {
+  declare SCHEDULER_NAME="$1"
+  local CONFIGURED_SCHEDULERS
+
+  IFS=',' read -r -a CONFIGURED_SCHEDULERS <<< "$(fn-schedulers)"
+  if fn-scheduler-value-in-array "$SCHEDULER_NAME" "${CONFIGURED_SCHEDULERS[@]}"; then
+    exit 0
+  fi
+  exit 1
+}
+
+fn-scheduler-value-in-array() {
+  local VALUE="$1"
+  local e
+  for e in "${@:2}"; do [[ "$e" == "$VALUE" ]] && return 0; done
+  return 1
+}

--- a/plugins/scheduler/plugin.toml
+++ b/plugins/scheduler/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "dokku core scheduler plugin"
+version = "0.9.4"
+[plugin.config]


### PR DESCRIPTION
I'm not sure how to make it so we can "inherit" schedulers. For instance, you'll probably want anything build-related to run locally, but maybe you don't in some cases. Thats why it has some weird logic around checking if you should use a particular scheduler.