### PR TITLE
Use short-hand method for shutting down all applications in upgrade docs

### DIFF
--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -24,7 +24,7 @@ If Dokku was installed via `apt-get install dokku` or `bootstrap.sh` (most commo
 
 ```shell
 sudo apt-get update
-dokku apps | tail -n+2 | xargs -L1 dokku ps:stop # stops each running app
+dokku --quiet apps | xargs -L1 dokku ps:stop # stops each running app
 sudo apt-get install -qq -y dokku herokuish sshcommand plugn
 dokku ps:rebuildall # rebuilds all applications
 ```
@@ -44,7 +44,7 @@ dokku ps:rebuildall # rebuilds all applications
 If you installed Dokku from source (less common), upgrade with:
 
 ```shell
-dokku apps | tail -n+2 | xargs -L1 dokku ps:stop # stops each running app
+dokku --quiet apps | xargs -L1 dokku ps:stop # stops each running app
 cd ~/dokku
 git pull --tags origin master
 

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -24,8 +24,7 @@ If Dokku was installed via `apt-get install dokku` or `bootstrap.sh` (most commo
 
 ```shell
 sudo apt-get update
-dokku apps
-dokku ps:stop APP # repeat to shut down each running app
+dokku apps | tail -n+2 | xargs -L1 dokku ps:stop # stops each running app
 sudo apt-get install -qq -y dokku herokuish sshcommand plugn
 dokku ps:rebuildall # rebuilds all applications
 ```
@@ -45,8 +44,7 @@ dokku ps:rebuildall # rebuilds all applications
 If you installed Dokku from source (less common), upgrade with:
 
 ```shell
-dokku apps
-dokku ps:stop APP # repeat to shut down each running app
+dokku apps | tail -n+2 | xargs -L1 dokku ps:stop # stops each running app
 cd ~/dokku
 git pull --tags origin master
 


### PR DESCRIPTION
Add short-hand method for shutting down all apps. Useful for users with large number of apps.