### PR TITLE
fix: do not overwrite the VHOST file during installation if it exists

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -109,7 +109,7 @@ case "$1" in
           rm -f "${DOKKU_ROOT}/VHOST"
       fi
     fi
-    
+
     db_get "dokku/hostname"
     echo "$RET" > "${DOKKU_ROOT}/HOSTNAME"
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -100,14 +100,16 @@ case "$1" in
       exit 0
     fi
 
-    db_get "dokku/vhost_enable"
-    if [ "$RET" = "true" ]; then
-        db_get "dokku/hostname"
-        echo "$RET" > "${DOKKU_ROOT}/VHOST"
-    else
-        rm -f "${DOKKU_ROOT}/VHOST"
+    if [ ! -f "${DOKKU_ROOT}/VHOST" ]; then
+      db_get "dokku/vhost_enable"
+      if [ "$RET" = "true" ]; then
+          db_get "dokku/hostname"
+          echo "$RET" > "${DOKKU_ROOT}/VHOST"
+      else
+          rm -f "${DOKKU_ROOT}/VHOST"
+      fi
     fi
-
+    
     db_get "dokku/hostname"
     echo "$RET" > "${DOKKU_ROOT}/HOSTNAME"
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -100,12 +100,16 @@ case "$1" in
       exit 0
     fi
 
-    if [ ! -f "${DOKKU_ROOT}/VHOST" ]; then
+    if [ -f "${DOKKU_ROOT}/VHOST" ]; then
+      echo "VHOST file detected, skipping modification"
+    else
       db_get "dokku/vhost_enable"
       if [ "$RET" = "true" ]; then
           db_get "dokku/hostname"
+          echo "Setting VHOST contents to $RET"
           echo "$RET" > "${DOKKU_ROOT}/VHOST"
       else
+          echo "VHOST disabled via debconf, removing"
           rm -f "${DOKKU_ROOT}/VHOST"
       fi
     fi


### PR DESCRIPTION
Fix to prevent dokku upgrade on debian systems overwrites ${DOKKU_ROOT}/VHOST

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
