### PR TITLE
fix: use python2.7 binary instead of python2 binary

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -1065,7 +1065,7 @@ get_json_value() {
   local JSON_NODE="$1"
   local JSON_NODE=${JSON_NODE//\./\"][\"}
   local JSON_NODE="[\"${JSON_NODE}\"]"
-  cat | python2 -c 'import json,sys;obj=json.load(sys.stdin);print json.dumps(obj'"${JSON_NODE}"').strip("\"")';
+  cat | python2.7 -c 'import json,sys;obj=json.load(sys.stdin);print json.dumps(obj'"${JSON_NODE}"').strip("\"")';
 }
 
 get_json_keys() {
@@ -1075,9 +1075,9 @@ get_json_keys() {
   local JSON_NODE=${JSON_NODE//\./\"][\"}
   local JSON_NODE="[\"${JSON_NODE}\"]"
   if [[ "$JSON_NODE" == "[\"\"]" ]]; then
-    cat | python2 -c 'import json,sys;obj=json.load(sys.stdin);print " ".join(obj.keys())';
+    cat | python2.7 -c 'import json,sys;obj=json.load(sys.stdin);print " ".join(obj.keys())';
   else
-    cat | python2 -c 'import json,sys;obj=json.load(sys.stdin);print " ".join(obj'"${JSON_NODE}"'.keys())';
+    cat | python2.7 -c 'import json,sys;obj=json.load(sys.stdin);print " ".join(obj'"${JSON_NODE}"'.keys())';
   fi
 }
 


### PR DESCRIPTION
On hosts where python3 is the system default python env and there is a minimal server installation, Dokku will silently fail to return the values of json keys.
