### PR TITLE
Update herokuish base image on updates using --pull

### DIFF
--- a/deb.mk
+++ b/deb.mk
@@ -86,16 +86,11 @@ deb-herokuish:
 	@echo "-> Creating deb files"
 	@echo "#!/usr/bin/env bash" >> /tmp/tmp/post-install
 	@echo "sleep 5" >> /tmp/tmp/post-install
-	@echo "count=\`sudo docker images | grep gliderlabs/herokuish | wc -l\`" >> /tmp/tmp/post-install
-	@echo 'if [ "$$count" -ne 0 ]; then' >> /tmp/tmp/post-install
-	@echo "  echo 'Removing old herokuish image'" >> /tmp/tmp/post-install
-	@echo "  sudo docker rmi gliderlabs/herokuish" >> /tmp/tmp/post-install
-	@echo "fi" >> /tmp/tmp/post-install
 	@echo "echo 'Importing herokuish into docker (around 5 minutes)'" >> /tmp/tmp/post-install
 	@echo 'if [[ ! -z $${http_proxy+x} ]]; then BUILDARGS="--build-arg http_proxy=$$http_proxy"; fi' >> /tmp/tmp/post-install
 	@echo 'if [[ ! -z $${https_proxy+x} ]]; then BUILDARGS="$$BUILDARGS --build-arg https_proxy=$$https_proxy"; fi' >> /tmp/tmp/post-install
 	@echo 'if [[ ! -z $${BUILDARGS+x} ]]; then echo Adding proxy settings to docker build: $$BUILDARGS; fi' >> /tmp/tmp/post-install
-	@echo 'sudo docker build $$BUILDARGS -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null' >> /tmp/tmp/post-install
+	@echo 'sudo docker build --pull $$BUILDARGS -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null' >> /tmp/tmp/post-install
 
 	@echo "-> Cloning repository"
 	git clone -q "https://github.com/$(HEROKUISH_REPO_NAME).git" --branch "v$(HEROKUISH_VERSION)" /tmp/tmp/herokuish > /dev/null

--- a/rpm/herokuish.postinst
+++ b/rpm/herokuish.postinst
@@ -7,14 +7,8 @@ main() {
 
   sleep 5
 
-  count=$(sudo docker images | grep -c gliderlabs/herokuish)
-  if [ "$count" -ne 0 ]; then
-    echo 'Removing old herokuish image'
-    sudo docker rmi gliderlabs/herokuish
-  fi
-
   echo 'Importing herokuish into docker (around 5 minutes)'
-  sudo docker build -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null
+  sudo docker build --pull -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null
 }
 
 main


### PR DESCRIPTION
Herokuish update fails if existing herokuish is used by other containers,
using `docker build --pull` will force to update also the base image.

```
Setting up herokuish (0.3.28) ...
Removing old herokuish image
Failed to remove image (gliderlabs/herokuish): Error response from daemon: conflict: unable to remove repository reference "gliderlabs/herokuish" (must force) - container dbf2298ab5a5 is using its referenced image 7d4a8d661476
Importing herokuish into docker (around 5 minutes)
```

The `--pull` option has been available since 2014 https://github.com/moby/moby/pull/9281

```
root@dokku:~# docker images | grep heroku
gliderlabs/herokuish              latest               b94c61b63e5d        3 months ago        1.32 GB
heroku/cedar                      14                   736ee34e10c1        19 months ago       1.26 GB

root@dokku:~# docker build --pull -t gliderlabs/herokuish /var/lib/herokuish
Sending build context to Docker daemon 57.86 kB
Step 1/5 : FROM heroku/cedar:14
14: Pulling from heroku/cedar
c02c7df4a131: Already exists
a3ed95caeb02: Already exists
b16a7286d2a5: Pull complete
011351573868: Pull complete
Digest: sha256:56872a131137003d9fc6eadf26e7a49bc90db3eed9b53e1dc4c26a9fc20107ea
Status: Downloaded newer image for heroku/cedar:14
 ---> d20bdc04fd6b
Step 2/5 : RUN curl https://github.com/gliderlabs/herokuish/releases/download/v0.3.24/herokuish_0.3.24_linux_x86_64.tgz 		--silent -L | tar -xzC /bin
 ---> Running in 91a5bc2da479
 ---> 891a22195988
Removing intermediate container 91a5bc2da479
Step 3/5 : RUN /bin/herokuish buildpack install 	&& ln -s /bin/herokuish /build 	&& ln -s /bin/herokuish /start 	&& ln -s /bin/herokuish /exec
 ---> Running in 2b66a2ca6f64
Cloning into '/tmp/buildpacks/00_buildpack-multi'...
Cloning into '/tmp/buildpacks/01_buildpack-ruby'...
Cloning into '/tmp/buildpacks/02_buildpack-nodejs'...
Cloning into '/tmp/buildpacks/03_buildpack-clojure'...
Cloning into '/tmp/buildpacks/04_buildpack-python'...
Cloning into '/tmp/buildpacks/05_buildpack-java'...
Cloning into '/tmp/buildpacks/06_buildpack-gradle'...
Cloning into '/tmp/buildpacks/07_buildpack-grails'...
Cloning into '/tmp/buildpacks/08_buildpack-scala'...
Cloning into '/tmp/buildpacks/09_buildpack-play'...
Cloning into '/tmp/buildpacks/10_buildpack-php'...
Cloning into '/tmp/buildpacks/11_buildpack-go'...
Cloning into '/tmp/buildpacks/12_buildpack-erlang'...
Cloning into '/tmp/buildpacks/13_buildpack-static'...
 ---> f2120e506d17
Removing intermediate container 2b66a2ca6f64
Step 4/5 : COPY include/default_user.bash /tmp/default_user.bash
 ---> 4983dd15fcbd
Removing intermediate container 58924a513e38
Step 5/5 : RUN bash /tmp/default_user.bash && rm -f /tmp/default_user.bash
 ---> Running in e29f86d8969e
 ---> f87b674a5d48
Removing intermediate container e29f86d8969e
Successfully built f87b674a5d48

root@dokku:~# docker images | grep heroku
gliderlabs/herokuish              latest               f87b674a5d48        About a minute ago   1.4 GB
heroku/cedar                      14                   d20bdc04fd6b        3 months ago         1.35 GB
```