### PR TITLE
Add stickler-ci configuration.

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,9 @@
+linters:
+  shellcheck:
+    shell: bash
+    exclude: SC2034
+  golint:
+
+files:
+    ignore:
+      - './debian/*'


### PR DESCRIPTION
In talking with @josegonzalez, stickler-ci.com helps reduce the amount of time maintainers spend reviewing code by automatically giving style feedback as pull request comments.

I've added linters for shell scripts and go files based on the linting I could find in the existing make files.

If you merge this, you will also need to log in to https://stickler-ci.com and enable webhooks for the repository by enabling the appropriate checkbox.
