### PR TITLE
Clarify the minimum Nginx version for HTTP/2 support

### DIFF
--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -117,6 +117,10 @@ The [HSTS header](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) 
 
 Beware that if you enable the header and a subsequent deploy of your application results in an HTTP deploy (for whatever reason), the way the header works means that a browser will not attempt to request the HTTP version of your site if the HTTPS version fails.
 
+## HTTP/2 support
+
+Certain versions of nginx have bugs that prevent [HTTP/2](https://nginx.org/en/docs/http/ngx_http_v2_module.html) from properly responding to all clients, thus causing applications to be unavailable. For HTTP/2 to be enabled in your applications' nginx configs, you need to have installed nginx 1.11.5 or higher. See [issue 2435](https://github.com/dokku/dokku/issues/2435) for more details.
+
 ## Running behind a load balancer
 
 Your application has access to the HTTP headers `X-Forwarded-Proto`, `X-Forwarded-Port` and `X-Forwarded-For`. These headers indicate the protocol of the original request (HTTP or HTTPS), the port number, and the IP address of the client making the request, respectively. The default configuration is for Nginx to set these headers.
@@ -162,4 +166,4 @@ This could result in security issue, for example, if your application looks at t
 
 ### SSL Port Exposure
 
-When your app is served from port `80` then the `/home/dokku/APP/nginx.conf` file will automatically be updated to instruct nginx to respond to ssl on port 443 as a new cert is added.  If your app uses a non-standard port (perhaps you have a dockerfile deploy exposing port `99999`) you may need to manually expose an ssl port via `dokku proxy:ports-add <APP> https:443:99999`.  
+When your app is served from port `80` then the `/home/dokku/APP/nginx.conf` file will automatically be updated to instruct nginx to respond to ssl on port 443 as a new cert is added.  If your app uses a non-standard port (perhaps you have a dockerfile deploy exposing port `99999`) you may need to manually expose an ssl port via `dokku proxy:ports-add <APP> https:443:99999`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ sudo DOKKU_TAG=v0.10.4 bash bootstrap.sh
 
 The installation process takes about 5-10 minutes, depending upon internet connection speed.
 
-If you're using Debian 8 or Ubuntu 14.04, make sure your package manager is configured to install a sufficiently recent version of nginx<sup>[3]</sup>, otherwise, the installation may fail due to "unmet dependencies" relating nginx. For [HTTP/2 support](configuration/ssl.md#http2-support), nginx >= 1.11.5<sup>[4]</sup> is required.
+If you're using Debian 8 or Ubuntu 14.04, make sure your package manager is configured to install a sufficiently recent version of nginx<sup>[3]</sup>, otherwise, the installation may fail due to "unmet dependencies" relating nginx.
 
 #### 2. Setup SSH key and Virtualhost Settings
 
@@ -60,5 +60,4 @@ As well, you may wish to customize your installation in some other fashion. or e
 
 - <sup>[1]: To check whether your system has an fqdn set, run `sudo hostname -f`</sup>
 - <sup>[2]: If your system has less than 1GB of memory, you can use [this workaround](/docs/getting-started/advanced-installation.md#vms-with-less-than-1gb-of-memory).</sup>
-- <sup>[3]: nginx >= 1.8.0 can be installed by enabling backports, or by adding [this PPA](https://launchpad.net/~nginx/+archive/ubuntu/stable) if you're using Ubuntu.</sup>
-- <sup>[4]: nginx >= 1.11.5 can be installed by using the [nginx repositories](https://www.nginx.com/resources/admin-guide/installing-nginx-open-source/), or by adding [this PPA](https://launchpad.net/~nginx/+archive/ubuntu/stable) if you're using Ubuntu.</sup>
+- <sup>[3]: nginx >= 1.8.0 can be installed via the [nginx repositories](https://www.nginx.com/resources/admin-guide/installing-nginx-open-source/), or by adding [this PPA](https://launchpad.net/~nginx/+archive/ubuntu/stable) if you're using Ubuntu. nginx >= 1.11.5 is necessary for HTTP/2 support</sup>

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -25,9 +25,9 @@ wget https://raw.githubusercontent.com/dokku/dokku/v0.10.4/bootstrap.sh;
 sudo DOKKU_TAG=v0.10.4 bash bootstrap.sh
 ```
 
-The installation process takes about 5-10 minutes, depending upon internet connection speed. 
+The installation process takes about 5-10 minutes, depending upon internet connection speed.
 
-If you're using Debian 8 or Ubuntu 14.04, make sure your package manager is configured to install a sufficiently recent version of nginx<sup>[3]</sup>, otherwise, the installation may fail due to "unmet dependencies" relating nginx.
+If you're using Debian 8 or Ubuntu 14.04, make sure your package manager is configured to install a sufficiently recent version of nginx<sup>[3]</sup>, otherwise, the installation may fail due to "unmet dependencies" relating nginx. For [HTTP/2 support](configuration/ssl.md#http2-support), nginx >= 1.11.5<sup>[4]</sup> is required.
 
 #### 2. Setup SSH key and Virtualhost Settings
 
@@ -61,3 +61,4 @@ As well, you may wish to customize your installation in some other fashion. or e
 - <sup>[1]: To check whether your system has an fqdn set, run `sudo hostname -f`</sup>
 - <sup>[2]: If your system has less than 1GB of memory, you can use [this workaround](/docs/getting-started/advanced-installation.md#vms-with-less-than-1gb-of-memory).</sup>
 - <sup>[3]: nginx >= 1.8.0 can be installed by enabling backports, or by adding [this PPA](https://launchpad.net/~nginx/+archive/ubuntu/stable) if you're using Ubuntu.</sup>
+- <sup>[4]: nginx >= 1.11.5 can be installed by using the [nginx repositories](https://www.nginx.com/resources/admin-guide/installing-nginx-open-source/), or by adding [this PPA](https://launchpad.net/~nginx/+archive/ubuntu/stable) if you're using Ubuntu.</sup>


### PR DESCRIPTION
Add docs for https://github.com/dokku/dokku/pull/2496
