### PR TITLE
Allow users to override the reported app url

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -29,6 +29,30 @@ The following plugin triggers describe those available to a Dokku installation. 
 
 > The example plugin trigger code is not guaranteed to be implemented as in within dokku, and are merely simplified examples. Please look at the Dokku source for larger, more in-depth examples.
 
+### `app-urls`
+
+- Description: Allows you to change the urls Dokku reports for an application. Will override any auto-detected urls.
+- Invoked by: `dokku deploy`, `dokku url`, and `dokku urls`
+- Arguments: `$APP $URL_TYPE`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+# Sets the domain to `internal.tld`
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+APP="$1"; URL_TYPE="$2"
+case "$URL_TYPE" in
+  url)
+    echo "https://internal.tld/${APP}/"
+    ;;
+  urls)
+    echo "https://internal.tld/${APP}/"
+    echo "http://internal.tld/${APP}/"
+    ;;
+esac
+```
+
 ### `check-deploy`
 
 - Description: Allows you to run checks on a deploy before Dokku allows the container to handle requests.

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -765,12 +765,26 @@ get_container_ports() {
 
 get_app_urls() {
   declare desc="print an app's available urls"
+  declare URL_TYPE="$1" APP="$2"
+  local urls
+
+  verify_app_name "$APP"
+  urls=$(plugn trigger app-urls "$APP" "$URL_TYPE")
+  if [[ -n "$urls" ]]; then
+    echo "$urls" | sort
+  else
+    internal_get_app_urls "$URL_TYPE" "$APP"
+  fi
+}
+
+internal_get_app_urls() {
+  declare desc="print an app's available urls"
   source "$PLUGIN_AVAILABLE_PATH/certs/functions"
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
   source "$PLUGIN_AVAILABLE_PATH/domains/functions"
   source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 
-  local APP="$2"; verify_app_name "$APP"
+  local APP="$2"
   local RAW_TCP_PORTS="$(get_app_raw_tcp_ports "$APP")"
   local URLS_FILE="$DOKKU_ROOT/$APP/URLS"
   local DOKKU_PROXY_PORT_MAP=$(config_get "$APP" DOKKU_PROXY_PORT_MAP || true)


### PR DESCRIPTION
This is useful in cases where the app url has some "interesting" structure - such as a subdomain or scheme change - for a specific installation.

Closes #3160
