### PR TITLE
strip restart flag from app_user_pre_deploy_trigger

### DIFF
--- a/plugins/00_dokku-standard/pre-deploy
+++ b/plugins/00_dokku-standard/pre-deploy
@@ -28,6 +28,8 @@ app_user_pre_deploy_trigger() {
   if [[ -n "$APP_PATHS" ]]; then
     CONTAINER_PATHS=$(echo "$APP_PATHS" | awk -F ':' '{ print $2 }' | xargs)
     DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG" | xargs)
+    # strip --restart args from DOCKER_ARGS
+    DOCKER_ARGS=$(sed -e "s/--restart=[[:graph:]]\+[[:blank:]]\?//g" <<< "$DOCKER_ARGS")
   fi
 
   if [[ "$DOKKU_APP_TYPE" == "herokuish" ]] && [[ -n "$CONTAINER_PATHS" ]]; then


### PR DESCRIPTION
under certain circumstances, this container will continue to restart and consume resources by not allowing old images to be deleted via `cleanup`