### PR TITLE
Allow quieter report output

### DIFF
--- a/plugins/apps/subcommands/report
+++ b/plugins/apps/subcommands/report
@@ -30,7 +30,7 @@ report_single_app() {
   )
 
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2 "$APP"
+    dokku_log_info2_quiet "$APP app information"
     if (is_deployed "$APP"); then
       for flag in "${flag_map[@]}"; do
         key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"

--- a/plugins/certs/subcommands/report
+++ b/plugins/certs/subcommands/report
@@ -93,7 +93,7 @@ report_single_app() {
   )
 
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2 "$APP ssl information"
+    dokku_log_info2_quiet "$APP ssl information"
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
       dokku_log_verbose "$(printf "%-20s %-25s" "${key^}" "${flag#*: }")"

--- a/plugins/checks/subcommands/report
+++ b/plugins/checks/subcommands/report
@@ -32,7 +32,7 @@ report_single_app() {
   )
 
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2 "$APP checks information"
+    dokku_log_info2_quiet "$APP checks information"
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
       dokku_log_verbose "$(printf "%-20s %-25s" "${key^}" "${flag#*: }")"

--- a/plugins/docker-options/subcommands/report
+++ b/plugins/docker-options/subcommands/report
@@ -25,7 +25,7 @@ report_single_app() {
   )
 
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2 "$APP docker options information"
+    dokku_log_info2_quiet "$APP docker options information"
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
       dokku_log_verbose "$(printf "%-20s %-25s" "${key^}" "${flag#*: }")"

--- a/plugins/domains/subcommands/report
+++ b/plugins/domains/subcommands/report
@@ -49,7 +49,7 @@ report_single_app() {
   )
 
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2 "$APP domains information"
+    dokku_log_info2_quiet "$APP domains information"
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
       dokku_log_verbose "$(printf "%-20s %-25s" "${key^}" "${flag#*: }")"

--- a/plugins/proxy/subcommands/report
+++ b/plugins/proxy/subcommands/report
@@ -27,7 +27,7 @@ report_single_app() {
   )
 
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2 "$APP proxy information"
+    dokku_log_info2_quiet "$APP proxy information"
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
       dokku_log_verbose "$(printf "%-20s %-25s" "${key^}" "${flag#*: }")"

--- a/plugins/ps/subcommands/report
+++ b/plugins/ps/subcommands/report
@@ -46,7 +46,7 @@ report_single_app() {
   )
 
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2 "$APP"
+    dokku_log_info2_quiet "$APP process information"
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
       dokku_log_verbose "$(printf "%-20s %-25s" "${key^}" "${flag#*: }")"

--- a/plugins/storage/subcommands/report
+++ b/plugins/storage/subcommands/report
@@ -25,7 +25,7 @@ report_single_app() {
   )
 
   if [[ -z "$INFO_FLAG" ]]; then
-    dokku_log_info2 "$APP storage information"
+    dokku_log_info2_quiet "$APP storage information"
     for flag in "${flag_map[@]}"; do
       key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
       dokku_log_verbose "$(printf "%-20s %-25s" "${key^}" "${flag#*: }")"


### PR DESCRIPTION
Users should have the option of suppressing headers, which are not always useful when interacting with dokku in a programmatic fashion.