### PR TITLE
Update CURL_CONNECT_TIMEOUT in docs

### DIFF
--- a/docs/deployment/methods/buildpacks.md
+++ b/docs/deployment/methods/buildpacks.md
@@ -87,7 +87,7 @@ If you see output similar this when deploying , you may need to override the cur
 
 ```shell
 dokku config:set --global CURL_TIMEOUT=600
-dokku config:set --global CURL_CONNECT_TIMEOUT=30
+dokku config:set --global CURL_CONNECT_TIMEOUT=180
 ```
 
 ## Clearing buildpack cache

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -150,7 +150,7 @@ it might that the curl command that is supposed to fetch the buildpack (anything
 
 ```shell
 dokku config:set --global CURL_TIMEOUT=600
-dokku config:set --global CURL_CONNECT_TIMEOUT=30
+dokku config:set --global CURL_CONNECT_TIMEOUT=180
 ```
 
 Please see https://github.com/dokku/dokku/issues/509


### PR DESCRIPTION
Current default of CURL_CONNECT_TIMEOUT is 90.
So 30 is shorter than default.
[ci skip]