### PR TITLE
[config] forward output from plugn triggers to user

### DIFF
--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -345,13 +345,12 @@ func VerifyImage(image string) bool {
 }
 
 //PlugnTrigger fire the given plugn trigger with the given args
-func PlugnTrigger(triggerName string, args ...string) (string, error) {
+func PlugnTrigger(triggerName string, args ...string) error {
 	shellArgs := make([]interface{}, len(args)+2)
 	shellArgs[0] = "trigger"
 	shellArgs[1] = triggerName
 	for i, arg := range args {
 		shellArgs[i+2] = arg
 	}
-	res, err := sh.Command("plugn", shellArgs...).Output()
-	return string(res), err
+	return sh.Command("plugn", shellArgs...).Run()
 }

--- a/plugins/config/config.go
+++ b/plugins/config/config.go
@@ -40,8 +40,7 @@ func SetMany(appName string, entries map[string]string, restart bool) (err error
 		common.LogInfo1("Setting config vars")
 		fmt.Println(prettyPrintEnvEntries("       ", entries))
 		env.Write()
-		args := append([]string{appName, "set"}, keys...)
-		common.PlugnTrigger("post-config-update", args...)
+		triggerUpdate(appName, "set", keys)
 	}
 	if !global && restart && env.GetBoolDefault("DOKKU_APP_RESTORE", true) {
 		triggerRestart(appName)
@@ -64,8 +63,7 @@ func UnsetMany(appName string, keys []string, restart bool) (err error) {
 	}
 	if changed {
 		env.Write()
-		args := append([]string{appName, "unset"}, keys...)
-		common.PlugnTrigger("post-config-update", args...)
+		triggerUpdate(appName, "unset", keys)
 	}
 	if !global && restart && env.GetBoolDefault("DOKKU_APP_RESTORE", true) {
 		triggerRestart(appName)
@@ -75,7 +73,14 @@ func UnsetMany(appName string, keys []string, restart bool) (err error) {
 
 func triggerRestart(appName string) {
 	common.LogInfo1(fmt.Sprintf("Restarting app %s", appName))
-	common.PlugnTrigger("app-restart", appName)
+	output, _ := common.PlugnTrigger("app-restart", appName)
+	fmt.Printf(output)
+}
+
+func triggerUpdate(appName string, operation string, args []string) {
+	args = append([]string{appName, operation}, args...)
+	output, _ := common.PlugnTrigger("post-config-update", args...)
+	fmt.Printf(output)
 }
 
 func loadAppOrGlobalEnv(appName string) (env *Env, err error) {

--- a/plugins/config/config.go
+++ b/plugins/config/config.go
@@ -73,14 +73,16 @@ func UnsetMany(appName string, keys []string, restart bool) (err error) {
 
 func triggerRestart(appName string) {
 	common.LogInfo1(fmt.Sprintf("Restarting app %s", appName))
-	output, _ := common.PlugnTrigger("app-restart", appName)
-	fmt.Printf(output)
+	if err := common.PlugnTrigger("app-restart", appName); err != nil {
+		common.LogWarn(fmt.Sprintf("Failure while restarting app: %s", err))
+	}
 }
 
 func triggerUpdate(appName string, operation string, args []string) {
 	args = append([]string{appName, operation}, args...)
-	output, _ := common.PlugnTrigger("post-config-update", args...)
-	fmt.Printf(output)
+	if err := common.PlugnTrigger("post-config-update", args...); err != nil {
+		common.LogWarn(fmt.Sprintf("Failure while triggering post-config-update: %s", err))
+	}
 }
 
 func loadAppOrGlobalEnv(appName string) (env *Env, err error) {


### PR DESCRIPTION
The config plugin was suppressing the output from `post-config-update` and `app-restart`