### PR TITLE
Feature: dokku ps:stopall

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,7 +1,7 @@
 linters:
   shellcheck:
     shell: bash
-    exclude: SC2034
+    exclude: SC2034,SC1090
   golint:
 
 files:

--- a/docs/deployment/process-management.md
+++ b/docs/deployment/process-management.md
@@ -14,6 +14,7 @@ ps:scale <app> <proc>=<count> [<proc>=<count>] # Get/Set how many instances of a
 ps:set-restart-policy <app> <policy>           # Sets app restart-policy
 ps:start <app>                                 # Start app container(s)
 ps:stop <app>                                  # Stop app container(s)
+ps:stopall                                     # Stop all app container(s)
 ```
 
 By default, Dokku will only start a single `web` process - if defined - though process scaling can be managed by the `ps` plugin or [via a custom `DOKKU_SCALE` file](/docs/deployment/process-management.md#manually-managing-process-scaling).
@@ -97,6 +98,12 @@ Deployed applications can be stopped using the `ps:stop` command. This turns off
 
 ```shell
 dokku ps:stop node-js-app
+```
+
+You may also stop all applications at once:
+
+```shell
+dokku ps:stopall
 ```
 
 ### Starting applications

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -744,7 +744,7 @@ verify_app_name "$APP"
 ### `post-stop`
 
 - Description: Can be used to run commands after an application is manually stopped
-- Invoked by: `dokku ps:stop`
+- Invoked by: `dokku ps:stop` and `dokku ps:stopall`
 - Arguments: `$APP`
 - Example:
 

--- a/docs/getting-started/uninstalling.md
+++ b/docs/getting-started/uninstalling.md
@@ -36,7 +36,7 @@ All applications should be stopped, and all docker containers and images deleted
 
 ```shell
 # stop all applications
-dokku --quiet apps | xargs dokku ps:stop
+dokku ps:stopall
 
 # cleanup containers and images
 dokku cleanup

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -39,9 +39,11 @@ If Dokku was installed via `apt-get install dokku` or `bootstrap.sh` (most commo
 sudo apt-get update
 
 # stop each running app
-# for 0.8.1 and newer versions, use
+# for 0.11.4 and newer versions, use
+dokku ps:stopall
+# for versions between 0.8.1 and 0.11.3, use
 dokku --quiet apps:list | xargs -L1 dokku ps:stop
-# for older versions, use 
+# for versions versions older than 0.8.1, use
 dokku --quiet apps | xargs -L1 dokku ps:stop
 
 # update dokku and it's dependencies

--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -11,6 +11,7 @@ case "$1" in
     ps:scale <app> <proc>=<count> [<proc>=<count>...], Get/Set how many instances of a given process to run
     ps:start <app>, Start app container(s)
     ps:stop <app>, Stop app container(s)
+    ps:stopall, Stop all app container(s)
     ps:rebuild <app>, Rebuild an app from source
     ps:rebuildall, Rebuild all apps from source
     ps:report [<app>] [<flag>], Displays a process report for one or more apps

--- a/plugins/ps/subcommands/stopall
+++ b/plugins/ps/subcommands/stopall
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/ps/functions"
+
+ps_stopall_cmd() {
+  declare desc="stops all apps via command line"
+  local cmd="ps:stopall"
+  for app in $(dokku_apps); do
+    ps_stop "$app"
+  done
+}
+
+ps_stopall_cmd "$@"

--- a/plugins/ps/subcommands/stopall
+++ b/plugins/ps/subcommands/stopall
@@ -1,13 +1,37 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
 source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 
 ps_stopall_cmd() {
   declare desc="stops all apps via command line"
   local cmd="ps:stopall"
+  local GNU_PARALLEL
+
+  if which parallel > /dev/null 2>&1; then
+    dokku_log_info1 "Rebuilding in parallel"
+    GNU_PARALLEL=$(parallel -V 2>&1 | grep GNU || true)
+    if [[ -z "$GNU_PARALLEL" ]]; then
+      # shellcheck disable=SC2046
+      parallel -i bash -c "dokku ps:stop {}" -- $(dokku_apps)
+    else
+      dokku_apps | parallel 'dokku ps:stop {}'
+    fi
+    return
+  fi
+
   for app in $(dokku_apps); do
-    ps_stop "$app"
+    if ! (is_deployed "$app"); then
+      dokku_log_warn "App $app has not been deployed"
+      continue
+    fi
+
+    dokku_log_verbose "Stopping app $app ..."
+    if ps_stop "$app"; then
+      continue
+    fi
+    dokku_log_warn "dokku ps:stop ${app} failed"
   done
 }
 


### PR DESCRIPTION
We have a command to `ps:rebuildall` and `ps:restartall` apps, but none to `ps:stopall`.

This PR adds said command and updates relevant documentation with its use.