### PR TITLE
Remove bad config keys on load from app/global envfiles

### DIFF
--- a/plugins/config/config_test.go
+++ b/plugins/config/config_test.go
@@ -140,6 +140,32 @@ func TestInvalidKeys(t *testing.T) {
 	}
 }
 
+func TestInvalidEnvOnDisk(t *testing.T) {
+	RegisterTestingT(t)
+	Expect(setupTestApp()).To(Succeed())
+	defer teardownTestApp()
+
+	appConfigFile := strings.Join([]string{testAppDir, "/ENV"}, "")
+	b := []byte("export --invalid-key=TESTING\nexport valid_key=value\n")
+	if err := ioutil.WriteFile(appConfigFile, b, 0644); err != nil {
+		return
+	}
+
+	env, err := LoadAppEnv(testAppName)
+	Expect(err).NotTo(HaveOccurred())
+	_, ok := env.Get("--invalid-key")
+	Expect(ok).To(Equal(false))
+	value, ok := env.Get("valid_key")
+	Expect(ok).To(Equal(true))
+	Expect(value).To(Equal("value"))
+
+	//LoadAppEnv eliminates it from the file
+	content, err := ioutil.ReadFile(appConfigFile)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(strings.Contains(string(content), "--invalid-key")).To(BeFalse())
+
+}
+
 func expectValue(appName string, key string, expected string) {
 	v, ok := Get(appName, key)
 	Expect(ok).To(Equal(true))

--- a/plugins/config/environment.go
+++ b/plugins/config/environment.go
@@ -253,6 +253,20 @@ func loadFromFile(name string, filename string) (env *Env, err error) {
 		envMap, err = godotenv.Read(filename)
 	}
 
+	dirty := false
+	for k := range envMap {
+		if err := validateKey(k); err != nil {
+			common.LogInfo1(fmt.Sprintf("Deleting invalid key %s from config for %s", k, name))
+			delete(envMap, k)
+			dirty = true
+		}
+	}
+	if dirty {
+		if err := godotenv.Write(envMap, filename); err != nil {
+			common.LogFail(fmt.Sprintf("Error writing back config for %s after removing invalid keys", name))
+		}
+	}
+
 	env = &Env{
 		name:     name,
 		filename: filename,


### PR DESCRIPTION
Sometimes <0.11 was placing invalid keys in app/global envfiles. In 0.11+ they were causing havoc and the user was unable to unset them.

Now we delete them from the envfiles when we encounter them.

resolves: #3036