### PR TITLE
Add newline character when printing config:get

### DIFF
--- a/plugins/config/subcommands.go
+++ b/plugins/config/subcommands.go
@@ -43,9 +43,9 @@ func CommandGet(args []string, global bool, quoted bool) {
 		os.Exit(1)
 	} else {
 		if quoted {
-			fmt.Printf("'%s'", singleQuoteEscape(value))
+			fmt.Printf("'%s'\n", singleQuoteEscape(value))
 		} else {
-			fmt.Printf("%s", value)
+			fmt.Printf("%s\n", value)
 		}
 	}
 }


### PR DESCRIPTION
## What

Adds a newline character at the end of `dokku config:get` output