### PR TITLE
feat: source /etc/defaults/dokku if available

### DIFF
--- a/contrib/dokku-update
+++ b/contrib/dokku-update
@@ -2,9 +2,30 @@
 set -eo pipefail
 shopt -s nullglob
 
+if [[ -r /etc/defaults/dokku ]]; then
+  # shellcheck disable=SC1091
+  source /etc/defaults/dokku
+fi
+
 export DOKKU_ROOT=${DOKKU_ROOT:=~dokku}
-[[ -f $DOKKU_ROOT/dokkurc ]] && source "$DOKKU_ROOT/dokkurc"
-[[ -d $DOKKU_ROOT/.dokkurc ]] && for f in $DOKKU_ROOT/.dokkurc/*; do source "$f"; done
+if [[ -f "$DOKKU_ROOT/dokkurc" ]]; then
+  if [[ -r $DOKKU_ROOT/dokkurc ]]; then
+    source "$DOKKU_ROOT/dokkurc"
+  else
+    echo "Unable to read $DOKKU_ROOT/dokkurc for sourcing" 1>&2
+    exit 1
+  fi
+fi
+if [[ -d $DOKKU_ROOT/.dokkurc ]]; then
+  for f in $DOKKU_ROOT/.dokkurc/*; do
+    if [[ -r "$f" ]]; then
+      source "$f"
+    else
+      echo "Unable to read $f for sourcing" 1>&2
+      exit 1
+    fi
+  done
+fi
 [[ $DOKKU_TRACE ]] && set -x
 
 export DOKKU_LIB_ROOT=${DOKKU_LIB_PATH:="/var/lib/dokku"}

--- a/debian/postinst
+++ b/debian/postinst
@@ -6,6 +6,11 @@ if [[ -e /usr/share/debconf/confmodule ]]; then
   . /usr/share/debconf/confmodule
 fi
 
+if [[ -r /etc/defaults/dokku ]]; then
+  # shellcheck disable=SC1091
+  source /etc/defaults/dokku
+fi
+
 readonly DOKKU_ROOT="${DOKKU_ROOT:-/home/dokku}"
 readonly DOKKU_LIB_ROOT="${DOKKU_LIB_PATH:-/var/lib/dokku}"
 

--- a/dokku
+++ b/dokku
@@ -2,6 +2,11 @@
 set -eo pipefail
 shopt -s nullglob
 
+if [[ -r /etc/defaults/dokku ]]; then
+  # shellcheck disable=SC1091
+  source /etc/defaults/dokku
+fi
+
 export DOKKU_ROOT=${DOKKU_ROOT:=~dokku}
 if [[ -f "$DOKKU_ROOT/dokkurc" ]]; then
   if [[ -r $DOKKU_ROOT/dokkurc ]]; then

--- a/rpm/dokku.postinst
+++ b/rpm/dokku.postinst
@@ -50,6 +50,11 @@ setup-version() {
 }
 
 main() {
+  if [[ -r /etc/defaults/dokku ]]; then
+    # shellcheck disable=SC1091
+    source /etc/defaults/dokku
+  fi
+
   readonly DOKKU_ROOT="${DOKKU_ROOT:-/home/dokku}"
   readonly DOKKU_LIB_ROOT="${DOKKU_LIB_PATH:-/var/lib/dokku}"
 


### PR DESCRIPTION
This allows users to override - at a top-level - the DOKKU_ROOT, DOKKU_LIB_ROOT, and other
configuration variables. If specified, this should begin to enable users to move their
Dokku installations to mounted drives.

Note that items installed from packages may not respect these paths, so further work may be in order.

Closes #2958