### PR TITLE
Remove unnecessary lines

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -108,9 +108,6 @@ case "$1" in
           db_get "dokku/hostname"
           echo "Setting VHOST contents to $RET"
           echo "$RET" > "${DOKKU_ROOT}/VHOST"
-      else
-          echo "VHOST disabled via debconf, removing"
-          rm -f "${DOKKU_ROOT}/VHOST"
       fi
     fi
 


### PR DESCRIPTION
Because never reached when `VHOST` is regular file.
(reachable when `VHOST` is fifo, etc.)

ref. https://github.com/dokku/dokku/commit/5e9306ad405136a47a867be6ef35b74eb751c85f#commitcomment-24880650