### PR TITLE
(re)Added SSL protocols TLSv1, TLSv1.1

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -65,7 +65,7 @@ server {
 
   ssl_certificate     {{ $.APP_SSL_PATH }}/server.crt;
   ssl_certificate_key {{ $.APP_SSL_PATH }}/server.key;
-  ssl_protocols       TLSv1.2;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   ssl_prefer_server_ciphers on;
 
   keepalive_timeout   70;


### PR DESCRIPTION
Not so old Androids are having problems connecting. (Android 4.2.2 and Android 4.3).

More info: I work with mobile apps APIs, so I'm seeing this failing quite often

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
