### PR TITLE
Ensure parallel runs properly for non-restorable apps and moreutils parallel

### DIFF
--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -26,7 +26,7 @@ ps_restore_all() {
     dokku_log_info1 "Restarting in parallel"
     GNU_PARALLEL=$(parallel -V 2>&1 | grep GNU || true)
     if [[ -z "$GNU_PARALLEL" ]]; then
-      # shellcheck disable=SC2086
+      # shellcheck disable=SC2046
       parallel -i bash -c "dokku ps:restore {}" -- $(dokku_apps)
     else
       dokku_apps | parallel --will-cite 'dokku ps:restore {}'

--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -26,6 +26,7 @@ ps_restore_all() {
     dokku_log_info1 "Restarting in parallel"
     GNU_PARALLEL=$(parallel -V 2>&1 | grep GNU || true)
     if [[ -z "$GNU_PARALLEL" ]]; then
+      # shellcheck disable=SC2086
       parallel -i bash -c "dokku ps:restore {}" -- $(dokku_apps)
     else
       dokku_apps | parallel --will-cite 'dokku ps:restore {}'

--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -7,7 +7,7 @@ source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 ps_restore_cmd() {
   declare desc="starts all apps with DOKKU_APP_RESTORE not set to 0 via command line"
   local cmd="ps:restore"
-  local APP="$1"
+  local APP="$2"
 
   if [[ -n "$APP" ]]; then
     DOKKU_APP_RESTORE="$(config_get "$APP" DOKKU_APP_RESTORE || true)"

--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -10,6 +10,11 @@ ps_restore_cmd() {
   local APP="$2"
 
   if [[ -n "$APP" ]]; then
+    if ! (is_deployed "$APP"); then
+      dokku_log_warn "App $APP has not been deployed"
+      return
+    fi
+
     DOKKU_APP_RESTORE="$(config_get "$APP" DOKKU_APP_RESTORE || true)"
     if [[ $DOKKU_APP_RESTORE != 0 ]]; then
       ps_start "$APP" || dokku_log_warn "dokku ps:restore ${APP} failed"
@@ -37,7 +42,7 @@ ps_restore_all() {
   for app in $(dokku_apps); do
     local DOKKU_APP_RESTORE=$(config_get "$app" DOKKU_APP_RESTORE || true)
     if [[ $DOKKU_APP_RESTORE != 0 ]]; then
-      echo "Restoring app $app ..."
+      dokku_log_verbose "Restoring app $app ..."
       if ps_start "$app"; then
         continue
       fi

--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -7,9 +7,29 @@ source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 ps_restore_cmd() {
   declare desc="starts all apps with DOKKU_APP_RESTORE not set to 0 via command line"
   local cmd="ps:restore"
+  local APP="$1"
+
+  if [[ -n "$APP" ]]; then
+    DOKKU_APP_RESTORE="$(config_get "$APP" DOKKU_APP_RESTORE || true)"
+    if [[ $DOKKU_APP_RESTORE != 0 ]]; then
+      ps_start "$APP" || dokku_log_warn "dokku ps:restore ${APP} failed"
+    fi
+  else
+    ps_restore_all
+  fi
+}
+  
+ps_restore_all() {
+  local GNU_PARALLEL
 
   if which parallel > /dev/null 2>&1; then
-    dokku_apps | parallel dokku ps:start
+    dokku_log_info1 "Restarting in parallel"
+    GNU_PARALLEL=$(parallel -V 2>&1 | grep GNU || true)
+    if [[ -z "$GNU_PARALLEL" ]]; then
+      parallel -i bash -c "dokku ps:restore {}" -- $(dokku_apps)
+    else
+      dokku_apps | parallel --will-cite 'dokku ps:restore {}'
+    fi
     return
   fi
 

--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -29,7 +29,7 @@ ps_restore_all() {
       # shellcheck disable=SC2046
       parallel -i bash -c "dokku ps:restore {}" -- $(dokku_apps)
     else
-      dokku_apps | parallel --will-cite 'dokku ps:restore {}'
+      dokku_apps | parallel 'dokku ps:restore {}'
     fi
     return
   fi

--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -40,6 +40,11 @@ ps_restore_all() {
   fi
 
   for app in $(dokku_apps); do
+    if ! (is_deployed "$app"); then
+      dokku_log_warn "App $app has not been deployed"
+      continue
+    fi
+
     local DOKKU_APP_RESTORE=$(config_get "$app" DOKKU_APP_RESTORE || true)
     if [[ $DOKKU_APP_RESTORE != 0 ]]; then
       dokku_log_verbose "Restoring app $app ..."

--- a/tests/unit/10_ps-herokuish.bats
+++ b/tests/unit/10_ps-herokuish.bats
@@ -142,7 +142,7 @@ teardown() {
   echo "status: "$status
   assert_success
 
-  run bash -c "dokku ps:restore"
+  run bash -c "dokku --trace ps:restore"
   echo "output: "$output
   echo "status: "$status
   assert_success
@@ -152,7 +152,7 @@ teardown() {
   echo "status: "$status
   assert_success
 
-  run bash -c "dokku --quiet ls | grep $TEST_APP | grep -q running"
+  run bash -c "dokku --quiet ls | grep $TEST_APP | grep -q stopped"
   echo "output: "$output
   echo "status: "$status
   assert_success


### PR DESCRIPTION
This is an alternative to #3023, and also adds support for moreutils parallel (I had this installed on a server I am running Dokku on, don't ask).