### PR TITLE
docs: WIP on explaining optional herokuish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rpm
 .DS_Store
 .ruby-version
+.idea/
 .vagrant
 data/
 stack.tgz

--- a/docs/getting-started/advanced-installation.md
+++ b/docs/getting-started/advanced-installation.md
@@ -44,7 +44,9 @@ cd dokku
 sudo BUILD_STACK=true STACK_URL=https://github.com/gliderlabs/herokuish.git make install
 ```
 
-Herokuish is recommended but not required. For Debian, `sudo DOKKU_NO_INSTALL_RECOMMENDS=true bash bootstrap.sh` is one way to skip the dependency, although it will also skip other recommended dependencies.
+## Skipping herokuish installation
+
+The `herokuish` package is recommended but not required if not using Heroku Buildpacks for deployment. Debian-based OS users can run the bootstrap installer via `sudo DOKKU_NO_INSTALL_RECOMMENDS=true bash bootstrap.sh` to skip the dependency. Please note that this will _also_ skip installation of other recommended dependencies.
 
 ## Configuring
 

--- a/docs/getting-started/advanced-installation.md
+++ b/docs/getting-started/advanced-installation.md
@@ -44,6 +44,8 @@ cd dokku
 sudo BUILD_STACK=true STACK_URL=https://github.com/gliderlabs/herokuish.git make install
 ```
 
+Herokuish is recommended but not required. For Debian, `sudo DOKKU_NO_INSTALL_RECOMMENDS=true bash bootstrap.sh` is one way to skip the dependency, although it will also skip other recommended dependencies.
+
 ## Configuring
 
 Once Dokku is installed, if you are not using the web-installer, you'll want to configure a the virtualhost setup as well as the push user. If you do not, your installation will be considered incomplete and you will not be able to deploy applications.


### PR DESCRIPTION
Per our conversation on Slack @josegonzalez - were you perhaps referring to the NO_INSTALL_RECOMMENDS in https://github.com/dokku/dokku/blob/3f50097619b3de2930b198d914b8dc1605816097/bootstrap.sh#L106 since herokuish is just a [recommended package](https://github.com/dokku/dokku/blob/3f50097619b3de2930b198d914b8dc1605816097/debian/control#L7)? Seems less optional in centos and also not sure the effect of not installing the other recommended package (parallel).

Seems that maybe it'd be best to point to this trick about about a `-` suffix https://serverfault.com/a/663803/309584 and provide a way to pass it through? Don't want people to skip recommends just to skip herokuish as the list of recommends should be decoupled.

Not real sure about `if [[ -n $DOKKU_DOCKERFILE ]]; then` in bootstrap.sh - haven't found where that's documented or how the name relates to what it seems to do (skipping recommends).

[ci skip]
