### PR TITLE
fix: move container status exclusively to ps plugin

### DIFF
--- a/docs/deployment/application-management.md
+++ b/docs/deployment/application-management.md
@@ -155,15 +155,11 @@ dokku apps:report
 =====> node-js-app
        App dir:             /home/dokku/node-js-app
        Git sha:             dbddc3f                  
-       App cid:             7b18489c98be             
-       Status:              running                  
 =====> python-sample
 not deployed
 =====> ruby-sample
        App dir:             /home/dokku/ruby-sample
        Git sha:             a2d477c
-       App cid:             78a44d71012a
-       Status:              running
 ```
 
 You can run the command for a specific app also.
@@ -176,8 +172,6 @@ dokku apps:report node-js-app
 =====> node-js-app
        App dir:             /home/dokku/node-js-app
        Git sha:             dbddc3f                  
-       App cid:             7b18489c98be             
-       Status:              running   
 ```
 
 You can pass flags which will output only the value of the specific information you want. For example:

--- a/plugins/apps/subcommands/report
+++ b/plugins/apps/subcommands/report
@@ -12,21 +12,9 @@ report_single_app() {
     INFO_FLAG=""
   fi
   verify_app_name "$APP"
-  local DOKKU_APP_CIDS=$(get_app_container_ids "$APP")
-  if [[ -n $DOKKU_APP_CIDS ]]; then
-    local cid
-    for CID in $DOKKU_APP_CIDS; do
-      local APP_CONTAINER_STATUS
-      local DOKKU_APP_CID
-      DOKKU_APP_CID=$CID
-      APP_CONTAINER_STATUS=$(docker inspect -f '{{.State.Status}}' "$CID")
-    done
-  fi
   local flag_map=(
     "--app-dir: $APP_DIR"
     "--git-sha: $(GIT_DIR="$APP_DIR" git rev-parse --short HEAD 2> /dev/null || false)"
-    "--app-cid: ${DOKKU_APP_CID:0:12}"
-    "--status: $APP_CONTAINER_STATUS"
   )
 
   if [[ -z "$INFO_FLAG" ]]; then

--- a/plugins/ps/subcommands/report
+++ b/plugins/ps/subcommands/report
@@ -34,9 +34,11 @@ report_single_app() {
   local DOKKU_APP_RESTORE=$(config_get "$APP" DOKKU_APP_RESTORE || true)
   local STATUSES=()
   if [[ "$DOKKU_APP_RESTORE" != 0 ]]; then RESTORE="true"; else RESTORE="false"; fi
+  local APP_CONTAINER_STATUS
   for CONTAINER_FILE in $CONTAINER_FILES; do
     CID=$(< "$DOKKU_ROOT/$APP/$CONTAINER_FILE")
-    local APP_CONTAINER_STATUS=$(docker inspect -f '{{.State.Running}}' "$CID")
+    APP_CONTAINER_STATUS=$(docker inspect -f '{{.State.Running}}' "$CID" 2> /dev/null)
+    [[ -z "$APP_CONTAINER_STATUS" ]] && APP_CONTAINER_STATUS="dead"
     STATUSES+=("${CONTAINER_FILE#*.}:$APP_CONTAINER_STATUS#${CID:0:12}")
   done
   local flag_map=(


### PR DESCRIPTION
This information didn't belong in the apps plugin and was incomplete.

Also set the container status to dead when it is not detected as running.
