### PR TITLE
Fix typo from "To use a dockerfiles" to "To use a dockerfile" singular

### DIFF
--- a/docs/deployment/methods/dockerfiles.md
+++ b/docs/deployment/methods/dockerfiles.md
@@ -6,7 +6,7 @@ While Dokku normally defaults to using [heroku buildpacks](https://devcenter.her
 
 > Dockerfile support is considered a **Power User** feature. By using Dockerfile-based deployment, you agree that you will not have the same comfort as that enjoyed by Buildpack users, and Dokku features may work differently. Differences between the two systems will be documented here.
 
-To use a dockerfiles for deployment, commit a valid `Dockerfile` to the root of your repository and push the repository to your Dokku installation. If this file is detected, Dokku will default to using it to construct containers **except** in the following two cases:
+To use a dockerfile for deployment, commit a valid `Dockerfile` to the root of your repository and push the repository to your Dokku installation. If this file is detected, Dokku will default to using it to construct containers **except** in the following two cases:
 
 - The application has a `BUILDPACK_URL` environment variable set via the `dokku config:set` command or in a committed `.env` file. In this case, Dokku will use your specified buildpack.
 - The application has a `.buildpacks` file in the root of the repository. In this case, Dokku will use your specified buildpack(s).


### PR DESCRIPTION
Hi!

Thanks for the great documentation for an equally great project.
This change just changes "To use a dockerfile**s** for deployment" to..."To use a dockerfile for deployment". A singular dockerfile.

Thanks again!