### PR TITLE
fix: Install python3-software-properties as an alternative to python-software-properties

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.9.4
 Section: web
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, gcc, man-db, sshcommand (>= 0.6.0), gliderlabs-sigil, docker-engine-cs (>= 1.9.1) | docker-engine (>= 1.9.1) | docker-ce | docker-ee, software-properties-common, python-software-properties
+Depends: locales, git, make, curl, gcc, man-db, sshcommand (>= 0.6.0), gliderlabs-sigil, docker-engine-cs (>= 1.9.1) | docker-engine (>= 1.9.1) | docker-ce | docker-ee, software-properties-common, python-software-properties | python3-software-properties
 Recommends: herokuish (>= 0.3.4), parallel
 Pre-Depends: nginx (>= 1.8.0), dnsutils, cgroupfs-mount | cgroup-lite, plugn (>= 0.3.0), sudo, python2.7, debconf
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>


### PR DESCRIPTION
Closes #2762

[ci skip]