### PR TITLE
fix: use or statements to add support for new docker packages

### DIFF
--- a/deb.mk
+++ b/deb.mk
@@ -106,7 +106,7 @@ deb-herokuish:
 	cp -rf /tmp/tmp/herokuish /tmp/build/var/lib/herokuish
 
 	@echo "-> Creating $(HEROKUISH_PACKAGE_NAME)"
-	sudo fpm -t deb -s dir -C /tmp/build -n herokuish -v $(HEROKUISH_VERSION) -a $(HEROKUISH_ARCHITECTURE) -p $(HEROKUISH_PACKAGE_NAME) --deb-pre-depends 'docker-engine-cs (>= 1.9.1) | docker-engine (>= 1.9.1)' --deb-pre-depends sudo --after-install /tmp/tmp/post-install --url "https://github.com/$(HEROKUISH_REPO_NAME)" --description $(HEROKUISH_DESCRIPTION) --license 'MIT License' .
+	sudo fpm -t deb -s dir -C /tmp/build -n herokuish -v $(HEROKUISH_VERSION) -a $(HEROKUISH_ARCHITECTURE) -p $(HEROKUISH_PACKAGE_NAME) --deb-pre-depends 'docker-engine-cs (>= 1.9.1) | docker-engine (>= 1.9.1) | docker-ce | docker-ee' --deb-pre-depends sudo --after-install /tmp/tmp/post-install --url "https://github.com/$(HEROKUISH_REPO_NAME)" --description $(HEROKUISH_DESCRIPTION) --license 'MIT License' .
 	mv *.deb /tmp
 
 deb-dokku:

--- a/rpm.mk
+++ b/rpm.mk
@@ -97,7 +97,7 @@ endif
 		--depends 'man-db' \
 		--depends 'sshcommand' \
 		--depends 'gliderlabs-sigil' \
-		--depends 'docker-engine >= 1.9.1' \
+		--depends 'docker-engine >= 1.9.1 | docker-engine-cs >= 1.9.1 | docker-ce | docker-ee' \
 		--depends 'bind-utils' \
 		--depends 'nginx' \
 		--depends 'plugn' \

--- a/rpm.mk
+++ b/rpm.mk
@@ -35,7 +35,7 @@ rpm-herokuish:
 		-v $(HEROKUISH_VERSION) \
 		-a $(RPM_ARCHITECTURE) \
 		-p $(HEROKUISH_RPM_PACKAGE_NAME) \
-		--depends 'docker-engine >= 1.9.1' \
+		--depends '/usr/bin/docker' \
 		--depends 'sudo' \
 		--after-install rpm/herokuish.postinst \
 		--url "https://github.com/$(HEROKUISH_REPO_NAME)" \

--- a/rpm.mk
+++ b/rpm.mk
@@ -97,7 +97,7 @@ endif
 		--depends 'man-db' \
 		--depends 'sshcommand' \
 		--depends 'gliderlabs-sigil' \
-		--depends 'docker-engine >= 1.9.1 | docker-engine-cs >= 1.9.1 | docker-ce | docker-ee' \
+		--depends '/usr/bin/docker' \
 		--depends 'bind-utils' \
 		--depends 'nginx' \
 		--depends 'plugn' \


### PR DESCRIPTION
Docker has this thing where they rebrand the debian package name once a year, and as YUM doesn't resolve anything like a "Provides" field, this is the best we can do (unless they all required the same metapackage).

Note that now we can't ensure a specific minor docker version via RPM, though I feel as though if you choose a crappy OS/package manager and we fail you, thats on you, not Dokku.

Closes #2732