### PR TITLE
fix: ensure we _always_ include all types in history output

### DIFF
--- a/contrib/release
+++ b/contrib/release
@@ -237,7 +237,7 @@ fn-repo-update-history-and-commit() {
   declare desc="Updates the history file and commits the changes"
   declare CURRENT_VERSION="$1" NEXT_VERSION="$2"
   local PULL_REQUEST_ID TITLE AUTHOR TYPE CHANGELOG_TEXT
-  local COMMIT_MESSAGE HISTORY HISTORY_CONTENTS HISTORY_DOCUMENTATION HISTORY_ENHANCEMENT HISTORY_BUG ISSUE_FILE
+  local COMMIT_MESSAGE HISTORY HISTORY_CONTENTS HISTORY_DOCUMENTATION HISTORY_ENHANCEMENT HISTORY_BUG HISTORY_OTHER ISSUE_FILE
 
   pushd "$ROOT_DIR" >/dev/null
 
@@ -258,8 +258,10 @@ fn-repo-update-history-and-commit() {
       HISTORY_BUG="${HISTORY_BUG}"$'\n'"$CHANGELOG_TEXT"
     elif [[ "$TYPE" == "documentation" ]]; then
       HISTORY_DOCUMENTATION="${HISTORY_DOCUMENTATION}"$'\n'"$CHANGELOG_TEXT"
-    elif [[ "$TYPE" == "enhancement" ]]; then
+    elif [[ "$TYPE" == "enhancement" ]] || [[ "$TYPE" == "refactor" ]]; then
       HISTORY_ENHANCEMENT="${HISTORY_ENHANCEMENT}"$'\n'"$CHANGELOG_TEXT"
+    else
+      HISTORY_OTHER="${HISTORY_OTHER}"$'\n'"$CHANGELOG_TEXT"
     fi
   done
 
@@ -279,6 +281,11 @@ fn-repo-update-history-and-commit() {
   if [[ "$HISTORY_DOCUMENTATION" ]]; then
     HISTORY="${HISTORY}"$'\n\n'"### Documentation"
     HISTORY="${HISTORY}"$'\n'"$HISTORY_DOCUMENTATION"
+  fi
+
+  if [[ "$HISTORY_OTHER" ]]; then
+    HISTORY="${HISTORY}"$'\n\n'"### Other"
+    HISTORY="${HISTORY}"$'\n'"$HISTORY_OTHER"
   fi
 
   sed -i.bak '1d' HISTORY.md && rm HISTORY.md.bak


### PR DESCRIPTION
In some cases, we might miss pull requests where there is more than one 'type' label, causing that pull request to be omitted from the history. This change ensures we always include pull requests in the change log.