### PR TITLE
ensure dokku-redeploy runs when docker is stopped then started

### DIFF
--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -39,10 +39,10 @@ User=dokku
 ExecStart=$dokku_path ps:restore
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=docker.service
 EOF
   if command -v systemctl &>/dev/null; then
-    systemctl enable dokku-redeploy
+    systemctl reenable dokku-redeploy
   fi
 fi
 


### PR DESCRIPTION
When the Docker engine is upgraded, there's a distinct stop and start event. However, the _dokku-redeploy.service_ does not run in this scenario, causing the Nginx container config to become stale. By changing the WantedBy declaration to docker.service, a Docker stop/stop will trigger _dokku ps:restore_.

I also replaced _enable_ with _renable_ for the systemctl service initialization so that an upgrade to Dokku will recreate the service symlink. If the service has not been previously enabled, systemd is smart enough to simply enable it. 