### PR TITLE
rm nginx configs on debian purge

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -24,6 +24,8 @@ main() {
   (nginx -t && service nginx reload) || true
 
   if [[ "$1" == "purge" ]]; then
+    rm -f /etc/nginx/conf.d/dokku.conf
+    rm -f /etc/nginx/conf.d/dokku-installer.conf
     rm -f ${DOKKU_ROOT}/.dokkurc ${DOKKU_ROOT}/dokkurc ${DOKKU_ROOT}/tls
     rm -f ${DOKKU_ROOT}/.ssh/authorized_keys ${DOKKU_ROOT}/.sshcommand
     rm -f ${DOKKU_ROOT}/ENV ${DOKKU_ROOT}/HOSTNAME ${DOKKU_ROOT}/VERSION


### PR DESCRIPTION
Per Slack conversation - going back to a blank slate can be helpful when messing around and I think removing these configs fits with Debian convention

`/etc/nginx/conf.d/dokku.conf` is created by the vhosts plugin but I think it also makes sense for purge

have not technically tested installing / uninstalling the modified package, let me know if that's needed