### PR TITLE
Change help run command be more explicit

### DIFF
--- a/docs/deployment/one-off-processes.md
+++ b/docs/deployment/one-off-processes.md
@@ -5,7 +5,7 @@ Sometimes you need to either inspect running containers or run a one-off command
 ## Run a command in an app environment
 
 ```
-run <app> <cmd>                                # Run a command in the environment of an application
+run <app> <cmd>                                # Run a command in a new container using the current application image
 ```
 
 The `run` command can be used to run a one-off process for a specific command. This will start a new container and run the desired command within that container. Note that this container will be stay around even after command completes. The container will be the same container as was used to start the currently deployed application.

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -9,7 +9,7 @@ case "$1" in
       declare desc="return standard plugin help content"
       cat<<help_content
     ls , Pretty listing of deployed applications and containers
-    run <app> <cmd>, Run a command in the environment of an application
+    run <app> <cmd>, Run a command in the container based on application image
     trace [on/off], Enable dokku tracing
     url <app>, Show the first URL for an application (compatibility)
     urls <app>, Show all URLs for an application

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -9,7 +9,7 @@ case "$1" in
       declare desc="return standard plugin help content"
       cat<<help_content
     ls , Pretty listing of deployed applications and containers
-    run <app> <cmd>, Run a command in the container based on application image
+    run <app> <cmd>, Run a command in a new container using the current application image
     trace [on/off], Enable dokku tracing
     url <app>, Show the first URL for an application (compatibility)
     urls <app>, Show all URLs for an application


### PR DESCRIPTION
I purpose to change help run command to more explicit, infact, suggested that command is running inside current application and not that new container based upon application image. 