### PR TITLE
Point to unattended install instructions

### DIFF
--- a/docs/getting-started/advanced-installation.md
+++ b/docs/getting-started/advanced-installation.md
@@ -48,17 +48,17 @@ sudo BUILD_STACK=true STACK_URL=https://github.com/gliderlabs/herokuish.git make
 
 The `herokuish` package is recommended but not required if not using Heroku Buildpacks for deployment. Debian-based OS users can run the bootstrap installer via `sudo DOKKU_NO_INSTALL_RECOMMENDS=true bash bootstrap.sh` to skip the dependency. Please note that this will _also_ skip installation of other recommended dependencies.
 
-## Configuring
+## Configuring an unattended installation
 
 Once Dokku is installed, if you are not using the web-installer, you'll want to configure a the virtualhost setup as well as the push user. If you do not, your installation will be considered incomplete and you will not be able to deploy applications.
 
+For Debian, unattended installation is described [Debian installation guide](/docs/getting-started/install/debian.md).
+
 *You should also stop and disable the `dokku-installer` service to remove public access to adding SSH keys.*
 
-Set up a domain and a wildcard domain pointing to that host. Make sure `/home/dokku/VHOST` is set to this domain. By default it's set to whatever hostname the host has. This file is only created if the hostname can be resolved by dig (`dig +short $(hostname -f)`). Otherwise you have to create the file manually and set it to your preferred domain. If this file still is not present when you push your app, Dokku will publish the app with a port number (i.e. `http://example.com:49154` - note the missing subdomain).
+Set up a domain using your preferred vendor and a wildcard domain pointing to the host running dokku. Make sure `/home/dokku/VHOST` is set to this domain. By default it's set to whatever hostname the host has. This file is only created if the hostname can be resolved by dig (`dig +short $(hostname -f)`). Otherwise you have to create the file manually and set it to your preferred domain. If this file still is not present when you push your app, Dokku will publish the app with a port number (i.e. `http://example.com:49154` - note the missing subdomain).
 
-Follow the [user management documentation](/docs/deployment/user-management.md) in order to add users to Dokku, or to give other Unix accounts access to Dokku.
-
-That's it!
+Follow the [user management documentation](/docs/deployment/user-management.md) in order to add ssh keys for users to Dokku, or to give other Unix accounts access to Dokku.
 
 ## VMs with less than 1GB of memory
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -33,9 +33,11 @@ If you're using Debian 8 or Ubuntu 14.04, make sure your package manager is conf
 
 Once the installation is complete, you can open a browser to setup your SSH key and virtualhost settings. Open your browser of choice and navigate to the host's IP address - or the domain you assigned to that IP previously - and configure Dokku via the web admin.
 
+Alternatively, instructions to skip the web installer with an unattended installation are available in the [advanced install guide](/docs/getting-started/advanced-installation/#configuring). 
+
 > **Warning:** If you don't complete setup via the web installer (even if you set up SSH keys and virtual hosts otherwise) your Dokku installation will remain vulnerable to anyone finding the setup page and inserting their key.
 
-> **Warning:** Web installer is not available on CentOS and Arch Linux. You will need to configure [SSH keys](/docs/deployment/user-management.md#adding-ssh-keys) and [virtual hosts](/docs/configuration/domains.md#customizing-hostnames) using dokku command line interface.
+> **Warning:** Web installer is not available on CentOS and Arch Linux. You will need to configure [SSH keys](/docs/deployment/user-management.md#adding-ssh-keys) and [virtual hosts](/docs/configuration/domains.md#customizing-hostnames) using dokku command line interface - see unattended installation linked above.
 
 #### 3. Deploy your first application
 


### PR DESCRIPTION
[ci skip]

> +*You should also stop and disable the `dokku-installer` service to remove public access to adding SSH keys.*

Could we get more information (link out if verbose) on the best way to do this?

> Otherwise you have to create the file manually and set it to your preferred domain

Hmm, instructions which tell people to write a file don't seem that that durable - it seems like newcomers could easily run into weird permissions errors and whatnot. Does `dokku:domains set-global` help here? Should we have a cross-platform way to set this?

related: https://github.com/dokku/dokku/issues/2247