### PR TITLE
Fix #2915

### DIFF
--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -152,8 +152,9 @@ git_build() {
 
 git_upload_pack_cmd() {
   declare desc="executes git-upload-pack"
-  local cmd="git-upload-pack"
-  local APP="$(echo "$2" | perl -pe 's/(?<!\\)'\''//g' | sed 's/\\'\''/'\''/g' | sed 's/^\///g')"
+  declare cmd="git-upload-pack"
+  declare APP="$2"
+  APP="$(echo "$APP" | perl -pe 's/(?<!\\)'\''//g' | sed 's/\\'\''/'\''/g' | sed 's/^\///g')"
   is_valid_app_name "$APP"
   plugn trigger git-pre-pull "$APP"
   cat | git-upload-pack "$DOKKU_ROOT/$APP"

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -153,7 +153,7 @@ git_build() {
 git_upload_pack_cmd() {
   declare desc="executes git-upload-pack"
   local cmd="git-upload-pack"
-  local APP="$(echo "$2" | perl -pe 's/(?<!\\)'\''//g' | sed 's/\\'\''/'\''/g')"
+  local APP="$(echo "$2" | perl -pe 's/(?<!\\)'\''//g' | sed 's/\\'\''/'\''/g' | sed 's/^\///g')"
   is_valid_app_name "$APP"
   plugn trigger git-pre-pull "$APP"
   cat | git-upload-pack "$DOKKU_ROOT/$APP"


### PR DESCRIPTION
Add forward slash cleanup of the app name for the git-upload-pack
command. Prevents is_valid_app_name from removing the application folder
on `git fetch`.