### PR TITLE
feat: allow usage of git 2.13.0+ by unsetting GIT_QUARANTINE_PATH during git worktree usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,6 @@ jobs:
       - run: |
           ./tests/ci/setup.sh
       - run: |
-          sudo apt-get remove -qq -y git
-          sudo apt-get install -qq -y git=1:1.9.1-1ubuntu0.7 git-man=1:1.9.1-1ubuntu0.7
-      - run: |
           echo 'export DOKKU_SKIP_CLEANUP=true' | sudo tee /home/dokku/.dokkurc/dokku_skip_cleanup
       - run: |
           # dokku.me now resolves to 10.0.0.2. add 10.0.0.2/24 to eth0

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -38,7 +38,9 @@ git_build_app_repo() {
   if use_git_worktree; then
     # git worktree - this method uses git worktree which was introduced in git 2.5
     pushd "$DOKKU_ROOT/$APP" > /dev/null
-    git worktree add "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV" > /dev/null
+    # unset the git quarantine path to allow us to use 2.13.0+
+    # See this issue for more information: https://github.com/dokku/dokku/issues/2796
+    env -u GIT_QUARANTINE_PATH git worktree add "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV" > /dev/null
     popd > /dev/null
     pushd "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" > /dev/null
   else


### PR DESCRIPTION
Closes #2796
