### PR TITLE
Add entry for insecure connection issue in Rails

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -195,3 +195,12 @@ sudo ufw disable
 
 ***
 
+__Symptom:__ I can't connect to my application because the server is sending an invalid response, or can't provide a secure connection.
+
+__Solution:__
+
+This can happen when your application is configured to enforce secure connections, but you don't have SSL set up for it.
+
+In Rails at least, if your `application.rb` or `environmnents/production.rb` include the line `configure.force_ssl = true`, which includes HSTS try commenting that out and redeploying.
+
+If this solves the issue, longer term you may want to consider [configuring SSL](http://dokku.viewdocs.io/dokku/configuration/ssl/).

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -199,8 +199,8 @@ __Symptom:__ I can't connect to my application because the server is sending an 
 
 __Solution:__
 
-This can happen when your application is configured to enforce secure connections, but you don't have SSL set up for it.
+This isn't usually an issue with Dokku, but rather an app config problem. This can happen when your application is configured to enforce secure connections/HSTS, but you don't have SSL set up for the app.
 
 In Rails at least, if your `application.rb` or `environmnents/production.rb` include the line `configure.force_ssl = true`, which includes HSTS try commenting that out and redeploying.
 
-If this solves the issue, longer term you may want to consider [configuring SSL](http://dokku.viewdocs.io/dokku/configuration/ssl/).
+If this solves the issue temporarily, longer term you should consider [configuring SSL](http://dokku.viewdocs.io/dokku/configuration/ssl/).


### PR DESCRIPTION
If an application is configured to enforce secure connections and SSL isn't configured for Dokku or the application, browsers will raise an Invalid Connection error.

Entry describes issue, a code resolution for Rails, and points users to the SSL docs.

[ci skip]
