### PR TITLE
feat: allow lower versions of docker-engine

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.12.5
 Section: web
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, gcc, man-db, netcat, sshcommand (>= 0.6.0), gliderlabs-sigil, docker-engine-cs (>= 1.9.1) | docker-engine (>= 1.9.1) | docker-io (>= 1.9.1)  | docker-ce | docker-ee, software-properties-common, python-software-properties | python3-software-properties, rsyslog
+Depends: locales, git, make, curl, gcc, man-db, netcat, sshcommand (>= 0.6.0), gliderlabs-sigil, docker-engine-cs (>= 1.7.1) | docker-engine (>= 1.7.1) | docker-io (>= 1.7.1)  | docker-ce | docker-ee, software-properties-common, python-software-properties | python3-software-properties, rsyslog
 Recommends: herokuish (>= 0.3.4), parallel, dokku-update
 Pre-Depends: nginx (>= 1.8.0) | openresty, dnsutils, cgroupfs-mount | cgroup-lite, plugn (>= 0.3.0), sudo, python2.7, debconf
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>


### PR DESCRIPTION
Some slightly older RHEL systems actually use ancient docker, and this allows them to use the latest "official" release. Any broken functionality is up to our users to figure out, and while this enables them to run Dokku, it is not "supported" in a sense.