### PR TITLE
Create proxy:ports-set call

### DIFF
--- a/docs/networking/port-management.md
+++ b/docs/networking/port-management.md
@@ -4,7 +4,8 @@
 
 ```
 proxy:ports <app>                        # List proxy port mappings for app
-proxy:ports-add <app> <scheme>:<host-port>:<container-port> [<scheme>:<host-port>:<container-port>...]           # Set proxy port mappings for app
+proxy:ports-set <app> <scheme>:<host-port>:<container-port> [<scheme>:<host-port>:<container-port>...]           # Set proxy port mappings for app
+proxy:ports-add <app> <scheme>:<host-port>:<container-port> [<scheme>:<host-port>:<container-port>...]           # Add proxy port mappings for app
 proxy:ports-clear <app>                  # Clear all proxy port mappings for app
 proxy:ports-remove <app> <host-port> [<host-port>|<scheme>:<host-port>:<container-port>...]                      # Unset proxy port mappings for app
 ```
@@ -86,7 +87,22 @@ curl http://node-js-app.dokku.me:8080
 Hello World!
 ```
 
-You can also remove a port mapping that is no longer necessary:
+Port mappings can also be force set using the `proxy:ports-set` command.
+
+```shell
+dokku proxy:ports-set node-js-app http:8080:5000
+```
+
+```
+-----> Setting config vars
+       DOKKU_PROXY_PORT_MAP: http:80:5000 http:8080:5000
+-----> Configuring node-js-app.dokku.me...(using built-in template)
+-----> Creating http nginx.conf
+-----> Running nginx-pre-reload
+       Reloading nginx
+```
+
+A port mapping can be removed using the `proxy:ports-remove` command if it no longer necessary:
 
 ```shell
 dokku proxy:ports-remove node-js-app http:80:5000

--- a/plugins/proxy/functions
+++ b/plugins/proxy/functions
@@ -66,7 +66,7 @@ filter_app_proxy_ports() {
 }
 
 add_proxy_ports() {
-  declare desc="add proxy port mappings from an app"
+  declare desc="add proxy port mappings for an app"
   local APP="$1"
   local PROXY_PORT_MAP="$(get_app_proxy_port_map "$APP")"
   shift 1
@@ -82,7 +82,7 @@ add_proxy_ports() {
 }
 
 remove_proxy_ports() {
-  declare desc="remove specific proxy port mappings from an app"
+  declare desc="remove specific proxy port mappings for an app"
   local APP="$1"
   local PROXY_PORT_MAP="$(get_app_proxy_port_map "$APP")"
   local RE_PORT='^[0-9]+$'
@@ -104,5 +104,20 @@ remove_proxy_ports() {
     config_set --no-restart "$APP" DOKKU_PROXY_PORT_MAP="$PROXY_PORT_MAP"
   else
     config_unset --no-restart "$APP" DOKKU_PROXY_PORT_MAP
+  fi
+}
+
+set_proxy_ports() {
+  declare desc="SET proxy port mappings for an app"
+  local APP="$1"
+  shift 1
+
+  local INPUT_PORTS="$*"
+  if [[ -n "$INPUT_PORTS" ]]; then
+    PROXY_PORT_MAP="$(merge_dedupe_list "$INPUT_PORTS" " ")"
+    config_set --no-restart "$APP" DOKKU_PROXY_PORT_MAP="$PROXY_PORT_MAP"
+  else
+    dokku proxy:help
+    dokku_log_fail "No port mapping specified. Exiting..."
   fi
 }

--- a/plugins/proxy/subcommands/ports-remove
+++ b/plugins/proxy/subcommands/ports-remove
@@ -2,7 +2,6 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
-source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 proxy_ports_remove_cmd() {
   declare desc="remove specific proxy port mappings from an app"

--- a/plugins/proxy/subcommands/ports-set
+++ b/plugins/proxy/subcommands/ports-set
@@ -3,14 +3,14 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 
-proxy_ports_add_cmd() {
+proxy_ports_set_cmd() {
   declare desc="add proxy port mappings from an app"
   local cmd="proxy:add"
   local APP="$2"; verify_app_name "$APP"
   shift 2
 
-  add_proxy_ports "$APP" "$@"
+  set_proxy_ports "$APP" "$@"
   plugn trigger post-proxy-ports-update "$APP" "add"
 }
 
-proxy_ports_add_cmd "$@"
+proxy_ports_set_cmd "$@"

--- a/tests/unit/40_proxy.bats
+++ b/tests/unit/40_proxy.bats
@@ -65,8 +65,28 @@ assert_external_port() {
   done
 }
 
-@test "(proxy) proxy:ports (list/add/remove/clear)" {
-  run dokku proxy:ports-add $TEST_APP http:8080:5000 https:8443:5000 http:1234:5001
+@test "(proxy) proxy:ports (list/add/set/remove/clear)" {
+  run /bin/bash -c "dokku proxy:ports-set $TEST_APP http:1234:5001"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run /bin/bash -c "dokku --quiet proxy:ports $TEST_APP | xargs"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "http 1234 5001"
+
+  run /bin/bash -c "dokku proxy:ports-add $TEST_APP http:8080:5002 https:8443:5003"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run /bin/bash -c "dokku --quiet proxy:ports $TEST_APP | xargs"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "http 1234 5001 http 8080 5002 https 8443 5003"
+
+  run /bin/bash -c "dokku proxy:ports-set $TEST_APP http:8080:5000 https:8443:5000 http:1234:5001"
   echo "output: "$output
   echo "status: "$status
   assert_success


### PR DESCRIPTION
In some cases, it may be useful to completely override the set ports for a given application - such as on initial deploy when there is no global domain set. This change also further allows us to handle automation in a smoother fashion.
