### PR TITLE
Prune worktree after build

### DIFF
--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -41,7 +41,6 @@ git_build_app_repo() {
     # unset the git quarantine path to allow us to use 2.13.0+
     # See this issue for more information: https://github.com/dokku/dokku/issues/2796
     env -u GIT_QUARANTINE_PATH git worktree add "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV" > /dev/null
-    trap 'rm -rf "$GIT_BUILD_APP_REPO_TMP_WORK_DIR"; git worktree prune > /dev/null' RETURN INT TERM EXIT
     popd > /dev/null
     pushd "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" > /dev/null
   else
@@ -64,6 +63,12 @@ git_build_app_repo() {
 
   suppress_output git submodule update --init --recursive
   find . -name .git -prune -exec rm -rf {} \; > /dev/null
+
+  if use_git_worktree; then
+    pushd "$DOKKU_ROOT/$APP"
+    git worktree prune
+    popd
+  fi
 
   local DOKKU_APP_DISABLE_ANSI_PREFIX_REMOVAL DOKKU_GLOBAL_DISABLE_ANSI_PREFIX_REMOVAL DOKKU_DISABLE_ANSI_PREFIX_REMOVAL
   DOKKU_APP_DISABLE_ANSI_PREFIX_REMOVAL=$(config_get "$APP" DOKKU_DISABLE_ANSI_PREFIX_REMOVAL || true)

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -41,6 +41,7 @@ git_build_app_repo() {
     # unset the git quarantine path to allow us to use 2.13.0+
     # See this issue for more information: https://github.com/dokku/dokku/issues/2796
     env -u GIT_QUARANTINE_PATH git worktree add "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV" > /dev/null
+    trap 'git worktree prune > /dev/null' RETURN INT TERM EXIT
     popd > /dev/null
     pushd "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" > /dev/null
   else

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -41,7 +41,7 @@ git_build_app_repo() {
     # unset the git quarantine path to allow us to use 2.13.0+
     # See this issue for more information: https://github.com/dokku/dokku/issues/2796
     env -u GIT_QUARANTINE_PATH git worktree add "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" "$REV" > /dev/null
-    trap 'git worktree prune > /dev/null' RETURN INT TERM EXIT
+    trap 'rm -rf "$GIT_BUILD_APP_REPO_TMP_WORK_DIR"; git worktree prune > /dev/null' RETURN INT TERM EXIT
     popd > /dev/null
     pushd "$GIT_BUILD_APP_REPO_TMP_WORK_DIR" > /dev/null
   else


### PR DESCRIPTION
Since #2973, Dokku add worktree when build app, And that worktree was remained after build.
This PR will prune that worktree after build.

FYI: try `git worktree list` on `/home/dokku/APPNAME`
```
kjwon15@shion:~dokku/armbot % git worktree list                                                                                                                                                                   
/home/dokku/armbot   (bare)
/tmp/dokku_git.1vgF  c9e98f9 (detached HEAD)
/tmp/dokku_git.78np  0dee744 (detached HEAD)
/tmp/dokku_git.7gJ1  c9e98f9 (detached HEAD)
/tmp/dokku_git.GNJj  5fb35cb (detached HEAD)
/tmp/dokku_git.Gtyb  ef758aa (detached HEAD)
/tmp/dokku_git.LD3N  c5b816d (detached HEAD)
/tmp/dokku_git.YDwg  ce093b7 (detached HEAD)
/tmp/dokku_git.YT7i  77ec789 (detached HEAD)
```