### PR TITLE
docs: Remove all references to VHOST files from documentation

### DIFF
--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -25,9 +25,9 @@ Applications typically have the following structure for their hostname:
 scheme://subdomain.domain.tld
 ```
 
-The `subdomain` is inferred from the pushed application name, while the `domain.tld` is set during initial configuration and stored in the `$DOKKU_ROOT/VHOST` file. It can then be modified with `dokku domains:add-global` and `dokku domains:remove-global`. This value is used as a default TLD for all applications on a host.
+The `subdomain` is inferred from the pushed application name, while the `domain.tld` is set during initial dokku configuration. It can then be modified with `dokku domains:add-global` and `dokku domains:remove-global`. This value is used as a default TLD for all applications on a host.
 
-If a FQDN such as `other.tld` is used as the application name, the default `$DOKKU_ROOT/VHOST` will be ignored and the resulting vhost URL for that application will be `other.tld`. The exception to this rule being that if the FQDN has the same ending as the default vhost (such as `subdomain.domain.tld`), then the entire FQDN will be treated as a subdomain. The application will therefore be deployed at `subdomain.domain.tld.domain.tld`.
+If a FQDN such as `other.tld` is used as the application name, the global virtualhost will be ignored and the resulting vhost URL for that application will be `other.tld`. The exception to this rule being that if the FQDN has the same ending as the default vhost (such as `subdomain.domain.tld`), then the entire FQDN will be treated as a subdomain. The application will therefore be deployed at `subdomain.domain.tld.domain.tld`.
 
 You can optionally override this in a plugin by implementing the `nginx-hostname` plugin trigger. For example, you can reverse the subdomain with the following sample `nginx-hostname` plugin trigger:
 

--- a/docs/getting-started/advanced-installation.md
+++ b/docs/getting-started/advanced-installation.md
@@ -56,7 +56,7 @@ For Debian, unattended installation is described [Debian installation guide](/do
 
 *You should also stop and disable the `dokku-installer` service to remove public access to adding SSH keys.*
 
-Set up a domain using your preferred vendor and a wildcard domain pointing to the host running dokku. Make sure `/home/dokku/VHOST` is set to this domain. By default it's set to whatever hostname the host has. This file is only created if the hostname can be resolved by dig (`dig +short $(hostname -f)`). Otherwise you have to create the file manually and set it to your preferred domain. If this file still is not present when you push your app, Dokku will publish the app with a port number (i.e. `http://example.com:49154` - note the missing subdomain).
+Set up a domain using your preferred vendor and a wildcard domain pointing to the host running dokku. You can manage this global domain using the [domains plugin](/docs/configuration/domains.md).
 
 Follow the [user management documentation](/docs/deployment/user-management.md) in order to add ssh keys for users to Dokku, or to give other Unix accounts access to Dokku.
 

--- a/docs/networking/dns.md
+++ b/docs/networking/dns.md
@@ -77,5 +77,5 @@ This section is a work in progress.  It is incomplete.
 
 Using the 'root' of your domain is nearly identical to the previous example.
 
-* hostname is under `example.tld`, still needs `A` record
-* Need to modify `/home/dokku/HOSTNAME` and `/home/dokku/VHOST`
+* hostname is under `example.tld`, still needs `A` record.
+* Update your global domain using the [domains plugin](docs/configuration/domains.md).


### PR DESCRIPTION
Users should never be in a position where they need to manually edit files managed by Dokku, and should be pushed to using the `domains` plugin where necessary.

Closes #3064

[ci skip]
