### PR TITLE
fix /etc/logrotate.d/dokku on debian

### DIFF
--- a/plugins/20_events/install
+++ b/plugins/20_events/install
@@ -60,7 +60,7 @@ $DOKKU_LOGS_DIR/*.log {
 EOF
 
   if [[ "$DOKKU_DISTRO" = "debian" ]]; then
-    sed -i 's/ syslog dokku$/root dokku/g' $DOKKU_LOGROTATE_FILE
+    sed -i 's/ syslog dokku$/ root dokku/g' $DOKKU_LOGROTATE_FILE
   fi
 
   flag_rsyslog_needs_restart=y


### PR DESCRIPTION
This fixes /etc/logrotate.d/dokku on debian.

What it contained:
```
suroot dokku
...
create 664root dokku
```

What it should contain:
```
su root dokku
...
create 664 root dokku
```
