### PR TITLE
add optional PROC_TYPE and CONTAINER_INDEX to docker-args-deploy plugn trigger

### DIFF
--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -215,6 +215,7 @@ Note: The following plugins have been supplied by our community and may not have
 | [Docker auto persist volumes](https://github.com/Flink/dokku-docker-auto-volumes)                 | [Flink][]             | 0.4.0+                |
 | [Hostname](https://github.com/michaelshobbs/dokku-hostname)                                       | [michaelshobbs][]     | 0.4.0+                |
 | [Logspout](https://github.com/michaelshobbs/dokku-logspout)                                       | [michaelshobbs][]     | 0.4.0+                |
+| [Syslog](https://github.com/michaelshobbs/dokku-syslog)                                           | [michaelshobbs][]     | 0.10.4+               |
 | [Long Timeout](https://github.com/investtools/dokku-long-timeout-plugin)                          | [investtools][]       | 0.4.0+                |
 | [Monit](https://github.com/cjblomqvist/dokku-monit)                                               | [cjblomqvist][]       | 0.3.x                 |
 | [Monorepo](https://github.com/iamale/dokku-monorepo)                                              | [iamale][]            | 0.4.0+                |

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -259,7 +259,7 @@ cache-bust-build-arg "$@"
 
 - Description:
 - Invoked by: `dokku deploy`
-- Arguments: `$APP $IMAGE_TAG`
+- Arguments: `$APP $IMAGE_TAG [$PROC_TYPE $CONTAINER_INDEX]`
 - Example:
 
 ```shell

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -541,7 +541,6 @@ dokku_deploy_cmd() {
   local DOKKU_SCALE_FILE="$DOKKU_ROOT/$APP/DOKKU_SCALE"
   local oldids=$(get_app_container_ids "$APP")
 
-  local DOKKU_DEFAULT_DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG")
   local DOKKU_IS_APP_PROXY_ENABLED="$(is_app_proxy_enabled "$APP")"
   local DOKKU_DOCKER_STOP_TIMEOUT="$(config_get "$APP" DOKKU_DOCKER_STOP_TIMEOUT || true)"
   [[ $DOKKU_DOCKER_STOP_TIMEOUT ]] && DOCKER_STOP_TIME_ARG="--time=${DOKKU_DOCKER_STOP_TIMEOUT}"
@@ -573,9 +572,10 @@ dokku_deploy_cmd() {
       local DOKKU_PORT_FILE="$DOKKU_ROOT/$APP/PORT.$PROC_TYPE.$CONTAINER_INDEX"
 
       # start the app
-      local DOCKER_ARGS="$DOKKU_DEFAULT_DOCKER_ARGS"
-      local DOCKER_ARGS+=" -e DYNO=$PROC_TYPE.$CONTAINER_INDEX "
-      [[ "$DOKKU_TRACE" ]] && local DOCKER_ARGS+=" -e TRACE=true "
+      local DOCKER_ARGS
+      DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")
+      DOCKER_ARGS+=" -e DYNO=$PROC_TYPE.$CONTAINER_INDEX "
+      [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" -e TRACE=true "
 
       [[ -n "$DOKKU_HEROKUISH" ]] && local START_CMD="/start $PROC_TYPE"
 


### PR DESCRIPTION
this will allow plugin developers more flexibility in crafting docker-args for the deploy phase. ex: `--log-opt tag=${APP}.${PROC_TYPE}.${CONTAINER_INDEX}`