### PR TITLE
fix: Validate that all application names are valid domain names

### DIFF
--- a/plugins/apps/functions
+++ b/plugins/apps/functions
@@ -5,10 +5,10 @@ source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 apps_create() {
   declare desc="verifies app name and creates an app"
-  [[ -z $1 ]] && dokku_log_fail "Please specify an app to run the command on"
-  [[ ! "$1" =~ ^[a-z].* && ! "$1" =~ ^[0-9].* ]] && dokku_log_fail "App name must begin with lowercase alphanumeric character"
-  [[ -d "$DOKKU_ROOT/$1" ]] && dokku_log_fail "Name is already taken"
-  local APP="$1"
+  declare APP="$1"
+  is_valid_app_name "$APP"
+
+  [[ -d "$DOKKU_ROOT/$APP" ]] && dokku_log_fail "Name is already taken"
 
   mkdir -p "$DOKKU_ROOT/$APP"
   echo "Creating $APP... done"

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -141,11 +141,14 @@ is_valid_app_name() {
   declare desc="verify app name format"
   local APP="$1"
   [[ ! -n "$APP" ]] && dokku_log_fail "APP must not be null"
-  if [[ ! "$APP" =~ ^[a-z].* && ! "$APP" =~ ^[0-9].* ]]; then
-    [[ -d "$DOKKU_ROOT/$APP" ]] && rm -rf "${DOKKU_ROOT:?}/$APP"
-    dokku_log_fail "App name must begin with lowercase alphanumeric character"
+  if [[ "$APP" =~ ^[a-z].* ]] || [[  "$APP" =~ ^[0-9].* ]]; then
+    if [[ ! $APP =~ [A-Z] ]] && [[ ! $APP =~ [:] ]]; then
+      return 0
+    fi
   fi
-  return 0
+
+  [[ -d "$DOKKU_ROOT/$APP" ]] && rm -rf "${DOKKU_ROOT:?}/$APP"
+  dokku_log_fail "App name must begin with lowercase alphanumeric character"
 }
 
 verify_app_name() {

--- a/tests/unit/10_apps.bats
+++ b/tests/unit/10_apps.bats
@@ -25,7 +25,16 @@ teardown () {
   echo "output: "$output
   echo "status: "$status
   assert_success
-  dokku --force apps:destroy 1994testapp
+
+  run dokku apps:create testapp:latest
+  echo "output: "$output
+  echo "status: "$status
+  assert_failure
+
+  run dokku apps:create testApp:latest
+  echo "output: "$output
+  echo "status: "$status
+  assert_failure
 
   run dokku apps:create TestApp
   echo "output: "$output


### PR DESCRIPTION
Invalid application names will need to be manually cleaned up by the user, and as such this is a bc-break.

Closes #3054
