### PR TITLE
feat: add support for rhel

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -91,7 +91,7 @@ install-dokku-from-package() {
     debian|ubuntu)
       install-dokku-from-deb-package "$@"
       ;;
-    centos)
+    centos|rhel)
       install-dokku-from-rpm-package "$@"
       ;;
     *)

--- a/contrib/dokku-update
+++ b/contrib/dokku-update
@@ -62,7 +62,7 @@ main() {
       apt-get update -qq > /dev/null
       apt-get -qq -y --force-yes dist-upgrade
       ;;
-    centos|opensuse)
+    centos|opensuse|rhel)
       dokku-log-warn "Updating this operating system is not supported"
       ;;
     *)

--- a/plugins/20_events/install
+++ b/plugins/20_events/install
@@ -13,7 +13,7 @@ flag_rsyslog_needs_restart=n
 # shellcheck disable=SC2174
 mkdir -m 775 -p "$DOKKU_LOGS_DIR"
 case "$DOKKU_DISTRO" in
-  arch|debian|centos)
+  arch|debian|centos|rhel)
     chgrp dokku "$DOKKU_LOGS_DIR"
     ;;
   *)
@@ -24,7 +24,7 @@ esac
 if [[ ! -f  "$DOKKU_EVENTS_LOGFILE" ]]; then
   touch "$DOKKU_EVENTS_LOGFILE"
   case "$DOKKU_DISTRO" in
-    arch|debian|centos)
+    arch|debian|centos|rhel)
       chgrp dokku "$DOKKU_EVENTS_LOGFILE"
       ;;
     *)

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -62,7 +62,7 @@ restart_nginx() {
       sudo /sbin/service nginx reload > /dev/null
       ;;
 
-    arch|centos)
+    arch|centos|rhel)
       sudo /usr/bin/systemctl reload nginx
       ;;
   esac

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -18,7 +18,7 @@ case "$DOKKU_DISTRO" in
     echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl reload nginx, /usr/sbin/nginx -t" > /etc/sudoers.d/dokku-nginx
     ;;
 
-  centos)
+  centos|rhel)
     echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl reload nginx, /usr/sbin/nginx -t" > /etc/sudoers.d/dokku-nginx
     echo "Defaults:dokku !requiretty" >> /etc/sudoers.d/dokku-nginx
     ;;
@@ -89,7 +89,7 @@ case "$DOKKU_DISTRO" in
     "$NGINX_INIT" nginx start || "$NGINX_INIT" nginx reload
     ;;
 
-  arch|centos)
+  arch|centos|rhel)
     NGINX_INIT="/usr/bin/systemctl"
     "$NGINX_INIT" start nginx || "$NGINX_INIT" reload nginx
     ;;


### PR DESCRIPTION
The centos rpm packages should be installable on centos once this is merged and released. However, Dokku will not maintain an Rhel-specific repository as there is no way for us to feasibly test it.

Closes #3046
