### PR TITLE
fix: Check the location of nginx in a central way

### DIFF
--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -6,14 +6,29 @@ source "$PLUGIN_AVAILABLE_PATH/config/functions"
 source "$PLUGIN_AVAILABLE_PATH/domains/functions"
 source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 
+get_nginx_location() {
+  declare desc="check that nginx is at the expected location and return it"
+  local NGINX_LOCATION="/usr/sbin/nginx"
+  if ! [ -x "$NGINX_LOCATION" ]; then
+    dokku_log_fail "Could not find nginx binary at ${NGINX_LOCATION}."
+    exit 1;
+  fi
+  echo "$NGINX_LOCATION"
+}
+
 validate_nginx() {
   declare desc="validate entire nginx config"
+  local NGINX_LOCATION=$(get_nginx_location)
+  if [ -z "$NGINX_LOCATION" ]; then
+    exit 1;
+  fi
+
   set +e
-  sudo /usr/sbin/nginx -t > /dev/null 2>&1
+  sudo "$NGINX_LOCATION" -t > /dev/null 2>&1
   local exit_code=$?
   set -e
   if [[ "$exit_code" -ne "0" ]]; then
-    sudo /usr/sbin/nginx -t
+    sudo "$NGINX_LOCATION" -t
     shopt -s nullglob
     local conf_file
     for conf_file in $DOKKU_ROOT/*/nginx.conf; do
@@ -152,11 +167,6 @@ is_spdy_enabled() {
   local MAJOR_VERSION MINOR_VERSION PATCH_VERSION
   local HAS_SUPPORT=true
 
-  if ! which nginx > /dev/null 2>&1; then
-    echo $HAS_SUPPORT
-    return
-  fi
-
   MAJOR_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[1]}')
   MINOR_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[2]}')
   PATCH_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[3]}')
@@ -178,11 +188,6 @@ is_http2_enabled() {
   local NGINX_VERSION="$1"
   local MAJOR_VERSION MINOR_VERSION PATCH_VERSION
   local HAS_SUPPORT=false
-
-  if ! which nginx > /dev/null 2>&1; then
-    echo $HAS_SUPPORT
-    return
-  fi
 
   MAJOR_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[1]}')
   MINOR_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[2]}')
@@ -281,7 +286,11 @@ nginx_build_config() {
       done
     fi
 
-    local NGINX_VERSION="$(nginx -v 2>&1 | cut -d'/' -f 2)"
+    local NGINX_LOCATION=$(get_nginx_location)
+    if [ -z "$NGINX_LOCATION" ]; then
+      exit 1;
+    fi
+    local NGINX_VERSION="$("$NGINX_LOCATION" -v 2>&1 | cut -d'/' -f 2)"
     local SPDY_SUPPORTED="$(is_spdy_enabled "$NGINX_VERSION")"
     local HTTP2_SUPPORTED="$(is_http2_enabled "$NGINX_VERSION")"
 

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -8,10 +8,14 @@ source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 
 get_nginx_location() {
   declare desc="check that nginx is at the expected location and return it"
-  local NGINX_LOCATION="/usr/sbin/nginx"
-  if ! [[ -x "$NGINX_LOCATION" ]]; then
-    dokku_log_fail "Could not find nginx binary at ${NGINX_LOCATION}."
-    exit 1;
+  local NGINX_LOCATION=$(which nginx 2>/dev/null)
+
+  if [[ -z "$NGINX_LOCATION" ]]; then
+    NGINX_LOCATION="/usr/sbin/nginx"
+    if ! [[ -x "$NGINX_LOCATION" ]]; then
+      dokku_log_fail "Could not find nginx binary in \$PATH or at '${NGINX_LOCATION}'."
+      exit 1;
+    fi
   fi
   echo "$NGINX_LOCATION"
 }

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -17,7 +17,6 @@ get_nginx_location() {
 
   if [[ ! -x "$NGINX_LOCATION" ]]; then
     dokku_log_fail "Could not find nginx binary in \$PATH or at '${NGINX_LOCATION}'."
-    exit 1;
   fi
 
   echo "$NGINX_LOCATION"

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -14,7 +14,7 @@ get_nginx_location() {
     NGINX_LOCATION="/usr/sbin/nginx"
   fi
 
-  if ! [[ -x "$NGINX_LOCATION" ]]; then
+  if [[ ! -x "$NGINX_LOCATION" ]]; then
     dokku_log_fail "Could not find nginx binary in \$PATH or at '${NGINX_LOCATION}'."
     exit 1;
   fi

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -8,8 +8,9 @@ source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 
 get_nginx_location() {
   declare desc="check that nginx is at the expected location and return it"
-  local NGINX_LOCATION=$(which nginx 2>/dev/null)
+  local NGINX_LOCATION
 
+  NGINX_LOCATION=$(which nginx 2>/dev/null)
   if [[ -z "$NGINX_LOCATION" ]]; then
     NGINX_LOCATION="/usr/sbin/nginx"
   fi
@@ -24,7 +25,8 @@ get_nginx_location() {
 
 validate_nginx() {
   declare desc="validate entire nginx config"
-  local NGINX_LOCATION=$(get_nginx_location)
+  local NGINX_LOCATION
+  NGINX_LOCATION=$(get_nginx_location)
   if [[ -z "$NGINX_LOCATION" ]]; then
     exit 1;
   fi
@@ -292,13 +294,14 @@ nginx_build_config() {
       done
     fi
 
-    local NGINX_LOCATION=$(get_nginx_location)
+    local NGINX_LOCATION NGINX_VERSION SPDY_SUPPORTED HTTP2_SUPPORTED
+    NGINX_LOCATION=$(get_nginx_location)
     if [[ -z "$NGINX_LOCATION" ]]; then
       exit 1;
     fi
-    local NGINX_VERSION="$("$NGINX_LOCATION" -v 2>&1 | cut -d'/' -f 2)"
-    local SPDY_SUPPORTED="$(is_spdy_enabled "$NGINX_VERSION")"
-    local HTTP2_SUPPORTED="$(is_http2_enabled "$NGINX_VERSION")"
+    NGINX_VERSION="$("$NGINX_LOCATION" -v 2>&1 | cut -d'/' -f 2)"
+    SPDY_SUPPORTED="$(is_spdy_enabled "$NGINX_VERSION")"
+    HTTP2_SUPPORTED="$(is_http2_enabled "$NGINX_VERSION")"
 
     eval "$(config_export app "$APP")"
     local SIGIL_PARAMS=(-f $NGINX_TEMPLATE APP="$APP" DOKKU_ROOT="$DOKKU_ROOT"

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -12,11 +12,13 @@ get_nginx_location() {
 
   if [[ -z "$NGINX_LOCATION" ]]; then
     NGINX_LOCATION="/usr/sbin/nginx"
-    if ! [[ -x "$NGINX_LOCATION" ]]; then
-      dokku_log_fail "Could not find nginx binary in \$PATH or at '${NGINX_LOCATION}'."
-      exit 1;
-    fi
   fi
+
+  if ! [[ -x "$NGINX_LOCATION" ]]; then
+    dokku_log_fail "Could not find nginx binary in \$PATH or at '${NGINX_LOCATION}'."
+    exit 1;
+  fi
+
   echo "$NGINX_LOCATION"
 }
 

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -9,7 +9,7 @@ source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 get_nginx_location() {
   declare desc="check that nginx is at the expected location and return it"
   local NGINX_LOCATION="/usr/sbin/nginx"
-  if ! [ -x "$NGINX_LOCATION" ]; then
+  if ! [[ -x "$NGINX_LOCATION" ]]; then
     dokku_log_fail "Could not find nginx binary at ${NGINX_LOCATION}."
     exit 1;
   fi
@@ -19,7 +19,7 @@ get_nginx_location() {
 validate_nginx() {
   declare desc="validate entire nginx config"
   local NGINX_LOCATION=$(get_nginx_location)
-  if [ -z "$NGINX_LOCATION" ]; then
+  if [[ -z "$NGINX_LOCATION" ]]; then
     exit 1;
   fi
 
@@ -287,7 +287,7 @@ nginx_build_config() {
     fi
 
     local NGINX_LOCATION=$(get_nginx_location)
-    if [ -z "$NGINX_LOCATION" ]; then
+    if [[ -z "$NGINX_LOCATION" ]]; then
       exit 1;
     fi
     local NGINX_VERSION="$("$NGINX_LOCATION" -v 2>&1 | cut -d'/' -f 2)"


### PR DESCRIPTION
- Now there's only a "single source of truth" for the location of the nginx
  binary.
- It is checked if it's there before it's needed.