### PR TITLE
fix: re-add is_container_running

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -398,6 +398,19 @@ is_deployed() {
   fi
 }
 
+is_container_running() {
+  declare desc="return 0 if given docker container id is in running state"
+  declare deprecated=true
+  local CID=$1
+  local CONTAINER_STATUS=$(docker inspect -f '{{.State.Running}}' "$CID" || true)
+
+  if [[ "$CONTAINER_STATUS" == "true" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 is_container_status() {
   declare desc="return 0 if given docker container id is in given state"
   local CID=$1


### PR DESCRIPTION
As this was not strictly announced in our migration guide, removing it is a bc-incompatible change we are not comfortable with. We may wish to remove it in the future.