### PR TITLE
fix: correct the guard around the config_export call in config_sub

### DIFF
--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -26,7 +26,7 @@ config_export() {
 
 config_all() {
   declare desc="Backwards compatible function for plugin use"
-  if [[ -z "$DOKKU_CONFIG_EXPORT" ]]; then
+  if [[ -n "$DOKKU_CONFIG_EXPORT" ]]; then
     config_export "$@"
     return 0
   fi

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -26,8 +26,8 @@ config_export() {
 
 config_all() {
   declare desc="Backwards compatible function for plugin use"
-  if [[ -n "$DOKKU_CONFIG_EXPORT" ]]; then
-    config_export "$@"
+  if [[ -z "$DOKKU_CONFIG_EXPORT" ]]; then
+    config_export app "$@"
     return 0
   fi
   


### PR DESCRIPTION
This affects all official plugins