### PR TITLE
chore: unskip initial herokuish test

### DIFF
--- a/tests/unit/10_ps-herokuish.bats
+++ b/tests/unit/10_ps-herokuish.bats
@@ -14,10 +14,6 @@ teardown() {
 }
 
 @test "(ps) herokuish" {
-  # CI support: 'Ah. I just spoke with our Docker expert --
-  # looks like docker exec is built to work with docker-under-libcontainer,
-  # but we're using docker-under-lxc. I don't have an estimated time for the fix, sorry
-  skip "circleci does not support docker exec at the moment."
   run bash -c "dokku ps $TEST_APP | grep -q \"node web.js\""
   echo "output: "$output
   echo "status: "$status


### PR DESCRIPTION
This was previously skipped on circleci 1.0 but 2.0 apparently has full `docker exec` support.
