### PR TITLE
include docker-options in the default `dokku`

### DIFF
--- a/plugins/docker-options/commands
+++ b/plugins/docker-options/commands
@@ -2,28 +2,36 @@
 [[ " help docker-options:help " == *" $1 "* ]] || exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-case "$1" in
-  help | docker-options:help)
-    help_content_func () {
-      declare desc="return docker-options plugin help content"
-      cat<<help_content
+docker_options_help_content_func() {
+    declare desc="return docker-options plugin help content"
+    cat<<help_content
     docker-options <app> [phase(s)], [DEPRECATED] Alternative for docker-options:report
     docker-options:add <app> <phase(s)> OPTION, Add Docker option to app for phase (comma separated phase list)
     docker-options:remove <app> <phase(s)> OPTION, Remove Docker option from app for phase (comma separated phase list)
     docker-options:report [<app>] [<flag>], Displays a docker options report for one or more apps
 help_content
-    }
+}
 
-    if [[ $1 = "docker-options:help" ]] ; then
-        echo -e 'Usage: dokku docker-options[:COMMAND]'
-        echo ''
-        echo 'Display app'"'"'s Docker options for all phases.'
-        echo ''
-        echo 'Additional commands:'
-        help_content_func | sort | column -c2 -t -s,
-    else
-        help_content_func
-    fi
+docker_options_help_cmd() {
+  if [[ $1 = "docker-options:help" ]] ; then
+    echo -e 'Usage: dokku docker-options[:COMMAND]'
+    echo ''
+    echo 'Display app'"'"'s Docker options for all phases.'
+    echo ''
+    echo 'Additional commands:'
+    docker_options_help_content_func | sort | column -c2 -t -s,
+  elif [[ $(ps -o command= $PPID) == *"--all"* ]]; then
+    docker_options_help_content_func
+  else
+    cat<<help_desc
+    docker-options, Pass options to Docker the various stages of an app
+help_desc
+  fi
+}
+
+case "$1" in
+  help | docker-options:help)
+    docker_options_help_cmd "$@"
   ;;
 
   *)


### PR DESCRIPTION
This PR should list the default enabled docker-options plugin in the help listing. This should ease the `discovery` of the plugin.