### PR TITLE
Point to docs in the right version

### DIFF
--- a/contrib/dokku-installer.py
+++ b/contrib/dokku-installer.py
@@ -254,7 +254,7 @@ PAGE = """
       $.post('/setup', data)
         .done(function() {
           $("#result").html("Success!")
-          window.location.href = "http://progrium.viewdocs.io/dokku/deployment/application-deployment/";
+          window.location.href = "http://progrium.viewdocs.io/dokku~{VERSION}/deployment/application-deployment/";
         })
         .fail(function(data) {
           $("#result").html("Something went wrong...")

--- a/contrib/dokku-installer.py
+++ b/contrib/dokku-installer.py
@@ -254,7 +254,7 @@ PAGE = """
       $.post('/setup', data)
         .done(function() {
           $("#result").html("Success!")
-          window.location.href = "http://progrium.viewdocs.io/dokku~{VERSION}/deployment/application-deployment/";
+          window.location.href = "http://dokku.viewdocs.io/dokku~{VERSION}/deployment/application-deployment/";
         })
         .fail(function(data) {
           $("#result").html("Something went wrong...")


### PR DESCRIPTION
Currently after finishing the setup trough the Web UI, the user gets redirected to the "master" version of the docs. This redirects the user to the docs matching the users version instead.

[ci skip]
