### PR TITLE
feat: Add the ability to ignore existing applications during a git clone

### DIFF
--- a/docs/deployment/application-management.md
+++ b/docs/deployment/application-management.md
@@ -158,6 +158,12 @@ By default, Dokku will deploy this new application, though you can skip the depl
 dokku apps:clone --skip-deploy node-js-app io-js-app
 ```
 
+Finally, if the application already exists, you may wish to ignore errors resulting from attempting to clone over it. To do so, you can use the `--ignore-existing` flag. A warning will be emitted, but the command will return 0.
+
+```shell
+dokku apps:clone --ignore-existing node-js-app io-js-app
+```
+
 ### Locking app deploys
 
 > New as of 0.11.6

--- a/plugins/apps/subcommands/clone
+++ b/plugins/apps/subcommands/clone
@@ -6,18 +6,32 @@ source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 
 apps_clone_cmd() {
   declare desc="clones an app"
-  declare OLD_APP="$2" NEW_APP="$3"
-  local cmd="apps:clone"
+  declare cmd="apps:clone" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
+  declare OLD_APP="$1" NEW_APP="$2"
+  local IGNORE_EXISTING=false
   local SKIP_REBUILD=false
 
-  if [[ "$2" == "--skip-deploy" ]]; then
-    SKIP_REBUILD=true
-    OLD_APP="$3"
-    NEW_APP="$4"
+  for arg in "$@"; do
+    [[ "$arg" == "--skip-deploy" ]] && shift 1 && SKIP_REBUILD=true
+    [[ "$arg" == "--ignore-existing" ]] && shift 1 && IGNORE_EXISTING=true
+    [[ "$arg" =~ ^--.* ]] || break
+  done
+
+  OLD_APP="$1" NEW_APP="$2"
+  [[ -z "$OLD_APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+
+  is_valid_app_name "$OLD_APP"
+  is_valid_app_name "$NEW_APP"
+  apps_exists "$OLD_APP" > /dev/null 2>&1 || dokku_log_fail "App does not exist"
+  if apps_exists "$NEW_APP" > /dev/null 2>&1; then
+    if [[ "$IGNORE_EXISTING" == true ]]; then
+      dokku_log_warn "Name is already taken"
+      return
+    fi
+
+    dokku_log_fail "Name is already taken"
   fi
 
-  [[ -z "$OLD_APP" ]] && dokku_log_fail "Please specify an app to run the command on"
-  [[ -d "$DOKKU_ROOT/$NEW_APP" ]] && dokku_log_fail "Name is already taken"
   local NEW_CACHE_DIR="$DOKKU_ROOT/$NEW_APP/cache"
   local NEW_CACHE_HOST_DIR="$DOKKU_HOST_ROOT/$NEW_APP/cache"
 

--- a/tests/unit/10_apps.bats
+++ b/tests/unit/10_apps.bats
@@ -131,7 +131,10 @@ teardown () {
   echo "output: "$output
   echo "status: "$status
   assert_success
+}
 
+@test "(apps) apps:clone --skip-deploy" {
+  deploy_app
   run bash -c "dokku apps:clone --skip-deploy $TEST_APP great-test-name"
   echo "output: "$output
   echo "status: "$status
@@ -140,6 +143,22 @@ teardown () {
   echo "output: "$output
   echo "status: "$status
   assert_failure
+  run bash -c "dokku --force apps:destroy great-test-name"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+}
+
+@test "(apps) apps:clone --ignore-existing" {
+  deploy_app
+  run bash -c "dokku apps:create great-test-name"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  run bash -c "dokku apps:clone --ignore-existing $TEST_APP great-test-name"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
   run bash -c "dokku --force apps:destroy great-test-name"
   echo "output: "$output
   echo "status: "$status


### PR DESCRIPTION
This makes it possible to create cloned apps if and only if they haven't already been created - a useful feature for review apps.
