### PR TITLE
Fix version number [ci skip]

### DIFF
--- a/docs/networking/proxy-management.md
+++ b/docs/networking/proxy-management.md
@@ -21,7 +21,7 @@ In Dokku 0.5.0, port proxying was decoupled from the `nginx-vhosts` plugin into 
 
 > Changed as of 0.11.0
 
-From Dokku versions `0.5.0` until `0.11.0`, enabling or disabling an application's proxy would **also** control whether or not the application was bound to all interfaces - e.g. `0.0.0.0`. As of `0.10.0`, this is now controlled by the network plugin. Please see the [network documentation](/docs/networking/network.md#container-network-interface-binding) for more information.
+From Dokku versions `0.5.0` until `0.11.0`, enabling or disabling an application's proxy would **also** control whether or not the application was bound to all interfaces - e.g. `0.0.0.0`. As of `0.11.0`, this is now controlled by the network plugin. Please see the [network documentation](/docs/networking/network.md#container-network-interface-binding) for more information.
 
 ### Displaying proxy reports about an app
 


### PR DESCRIPTION
In document of Container network interface binding,
I think ``As of `0.10.0` `` is a typo.