### PR TITLE
Remove ls from command's help

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
-[[ " help help:help ls:help run:help trace:help url:help urls:help version:help " == *" $1 "* ]] || exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
+[[ " help help:help run:help trace:help url:help urls:help version:help " == *" $1 "* ]] || exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 case "$1" in
-  help|ls:help|run:help|trace:help|url:help|urls:help|version:help)
+  help|run:help|trace:help|url:help|urls:help|version:help)
     [[ $(echo "$1" | sed '/.*:help/!d') ]] && help_topic="${1%\:help}"
     help_content_func () {
       declare desc="return standard plugin help content"
       cat<<help_content
-    ls , Pretty listing of deployed applications and containers
     run <app> <cmd>, Run a command in a new container using the current application image
     trace [on/off], Enable dokku tracing
     url <app>, Show the first URL for an application (compatibility)


### PR DESCRIPTION
After da1ea2d the command `ls` is not available but `dokku help` still shows it as a valid command.

```bash
vagrant@dokku:~$ dokku version
0.12.2
vagrant@dokku:~$ dokku ls
 !     `ls` is not a dokku command.
 !     See `dokku help` for a list of available commands.
vagrant@dokku:~$ dokku help | grep ls
    ls               Pretty listing of deployed applications and containers
vagrant@dokku:~$
```