### PR TITLE
fix: return/exit 1 when an image being deployed is invalid

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -744,6 +744,8 @@ release_and_deploy() {
     fi
 
     echo
+  else
+    return 1
   fi
 }
 

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -744,8 +744,6 @@ release_and_deploy() {
     fi
 
     echo
-  else
-    return 1
   fi
 }
 

--- a/plugins/tags/subcommands/deploy
+++ b/plugins/tags/subcommands/deploy
@@ -10,7 +10,8 @@ tags_deploy_cmd() {
   local APP="$2"; local IMAGE_TAG="$3"
   verify_app_name "$APP"
 
-  release_and_deploy "$APP" "$IMAGE_TAG"
+  verify_image "$IMAGE" || return 1
+  release_and_deploy "$APP" "$IMAGE_TAG"  
 }
 
 tags_deploy_cmd "$@"

--- a/plugins/tags/subcommands/deploy
+++ b/plugins/tags/subcommands/deploy
@@ -10,6 +10,7 @@ tags_deploy_cmd() {
   local APP="$2"; local IMAGE_TAG="$3"
   verify_app_name "$APP"
 
+  local IMAGE="$(get_app_image_name "$APP" "$IMAGE_TAG")"
   verify_image "$IMAGE" || return 1
   release_and_deploy "$APP" "$IMAGE_TAG"  
 }

--- a/plugins/tags/subcommands/deploy
+++ b/plugins/tags/subcommands/deploy
@@ -6,11 +6,12 @@ source "$PLUGIN_AVAILABLE_PATH/tags/functions"
 tags_deploy_cmd() {
   declare desc="deploys an app with a given tagged image via command line"
   local cmd="tags:deploy"
-  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
-  local APP="$2"; local IMAGE_TAG="$3"
+  declare APP="$2" IMAGE_TAG="$3"
+  local IMAGE
+  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
 
-  local IMAGE="$(get_app_image_name "$APP" "$IMAGE_TAG")"
+  IMAGE="$(get_app_image_name "$APP" "$IMAGE_TAG")"
   verify_image "$IMAGE" || return 1
   release_and_deploy "$APP" "$IMAGE_TAG"  
 }

--- a/tests/unit/40_tags.bats
+++ b/tests/unit/40_tags.bats
@@ -46,3 +46,10 @@ teardown() {
   echo "status: "$status
   assert_success
 }
+
+@test "(tags) tags:deploy (missing tag)" {
+  run /bin/bash -c "dokku tags:create $TEST_APP missing-tag"
+  echo "output: "$output
+  echo "status: "$status
+  assert_failure
+}

--- a/tests/unit/40_tags.bats
+++ b/tests/unit/40_tags.bats
@@ -48,7 +48,7 @@ teardown() {
 }
 
 @test "(tags) tags:deploy (missing tag)" {
-  run /bin/bash -c "dokku tags:create $TEST_APP missing-tag"
+  run /bin/bash -c "dokku tags:deploy $TEST_APP missing-tag"
   echo "output: "$output
   echo "status: "$status
   assert_failure


### PR DESCRIPTION
Closes #2916
