### PR TITLE
[config] use high-availability pool keyserver

### DIFF
--- a/tests.mk
+++ b/tests.mk
@@ -5,7 +5,7 @@ ifneq ($(shell shellcheck --version > /dev/null 2>&1 ; echo $$?),0)
 ifeq ($(SYSTEM),Darwin)
 	brew install shellcheck
 else
-	sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
+	sudo apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 5072E1F5
 	sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
 	sudo rm -rf /var/lib/apt/lists/* && sudo apt-get clean
 	sudo apt-get update -qq && sudo apt-get install -qq -y shellcheck


### PR DESCRIPTION
Out of my wheelhouse, but per our conversation in Slack, trying to prevent build failures such as: https://circleci.com/gh/dokku/dokku/4368#tests/containers/2

Decided on this after reviewing a few resources and finishing with https://lists.gnupg.org/pipermail/gnupg-devel/2015-July/030108.html - https://sks-keyservers.net/overview-of-pools.php notes: 
> This is a high-availibility subset of the pool that require all servers to be identified as a clustered setup