### PR TITLE
Use special name for global

### DIFF
--- a/plugins/config/environment.go
+++ b/plugins/config/environment.go
@@ -78,7 +78,7 @@ func LoadMergedAppEnv(appName string) (env *Env, err error) {
 
 //LoadGlobalEnv loads the global environment
 func LoadGlobalEnv() (*Env, error) {
-	return loadFromFile("global", getGlobalFile())
+	return loadFromFile("<global>", getGlobalFile())
 }
 
 //Get an environment variable


### PR DESCRIPTION
Use name with `<>` like `<unknown>` to distinguish global env and env of app named global