### PR TITLE
Correct typo in docker-options:remove error output

### DIFF
--- a/plugins/docker-options/subcommands/remove
+++ b/plugins/docker-options/subcommands/remove
@@ -11,7 +11,7 @@ docker_options_remove_cmd() {
   read -ra passed_phases <<< "$(get_phases "$3")"
   shift 3 # everything else passed is the docker option
   # shellcheck disable=SC2154
-  [[ -z ${passed_docker_option="$@"} ]] && dokku_log_fail "Please specify docker options to add to the phase"
+  [[ -z ${passed_docker_option="$@"} ]] && dokku_log_fail "Please specify docker options to remove from the phase"
   remove_passed_docker_option passed_phases[@] "${passed_docker_option[@]}"
 }
 


### PR DESCRIPTION
[ci skip]