### PR TITLE
Add support for Health Check Headers in CHECKS

### DIFF
--- a/docs/deployment/methods/images.md
+++ b/docs/deployment/methods/images.md
@@ -158,3 +158,12 @@ Here's a more complete example using the above method:
 # build the image
 docker build -t dokku/test-app:v12 .
 # copy the image to the dokku host
+docker save dokku/test-app:v12 | bzip2 | ssh my.dokku.host "bunzip2 | docker load"
+# tag and deploy the image
+ssh my.dokku.host "dokku tags:create test-app previous; dokku tags:deploy test-app v12 && dokku tags:create test-app latest"
+```
+
+## Related articles
+- [Setting up Persistent Storage](/docs/advanced-usage/persistent-storage.md)
+- [Defining Environment Variables](/docs/configuration/environment-variables.md)
+- [Setting up the Ports](/docs/advanced-usage/proxy-management.md)

--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -68,6 +68,10 @@ checks_check_deploy() {
   local TIMEOUT="${DOKKU_CHECKS_TIMEOUT:-30}"
   # use this number of retries for checks
   local ATTEMPTS="${DOKKU_CHECKS_ATTEMPTS:-5}"
+  # Health check header
+  local HEALTH_CHECK_HEADER="${DOKKU_CHECKS_HEALTH_CHECK_HEADER}"
+  # Health check token
+  local HEALTH_CHECK_TOKEN="${DOKKU_CHECKS_HEALTH_CHECK_TOKEN}"
 
   # try to copy CHECKS from container if not in APP dir & quit gracefully if it doesn't exist
   # docker cp exits with status 1 when run as non-root user when it tries to chown the file
@@ -135,6 +139,8 @@ checks_check_deploy() {
       [[ "$NAME" = "WAIT" ]] && local WAIT=$VALUE
       [[ "$NAME" = "TIMEOUT" ]] && local TIMEOUT=$VALUE
       [[ "$NAME" = "ATTEMPTS" ]] && local ATTEMPTS=$VALUE
+      [[ "$NAME" = "HEALTH_CHECK_HEADER" ]] && local HEALTH_CHECK_HEADER=$VALUE
+      [[ "$NAME" = "HEALTH_CHECK_TOKEN" ]] && local HEALTH_CHECK_TOKEN=$VALUE
     fi
   done
 
@@ -190,6 +196,9 @@ checks_check_deploy() {
         local URL_PATHNAME=${UNPREFIXED#$URL_HOSTNAME}
 
         local HEADERS="-H Host:$URL_HOSTNAME"
+        if [[ -n HEALTH_CHECK_HEADER && -n HEALTH_CHECK_TOKEN ]]; then
+          local HEADERS+=" -H ${HEALTH_CHECK_HEADER}:${HEALTH_CHECK_TOKEN}"
+        fi
       else
         local URL_HOSTNAME=localhost
         local URL_PATHNAME=$CHECK_URL


### PR DESCRIPTION
**Added settings for CHECKS file**
- `HEALTH_CHECK_HEADER`
- `HEALTH_CHECK_TOKEN`

**Added Environment Variables**
- `DOKKU_CHECKS_HEALTH_CHECK_HEADER`
- `DOKKU_CHECKS_HEALTH_CHECK_TOKEN`

_Note: This is a unchecked, untested addition which should work, but i cannot run tests._
