### PR TITLE
refactor: split-up build process into "builder" functionality

### DIFF
--- a/plugins/builder-dockerfile/build
+++ b/plugins/builder-dockerfile/build
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+
+main() {
+  declare desc="build phase"
+  declare APP="$1" APP_IMAGE_NAME="$2" DOKKU_APP_TYPE="$3" TMP_WORK_DIR="$4" CACHE_DIR="$5"
+  local CONTAINER_ID DOCKER_ARGS DOCKERFILE_CMD DOCKERFILE_ENTRYPOINT DOCKERFILE_PORTS IMAGE
+
+  if [[ "$DOKKU_APP_TYPE" != "dockerfile" ]]; then
+    return
+  fi
+
+  # extract first port from Dockerfile
+  DOCKERFILE_PORTS=$(get_dockerfile_exposed_ports Dockerfile)
+  [[ -n "$DOCKERFILE_PORTS" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_PORTS="$DOCKERFILE_PORTS"
+
+  # extract ENTRYPOINT/CMD from Dockerfile
+  DOCKERFILE_ENTRYPOINT=$(extract_directive_from_dockerfile Dockerfile ENTRYPOINT)
+  [[ -n "$DOCKERFILE_ENTRYPOINT" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_ENTRYPOINT="$DOCKERFILE_ENTRYPOINT"
+  DOCKERFILE_CMD=$(extract_directive_from_dockerfile Dockerfile CMD)
+  [[ -n "$DOCKERFILE_CMD" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_CMD="$DOCKERFILE_CMD"
+  plugn trigger pre-build-dockerfile "$APP"
+
+  [[ "$DOKKU_DOCKERFILE_CACHE_BUILD" == "false" ]] && DOKKU_DOCKER_BUILD_OPTS="$DOKKU_DOCKER_BUILD_OPTS --no-cache"
+  DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$DOKKU_APP_TYPE")
+  # strip --volume and -v args from DOCKER_ARGS
+  DOCKER_ARGS=$(sed -e "s/--volume=[[:graph:]]\+[[:blank:]]\?//g" -e "s/-v[[:blank:]]\?[[:graph:]]\+[[:blank:]]\?//g" <<< "$DOCKER_ARGS")
+
+  # shellcheck disable=SC2086
+  docker build $DOCKER_ARGS $DOKKU_DOCKER_BUILD_OPTS -t $APP_IMAGE_NAME .
+
+  plugn trigger post-build-dockerfile "$APP"
+}
+
+main "$@"

--- a/plugins/builder-dockerfile/build-type
+++ b/plugins/builder-dockerfile/build-type
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+
+main() {
+  declare desc="determines the build type for an application"
+  declare APP="$1" BUILD_TYPE="2" TMP_WORK_DIR="$3"
+  declare STDIN
+  STDIN=$(cat)
+
+  if [[ -n "$BUILD_TYPE" ]]; then
+    echo "$STDIN"
+    return
+  fi
+
+  pushd "$TMP_WORK_DIR" > /dev/null
+  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && [[ -z $(config_get "$APP" BUILDPACK_URL || true) ]]; then
+    echo "dockerfile"
+    return
+  fi
+
+  echo "$STDIN"
+}
+
+main "$@"

--- a/plugins/builder-dockerfile/plugin.toml
+++ b/plugins/builder-dockerfile/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "dokku core builder-dockerfile plugin"
+version = "0.10.4"
+[plugin.config]

--- a/plugins/builder-dockerfile/release
+++ b/plugins/builder-dockerfile/release
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+main() {
+  declare desc="build phase"
+  declare APP="$1" APP_IMAGE_NAME="$2" DOKKU_APP_TYPE="$3" IMAGE_TAG="$4"
+  local DOCKER_IMAGE_PORTS DOKKU_DOCKERFILE_PORTS
+
+  if [[ "$DOKKU_APP_TYPE" != "dockerfile" ]]; then
+    return
+  fi
+
+  DOKKU_DOCKERFILE_PORTS=$(config_get "$APP" DOKKU_DOCKERFILE_PORTS || true)
+  if [[ -z "$DOKKU_DOCKERFILE_PORTS" ]]; then
+    DOCKER_IMAGE_PORTS=$(get_exposed_ports_from_image "$IMAGE")
+    [[ -n "$DOCKER_IMAGE_PORTS" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_PORTS="$DOCKER_IMAGE_PORTS"
+  fi
+
+  # buildstep plugins don't necessarily make sense for dockerfiles. call the new breed!!!
+  plugn trigger pre-release-dockerfile "$APP" "$IMAGE_TAG"
+  plugn trigger post-release-dockerfile "$APP" "$IMAGE_TAG"
+}
+
+main "$@"

--- a/plugins/builder-herokuish/build
+++ b/plugins/builder-herokuish/build
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+
+main() {
+  declare desc="build phase"
+  declare APP="$1" APP_IMAGE_NAME="$2" DOKKU_APP_TYPE="$3" TMP_WORK_DIR="$4" CACHE_DIR="$5"
+  local APP_IMAGE_NAME CONTAINER_ID DOCKER_ARGS DOKKU_IMAGE
+
+  if [[ "$DOKKU_APP_TYPE" != "herokuish" ]]; then
+    return
+  fi
+
+  DOKKU_IMAGE="$(config_get "$APP" DOKKU_IMAGE || echo "$DOKKU_IMAGE")"
+  CONTAINER_ID="$(tar -c . | docker run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /app && tar -xC /app")"
+  test "$(docker wait "$CONTAINER_ID")" -eq 0
+  docker commit "$CONTAINER_ID" "$APP_IMAGE_NAME" > /dev/null
+  [[ -d "$CACHE_DIR" ]] || mkdir -p "$CACHE_DIR"
+  plugn trigger pre-build-buildpack "$APP"
+
+  DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$DOKKU_APP_TYPE")
+  [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" -e TRACE=true "
+  # shellcheck disable=SC2086
+  CONTAINER_ID="$(docker run $DOKKU_GLOBAL_RUN_ARGS -d -v $CACHE_DIR:/cache -e CACHE_PATH=/cache $DOCKER_ARGS $APP_IMAGE_NAME /build)"
+  docker attach "$CONTAINER_ID"
+  test "$(docker wait "$CONTAINER_ID")" -eq 0
+  docker commit "$CONTAINER_ID" "$APP_IMAGE_NAME" > /dev/null
+
+  plugn trigger post-build-buildpack "$APP"
+}
+
+main "$@"

--- a/plugins/builder-herokuish/build-type
+++ b/plugins/builder-herokuish/build-type
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+
+main() {
+  declare desc="determines the build type for an application"
+  declare APP="$1" BUILD_TYPE="2" TMP_WORK_DIR="$3"
+  declare STDIN
+  STDIN=$(cat)
+
+  if [[ -n "$BUILD_TYPE" ]]; then
+    echo "$STDIN"
+    return
+  fi
+
+  pushd "$TMP_WORK_DIR" > /dev/null
+  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && [[ -z $(config_get "$APP" BUILDPACK_URL || true) ]]; then
+    echo "$STDIN"
+    return
+  fi
+
+  echo "herokuish"
+}
+
+main "$@"

--- a/plugins/builder-herokuish/plugin.toml
+++ b/plugins/builder-herokuish/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "dokku core builder-herokuish plugin"
+version = "0.10.4"
+[plugin.config]

--- a/plugins/builder-herokuish/release
+++ b/plugins/builder-herokuish/release
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+
+main() {
+  declare desc="build phase"
+  declare APP="$1" APP_IMAGE_NAME="$2" DOKKU_APP_TYPE="$3" IMAGE_TAG="$4"
+  local CONTAINER_ID
+
+  if [[ "$DOKKU_APP_TYPE" != "herokuish" ]]; then
+    return
+  fi
+
+  plugn trigger pre-release-buildpack "$APP" "$IMAGE_TAG"
+  if [[ -n $(config_export global) ]]; then
+    CONTAINER_ID=$(config_export global | docker run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh")
+    test "$(docker wait "$CONTAINER_ID")" -eq 0
+    docker commit "$CONTAINER_ID" "$IMAGE" > /dev/null
+  fi
+  if [[ -n $(config_export app "$APP") ]]; then
+    CONTAINER_ID=$(config_export app "$APP" | docker run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh")
+    test "$(docker wait "$CONTAINER_ID")" -eq 0
+    docker commit "$CONTAINER_ID" "$IMAGE" > /dev/null
+  fi
+  plugn trigger post-release-buildpack "$APP" "$IMAGE_TAG"
+}
+
+main "$@"

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -437,98 +437,28 @@ is_app_running() {
 
 dokku_build() {
   declare desc="build phase"
-  source "$PLUGIN_AVAILABLE_PATH/config/functions"
-
-  local APP="$1"; local IMAGE_SOURCE_TYPE="$2"; local TMP_WORK_DIR="$3"; local IMAGE=$(get_app_image_name "$APP")
+  declare APP="$1" DOKKU_APP_TYPE="$2" TMP_WORK_DIR="$3"
+  local APP_IMAGE_NAME CACHE_DIR
   verify_app_name "$APP"
 
-  local CACHE_DIR="$DOKKU_ROOT/$APP/cache"
+  APP_IMAGE_NAME=$(get_app_image_name "$APP")
+  CACHE_DIR="$DOKKU_ROOT/$APP/cache"
 
   eval "$(config_export app "$APP")"
   pushd "$TMP_WORK_DIR" &> /dev/null
-
-  case "$IMAGE_SOURCE_TYPE" in
-    herokuish)
-      DOKKU_IMAGE="$(config_get "$APP" DOKKU_IMAGE || echo "$DOKKU_IMAGE")"
-      local id=$(tar -c . | docker run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /app && tar -xC /app")
-      test "$(docker wait "$id")" -eq 0
-      docker commit "$id" "$IMAGE" > /dev/null
-      [[ -d $CACHE_DIR ]] || mkdir -p "$CACHE_DIR"
-      plugn trigger pre-build-buildpack "$APP"
-
-      local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$IMAGE_SOURCE_TYPE")
-      [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" -e TRACE=true "
-      # shellcheck disable=SC2086
-      local id=$(docker run $DOKKU_GLOBAL_RUN_ARGS -d -v $CACHE_DIR:/cache -e CACHE_PATH=/cache $DOCKER_ARGS $IMAGE /build)
-      docker attach "$id"
-      test "$(docker wait "$id")" -eq 0
-      docker commit "$id" "$IMAGE" > /dev/null
-
-      plugn trigger post-build-buildpack "$APP"
-      ;;
-
-    dockerfile)
-      # extract first port from Dockerfile
-      local DOCKERFILE_PORTS=$(get_dockerfile_exposed_ports Dockerfile)
-      [[ -n "$DOCKERFILE_PORTS" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_PORTS="$DOCKERFILE_PORTS"
-
-      # extract ENTRYPOINT/CMD from Dockerfile
-      local DOCKERFILE_ENTRYPOINT=$(extract_directive_from_dockerfile Dockerfile ENTRYPOINT)
-      [[ -n "$DOCKERFILE_ENTRYPOINT" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_ENTRYPOINT="$DOCKERFILE_ENTRYPOINT"
-      local DOCKERFILE_CMD=$(extract_directive_from_dockerfile Dockerfile CMD)
-      [[ -n "$DOCKERFILE_CMD" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_CMD="$DOCKERFILE_CMD"
-      plugn trigger pre-build-dockerfile "$APP"
-
-      [[ "$DOKKU_DOCKERFILE_CACHE_BUILD" == "false" ]] && DOKKU_DOCKER_BUILD_OPTS="$DOKKU_DOCKER_BUILD_OPTS --no-cache"
-      local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$IMAGE_SOURCE_TYPE")
-      # strip --volume and -v args from DOCKER_ARGS
-      local DOCKER_ARGS=$(sed -e "s/--volume=[[:graph:]]\+[[:blank:]]\?//g" -e "s/-v[[:blank:]]\?[[:graph:]]\+[[:blank:]]\?//g" <<< "$DOCKER_ARGS")
-
-      # shellcheck disable=SC2086
-      docker build $DOCKER_ARGS $DOKKU_DOCKER_BUILD_OPTS -t $IMAGE .
-
-      plugn trigger post-build-dockerfile "$APP"
-      ;;
-
-    *)
-      dokku_log_fail "Building image source type $IMAGE_SOURCE_TYPE not supported!"
-      ;;
-  esac
+  plugn trigger build "$APP" "$APP_IMAGE_NAME" "$DOKKU_APP_TYPE" "$TMP_WORK_DIR" "$CACHE_DIR"
+  # TODO: Handle case where the DOKKU_APP_TYPE is invalid?
 }
 
 dokku_release() {
   declare desc="release phase"
-  source "$PLUGIN_AVAILABLE_PATH/config/functions"
-
-  local APP="$1"; local IMAGE_SOURCE_TYPE="$2"; local IMAGE_TAG="$3"; local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
+  declare APP="$1" APP_IMAGE_NAME="$2" DOKKU_APP_TYPE="$3" IMAGE_TAG="$4"
+  local APP_IMAGE_NAME
   verify_app_name "$APP"
 
-  case "$IMAGE_SOURCE_TYPE" in
-    herokuish)
-      plugn trigger pre-release-buildpack "$APP" "$IMAGE_TAG"
-      if [[ -n $(config_export global) ]]; then
-        local id=$(config_export global | docker run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh")
-        test "$(docker wait "$id")" -eq 0
-        docker commit "$id" "$IMAGE" > /dev/null
-      fi
-      if [[ -n $(config_export app "$APP") ]]; then
-        local id=$(config_export app "$APP" | docker run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh")
-        test "$(docker wait "$id")" -eq 0
-        docker commit "$id" "$IMAGE" > /dev/null
-      fi
-      plugn trigger post-release-buildpack "$APP" "$IMAGE_TAG"
-      ;;
-
-    dockerfile)
-      # buildstep plugins don't necessarily make sense for dockerfiles. call the new breed!!!
-      plugn trigger pre-release-dockerfile "$APP" "$IMAGE_TAG"
-      plugn trigger post-release-dockerfile "$APP" "$IMAGE_TAG"
-      ;;
-
-    *)
-      dokku_log_fail "Releasing image source type $IMAGE_SOURCE_TYPE not supported!"
-      ;;
-  esac
+  APP_IMAGE_NAME=$(get_app_image_name "$APP" "$IMAGE_TAG")
+  plugin trigger release "$APP" "$APP_IMAGE_NAME" "$DOKKU_APP_TYPE" "$IMAGE_TAG"
+  # TODO: Handle case where the DOKKU_APP_TYPE is invalid?
 }
 
 dokku_deploy_cmd() {
@@ -709,33 +639,30 @@ release_and_deploy() {
   declare desc="main function for releasing and deploying an app"
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
-  local APP="$1"; local IMAGE_TAG="$2"; local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
-  local DOKKU_DOCKERFILE_PORTS
+  declare APP="$1" IMAGE_TAG="$2";
+  local APP_IMAGE_NAME DOKKU_DOCKERFILE_PORTS DOKKU_APP_TYPE
 
   verify_app_name "$APP"
 
-  if verify_image "$IMAGE"; then
-    if is_image_herokuish_based "$IMAGE"; then
-      local IMAGE_SOURCE_TYPE="herokuish"
-    else
-      local IMAGE_SOURCE_TYPE="dockerfile"
-      DOKKU_DOCKERFILE_PORTS=$(config_get "$APP" DOKKU_DOCKERFILE_PORTS || true)
-      if [[ -z "$DOKKU_DOCKERFILE_PORTS" ]]; then
-        local DOCKER_IMAGE_PORTS=$(get_exposed_ports_from_image "$IMAGE")
-        [[ -n "$DOCKER_IMAGE_PORTS" ]] && config_set --no-restart "$APP" DOKKU_DOCKERFILE_PORTS="$DOCKER_IMAGE_PORTS"
+  APP_IMAGE_NAME=$(get_app_image_name "$APP" "$IMAGE_TAG")
+  if verify_image "$APP_IMAGE_NAME"; then
+    # TODO: Figure out how to better customize this
+    DOKKU_APP_TYPE="$(config_get "$APP" DOKKU_APP_TYPE || true)"
+    if [[ -z "$DOKKU_APP_TYPE" ]]; then
+      local DOKKU_APP_TYPE="dockerfile"
+      if is_image_herokuish_based "$APP_IMAGE_NAME"; then
+        local DOKKU_APP_TYPE="herokuish"
       fi
     fi
 
+    dokku_log_info1 "Releasing $APP ($APP_IMAGE_NAME)..."
+    dokku_release "$APP" "$APP_IMAGE_NAME" "$DOKKU_APP_TYPE" "$IMAGE_TAG"
+
     local DOKKU_APP_SKIP_DEPLOY="$(config_get "$APP" DOKKU_SKIP_DEPLOY || true)"
     local DOKKU_GLOBAL_SKIP_DEPLOY="$(config_get --global DOKKU_SKIP_DEPLOY || true)"
-
     local DOKKU_SKIP_DEPLOY=${DOKKU_APP_SKIP_DEPLOY:="$DOKKU_GLOBAL_SKIP_DEPLOY"}
-
-    dokku_log_info1 "Releasing $APP ($IMAGE)..."
-    dokku_release "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG"
-
     if [[ "$DOKKU_SKIP_DEPLOY" != "true" ]]; then
-      dokku_log_info1 "Deploying $APP ($IMAGE)..."
+      dokku_log_info1 "Deploying $APP ($APP_IMAGE_NAME)..."
       dokku_deploy_cmd "$APP" "$IMAGE_TAG"
       dokku_log_info2 "Application deployed:"
       get_app_urls urls "$APP" | sed "s/^/       /"
@@ -749,14 +676,15 @@ release_and_deploy() {
 
 dokku_receive() {
   declare desc="receives an app kicks off deploy process"
+  declare APP="$1" DOKKU_APP_TYPE="$2" TMP_WORK_DIR="$3"
+  local DOKKU_SKIP_CLEANUP
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
-  local APP="$1"; local IMAGE=$(get_app_image_name "$APP"); local IMAGE_SOURCE_TYPE="$2"; local TMP_WORK_DIR="$3"
-  local DOKKU_SKIP_CLEANUP="$(config_get "$APP" DOKKU_SKIP_CLEANUP || true)"
+  DOKKU_SKIP_CLEANUP="$(config_get "$APP" DOKKU_SKIP_CLEANUP || true)"
   docker_cleanup "$APP"
-  dokku_log_info1 "Building $APP from $IMAGE_SOURCE_TYPE..."
-  config_set --no-restart "$APP" DOKKU_APP_TYPE="$IMAGE_SOURCE_TYPE" &> /dev/null
-  dokku_build "$APP" "$IMAGE_SOURCE_TYPE" "$TMP_WORK_DIR"
+  dokku_log_info1 "Building $APP from $DOKKU_APP_TYPE..."
+  config_set --no-restart "$APP" DOKKU_APP_TYPE="$DOKKU_APP_TYPE" &> /dev/null
+  dokku_build "$APP" "$DOKKU_APP_TYPE" "$TMP_WORK_DIR"
   release_and_deploy "$APP"
 }
 

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -64,13 +64,11 @@ git_build_app_repo() {
 
   plugn trigger post-extract "$APP" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV" | sed -u "s/^/"$'\e[1G'"/"
 
-  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && [[ -z $(config_get "$APP" BUILDPACK_URL || true) ]]; then
-    plugn trigger pre-receive-app "$APP" "dockerfile" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV"
-    dokku_receive "$APP" "dockerfile" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
-  else
-    plugn trigger pre-receive-app "$APP" "herokuish" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV"
-    dokku_receive "$APP" "herokuish" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
-  fi
+  local DOKKU_APP_TYPE
+  DOKKU_APP_TYPE="$(config_get "$APP" DOKKU_APP_TYPE || true)"
+  DOKKU_APP_TYPE="$(plugn trigger build-type "$APP" "$DOKKU_APP_TYPE" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR")"
+  plugn trigger pre-receive-app "$APP" "$DOKKU_APP_TYPE" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV"
+  dokku_receive "$APP" "$DOKKU_APP_TYPE" "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
 }
 
 suppress_output() {

--- a/plugins/tar/functions
+++ b/plugins/tar/functions
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 tar_build() {
   declare desc="builds apps from tarball via command line"
@@ -26,13 +27,11 @@ tar_build() {
 
   plugn trigger post-extract "$APP" "$TAR_BUILD_TMP_WORK_DIR"
 
-  if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]] && [[ -z $(config_get "$APP" BUILDPACK_URL || true) ]]; then
-    plugn trigger pre-receive-app "$APP" "dockerfile" "$TAR_BUILD_TMP_WORK_DIR"
-    dokku_receive "$APP" "dockerfile" "$TAR_BUILD_TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
-  else
-    plugn trigger pre-receive-app "$APP" "herokuish" "$TAR_BUILD_TMP_WORK_DIR"
-    dokku_receive "$APP" "herokuish" "$TAR_BUILD_TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
-  fi
+  local DOKKU_APP_TYPE
+  DOKKU_APP_TYPE="$(config_get "$APP" DOKKU_APP_TYPE || true)"
+  DOKKU_APP_TYPE="$(plugn trigger build-type "$APP" "$DOKKU_APP_TYPE" "$TAR_BUILD_TMP_WORK_DIR")"
+  plugn trigger pre-receive-app "$APP" "$DOKKU_APP_TYPE" "$TAR_BUILD_TMP_WORK_DIR"
+  dokku_receive "$APP" "$DOKKU_APP_TYPE" "$TAR_BUILD_TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
 }
 
 tar_in_cmd() {


### PR DESCRIPTION
This will allow users the ability to customize the build process by replacing herokuish/dockerfile builds with something custom, such as a lambda function builder.

Totally possible I don't merge this in.

@michaelshobbs this is just a POC, was wondering if you had thoughts on whats going on here.