### PR TITLE
Turn on ps-post-stop hook.

### DIFF
--- a/plugins/ps/post-stop
+++ b/plugins/ps/post-stop
@@ -11,3 +11,5 @@ ps_post_stop() {
 
   config_set --no-restart "$APP" DOKKU_APP_RESTORE=0
 }
+
+ps_post_stop "$@"


### PR DESCRIPTION
ps_post_stop() is defined but never used, DOKKU_APP_RESTORE never set to `1`.

That is really nice to prevent the application restart by hooks (such as `config_set`) for manually stopped applications.