### PR TITLE
restore only apps with DOKKU_APP_RESTORE=1 when parallel is installed

### DIFF
--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -7,14 +7,21 @@ source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 ps_restore_cmd() {
   declare desc="starts all apps with DOKKU_APP_RESTORE not set to 0 via command line"
   local cmd="ps:restore"
+  local DOKKU_APP_RESTORE
 
   if which parallel > /dev/null 2>&1; then
-    dokku_apps | parallel dokku ps:start
+    for app in $(dokku_apps); do
+      DOKKU_APP_RESTORE=$(config_get "$app" DOKKU_APP_RESTORE || true)
+      if [[ $DOKKU_APP_RESTORE != 0 ]]; then
+        sem -j+0 "dokku ps:start $app"
+      fi
+    done
+    sem --wait
     return
   fi
 
   for app in $(dokku_apps); do
-    local DOKKU_APP_RESTORE=$(config_get "$app" DOKKU_APP_RESTORE || true)
+    DOKKU_APP_RESTORE=$(config_get "$app" DOKKU_APP_RESTORE || true)
     if [[ $DOKKU_APP_RESTORE != 0 ]]; then
       echo "Restoring app $app ..."
       if ps_start "$app"; then


### PR DESCRIPTION
Properly check DOKKU_APP_RESTORE=1 when restoring all apps in parallel, like it's done in sequencial mode.

`sem` is one of the commands installed by the `parallel` package. `j+0` means number of CPU cores.