### PR TITLE
Updated help text on config:set to have commands in working order

### DIFF
--- a/plugins/config/src/commands/commands.go
+++ b/plugins/config/src/commands/commands.go
@@ -21,7 +21,7 @@ Additional commands:`
 	helpContent = `
     config (<app>|--global), Pretty-print an app or global environment
     config:get (<app>|--global) KEY, Display a global or app-specific config value
-    config:set (<app>|--global) [--encoded] [--no-restart] KEY1=VALUE1 [KEY2=VALUE2 ...], Set one or more config vars
+    config:set [--encoded] [--no-restart] (<app>|--global) KEY1=VALUE1 [KEY2=VALUE2 ...], Set one or more config vars
     config:unset (<app>|--global) KEY1 [KEY2 ...], Unset one or more config vars
     config:export (<app>|--global) [--envfile], Export a global or app environment
     config:keys (<app>|--global) [--merged], Show keys set in environment


### PR DESCRIPTION
The `config:set` command was not working in the order the help text provided suggested. It works if you put the app name after the options for `encoded` and `no-restart`, so I rearranged the help text to make this clear.