### PR TITLE
Fix deprecated command invocation

### DIFF
--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -36,7 +36,7 @@ If Dokku was installed via `apt-get install dokku` or `bootstrap.sh` (most commo
 
 ```shell
 sudo apt-get update
-dokku --quiet apps | xargs -L1 dokku ps:stop # stops each running app
+dokku --quiet apps:list | xargs -L1 dokku ps:stop # stops each running app
 sudo apt-get install -qq -y dokku herokuish sshcommand plugn
 dokku ps:rebuildall # rebuilds all applications
 ```
@@ -56,7 +56,7 @@ dokku ps:rebuildall # rebuilds all applications
 If you installed Dokku from source (less common), upgrade with:
 
 ```shell
-dokku --quiet apps | xargs -L1 dokku ps:stop # stops each running app
+dokku --quiet apps:list | xargs -L1 dokku ps:stop # stops each running app
 cd ~/dokku
 git pull --tags origin master
 


### PR DESCRIPTION
Invoking `dokku apps` has been deprecated, use `dokku apps:list`

[ci skip]
