### PR TITLE
skip validity check for config:unset

### DIFF
--- a/plugins/config/config.go
+++ b/plugins/config/config.go
@@ -66,11 +66,6 @@ func UnsetMany(appName string, keys []string, restart bool) (err error) {
 	}
 	var changed = false
 	for _, k := range keys {
-		if err = validateKey(k); err != nil {
-			return
-		}
-	}
-	for _, k := range keys {
 		if _, hasKey := env.Map()[k]; hasKey {
 			common.LogInfo1(fmt.Sprintf("Unsetting %s", k))
 			env.Unset(k)

--- a/plugins/config/config_test.go
+++ b/plugins/config/config_test.go
@@ -132,7 +132,7 @@ func TestInvalidKeys(t *testing.T) {
 	invalidKeys := []string{"0invalidKey", "invalid:key", "invalid=Key", "!invalidKey"}
 	for _, key := range invalidKeys {
 		Expect(SetMany(testAppName, map[string]string{key: "value"}, false)).NotTo(Succeed())
-		Expect(UnsetMany(testAppName, []string{key}, false)).NotTo(Succeed())
+		Expect(UnsetMany(testAppName, []string{key}, false)).To(Succeed())
 		value, ok := Get(testAppName, key)
 		Expect(ok).To(Equal(false))
 		value = GetWithDefault(testAppName, key, "default")

--- a/plugins/config/config_test.go
+++ b/plugins/config/config_test.go
@@ -140,6 +140,25 @@ func TestInvalidKeys(t *testing.T) {
 	}
 }
 
+func TestInvalidEnvOnDisk(t *testing.T) {
+	RegisterTestingT(t)
+	Expect(setupTestApp()).To(Succeed())
+	defer teardownTestApp()
+
+	b := []byte("export --invalid-key=TESTING\nexport valid_key=value\n")
+	if err := ioutil.WriteFile(strings.Join([]string{testAppDir, "/ENV"}, ""), b, 0644); err != nil {
+		return
+	}
+
+	env, err := LoadAppEnv(testAppName)
+	Expect(err).To(Succeed())
+	_, ok := env.Get("--invalid-key")
+	Expect(ok).To(Equal(false))
+	value, ok := env.Get("valid_key")
+	Expect(ok).To(Equal(true))
+	Expect(value).To(Equal("value"))
+}
+
 func expectValue(appName string, key string, expected string) {
 	v, ok := Get(appName, key)
 	Expect(ok).To(Equal(true))

--- a/plugins/config/environment.go
+++ b/plugins/config/environment.go
@@ -253,6 +253,13 @@ func loadFromFile(name string, filename string) (env *Env, err error) {
 		envMap, err = godotenv.Read(filename)
 	}
 
+	for k := range envMap {
+		if err := validateKey(k); err != nil {
+			common.LogVerbose(fmt.Sprintf("Ignoring key %s from config for %s", k, name))
+			delete(envMap, k)
+		}
+	}
+
 	env = &Env{
 		name:     name,
 		filename: filename,


### PR DESCRIPTION
Sometimes <0.11 was placing invalid keys in app/global envfiles. In 0.11+ they were causing havoc and the user was unable to unset them. This allows the keys to at least be unset.

In the cases we've seen, 0.10 didn't actually display or have a value for that invalid key, it was just lurking in the envfile. Since it doesn't seem it was ever possible to use the invalid key, should we just filter them automatically when 11.0 loads the envfile?

resolves: #3036 
