### PR TITLE
Add plugin to manage Dockerfile location to documentation

### DIFF
--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -97,6 +97,7 @@ Note: The following plugins have been supplied by our community and may not have
 [michaelshobbs]: https://github.com/michaelshobbs
 [mikecsh]: https://github.com/mikecsh
 [mikexstudios]: https://github.com/mikexstudios
+[mimischi]: https://github.com/mimischi
 [mixxorz]: https://github.com/mixxorz
 [mlebkowski]: https://github.com/mlebkowski
 [motin]: https://github.com/motin
@@ -176,6 +177,7 @@ Note: The following plugins have been supplied by our community and may not have
 | [Docker Direct](https://github.com/josegonzalez/dokku-docker-direct)                              | [josegonzalez][]      | 0.4.0+                |
 | [Dokku Clone](https://github.com/crisward/dokku-clone)                                            | [crisward][]          | 0.4.0+                |
 | [Dokku Copy App Config Files](https://github.com/josegonzalez/dokku-supply-config)                | [josegonzalez][]      | 0.4.0+                |
+| [Dockerfile custom path](https://github.com/mimischi/dokku-dockerfile)                            | [mimischi][]          | 0.8.0+                |
 | [Dokku Registry](https://github.com/agco-adm/dokku-registry)<sup>1</sup>                          | [agco-adm][]          | 0.4.0+                |
 | [Dokku Require](https://github.com/crisward/dokku-require)<sup>2</sup>                            | [crisward][]          | 0.4.0+                |
 | [git rev-parse HEAD in env](https://github.com/dokku-community/dokku-git-rev)                     | [cjblomqvist][]       | 0.4.0+                |


### PR DESCRIPTION
Some time ago I've created the [`dokku-dockerfile`](https://github.com/mimischi/dokku-dockerfile) plugin. It points Dokku to a different `Dockerfile` path, relative to the project root, when building the app. Sometimes a projects does not want to clutter their project root with a load of deployment files, so this plugin helps, by telling Dokku where to look for the actual `Dockerfile`.

I'm not sure what the actual minimal Dokku version is I'd have to set, so any feedback is appreciated.

[ci skip]
