### PR TITLE
Remove aufs step from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ sigil:
 	wget -qO /tmp/sigil_latest.tgz ${SIGIL_URL}
 	tar xzf /tmp/sigil_latest.tgz -C /usr/local/bin
 
-docker: aufs
+docker:
 	apt-get install -qq -y curl
 	egrep -i "^docker" /etc/group || groupadd docker
 	usermod -aG docker dokku
@@ -147,11 +147,6 @@ ifdef DOCKER_VERSION
 	apt-get install -qq -y docker-engine=${DOCKER_VERSION} || (apt-cache madison docker-engine ; exit 1)
 endif
 	sleep 2 # give docker a moment i guess
-endif
-
-aufs:
-ifndef CI
-	lsmod | grep aufs || modprobe aufs || apt-get install -qq -y linux-image-extra-`uname -r` > /dev/null
 endif
 
 stack:


### PR DESCRIPTION
Remove aufs step from Makefile in favor of aufs provisioning provided by official docker install script.

The [docker install script](https://get.docker.com/) used in this Makefile will install aufs if necessary for the environments (ubuntu/debian) where its available.

This is one of several PRs required to have Dokku installable in a raspbian environment where the aufs storage driver is not available nor necessary for that environment (Older versions of Docker required AUFS, this is no longer the case).
