### PR TITLE
fix: use a colon instead of a slash for remotes

### DIFF
--- a/docs/deployment/application-deployment.md
+++ b/docs/deployment/application-deployment.md
@@ -60,7 +60,7 @@ git push dokku master
 ```
 
 > Note: Some tools may not support the short-upstream syntax referenced above, and you may need to prefix
-> the upstream with the scheme `ssh://` like so: `ssh://dokku@dokku.me/ruby-rails-sample`
+> the upstream with the scheme `ssh://` like so: `ssh://dokku@dokku.me:ruby-rails-sample`
 > Please see the [Git](https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a) documentation for more details.
 
 ```


### PR DESCRIPTION
Using a slash is broken as it will assume that is part of the remote name.

Refs #2915