### PR TITLE
Fix HTTP -> HTTPS CORS

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -12,6 +12,7 @@ server {
   access_log  /var/log/nginx/{{ $.APP }}-access.log;
   error_log   /var/log/nginx/{{ $.APP }}-error.log;
 {{ if (and (eq $listen_port "80") ($.SSL_INUSE)) }}
+  add_header 'Access-Control-Allow-Origin' '*';
   return 301 https://$host:{{ $.NGINX_SSL_PORT }}$request_uri;
 {{ else }}
   location    / {


### PR DESCRIPTION
When we're redirecting from HTTP -> HTTPS the redirect is handled by Nginx itself, our applications never see the original request. In this case we should return a CORS-compatible redirect, without doing so browsers block the redirect and our application never gets the expected HTTPS request. 

There's no security implications here as we're simply instructing the browser to use HTTPS. When the browser proceeds to fire the request over HTTPS, then the application can handle the request and chose whether or not to include CORS headers allowing the browser to handle the response.