### PR TITLE
Fix error text when using "dokku plugin:uninstall"

### DIFF
--- a/plugins/plugin/subcommands/uninstall
+++ b/plugins/plugin/subcommands/uninstall
@@ -7,7 +7,7 @@ source "$PLUGIN_AVAILABLE_PATH/plugin/internal-functions"
 plugin_uninstall_cmd() {
   declare desc="uninstalls plugin via command line"
   local cmd="plugin:uninstall"
-  [[ -z $2 ]] && dokku_log_fail "Please specify a plugin to enable"
+  [[ -z $2 ]] && dokku_log_fail "Please specify a plugin to uninstall"
   local PLUGIN="$2"
   uninstall_plugin "$PLUGIN"
   plugin_prime_bash_completion


### PR DESCRIPTION
Fix an incorrect error message when failing to specify an app when using dokku plugin:uninstall

Previously said "Please specify a plugin to enable" and now says, "Please specify a plugin to uninstall"