### PR TITLE
feat: allow disabling chown for persistent storage in scheduler-docker-local

### DIFF
--- a/docs/advanced-usage/persistent-storage.md
+++ b/docs/advanced-usage/persistent-storage.md
@@ -39,7 +39,7 @@ dokku storage:mount node-js-app /var/lib/dokku/data/storage/node-js-app:/storage
 
 Dokku will then mount the shared contents of `/var/lib/dokku/data/storage` to `/storage` inside the container.
 
-Once you have mounted persistent storage, you will also need to restart the application. See the 
+Once you have mounted persistent storage, you will also need to restart the application. See the
 [process scaling documentation](/docs/deployment/process-management.md) for more information.
 
 ```shell
@@ -132,7 +132,7 @@ Your app may have services that are running in memory and need to be backed up l
 By default, Dokku will only bind storage mounts during the deploy and run phases. Under certain conditions, one might want to bind a storage mount during the build phase. This can be accomplished by using the `docker-options` plugin directly.
 
 ```shell
-dokku docker-options:add <app> build "-v /tmp/python-test:/opt/test"
+dokku docker-options:add node-js-app build "-v /tmp/python-test:/opt/test"
 ```
 
 You cannot use mounted volumes during the build phase of a Dockerfile deploy. This is because Docker does not support volumes when executing `docker build`.
@@ -147,4 +147,4 @@ By default, Dokku will execute your buildpack application processes as the `hero
 
 > NOTE: this user must exist in your herokuish image.
 
-Additionally, Dokku will ensure your storage mounts are owned by either `herokuishuser` or the overridden value you have set in `DOKKU_APP_USER`.
+Additionally, the default `docker-local` scheduler that comes with Dokku will ensure your storage mounts are owned by either `herokuishuser` or the overridden value you have set in `DOKKU_APP_USER`. See the [scheduler-docker-local documentation](/docs/advanced-usage/schedulers/docker-local.md#disabling-chown-of-persistent-storage) docs for more information.

--- a/docs/advanced-usage/schedulers/docker-local.md
+++ b/docs/advanced-usage/schedulers/docker-local.md
@@ -1,5 +1,12 @@
 # Docker Local Scheduler
 
+> Subcommands new as of 0.12.12
+
+```
+scheduler-docker-local:report [<app>] [<flag>]              # Displays a scheduler-docker-local report for one or more apps
+scheduler-docker-local:set <app> <key> (<value>)            # Set or clear a scheduler-docker-local property for an app
+```
+
 > New as of 0.12.0
 
 Dokku natively includes functionality to manage application lifecycles for a single server using the `scheduler-docker-local` plugin. It is the default scheduler, but as with all schedulers, it is set on a per-application basis. The scheduler can currently be overridden by running the following command:
@@ -12,6 +19,22 @@ As it is the default, unsetting the `DOCKER_SCHEDULER` config variable is also a
 
 ```shell
 dokku config:unset node-js-app DOCKER_SCHEDULER
+```
+
+## Usage
+
+### Disabling chown of persistent storage
+
+The `scheduler-docker-local` plugin will ensure your storage mounts are owned by either `herokuishuser` or the overridden value you have set in `DOKKU_APP_USER`. You may disable this by running the following `scheduler-docker-local:set` command for your application:
+
+```shell
+dokku scheduler-docker-local:set node-js-app DISABLE_CHOWN true
+```
+
+Once set, you may re-enable it by setting a blank value for `DISABLE_CHOWN`:
+
+```shell
+dokku scheduler-docker-local:set node-js-app DISABLE_CHOWN
 ```
 
 ## Implemented Triggers

--- a/plugins/scheduler-docker-local/commands
+++ b/plugins/scheduler-docker-local/commands
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/scheduler-docker-local/internal-functions"
+
+case "$1" in
+  help | scheduler-docker-local:help)
+    cmd-scheduler-docker-local-help "$@"
+    ;;
+
+  *)
+    exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
+    ;;
+
+esac

--- a/plugins/scheduler-docker-local/install
+++ b/plugins/scheduler-docker-local/install
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 
 scheduler-docker-local-install() {
   declare desc="scheduler-docker-local install plugin trigger"
@@ -7,6 +8,8 @@ scheduler-docker-local-install() {
 
   mkdir -p "${DOKKU_LIB_ROOT}/data/scheduler-docker-local"
   chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/scheduler-docker-local"
+
+  fn-plugin-property-setup "scheduler-docker-local"
 }
 
 scheduler-docker-local-install "$@"

--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+cmd-scheduler-docker-local-report() {
+  declare desc="displays a scheduler-docker-local report for one or more apps"
+  local cmd="scheduler-docker-local:report"
+  local INSTALLED_APPS=$(dokku_apps)
+  local APP="$2" INFO_FLAG="$3"
+
+  if [[ -n "$APP" ]] && [[ "$APP" == --* ]]; then
+    INFO_FLAG="$APP"
+    APP=""
+  fi
+
+  if [[ -z "$APP" ]] && [[ -z "$INFO_FLAG" ]]; then
+    INFO_FLAG="true"
+  fi
+
+  if [[ -z "$APP" ]]; then
+    for app in $INSTALLED_APPS; do
+      cmd-scheduler-docker-local-report-single "$app" "$INFO_FLAG" | tee || true
+    done
+  else
+    cmd-scheduler-docker-local-report-single "$APP" "$INFO_FLAG"
+  fi
+}
+
+cmd-scheduler-docker-local-report-single() {
+  declare APP="$1" INFO_FLAG="$2"
+  if [[ "$INFO_FLAG" == "true" ]]; then
+    INFO_FLAG=""
+  fi
+  verify_app_name "$APP"
+  local flag_map=(
+    "--scheduler-docker-local-disable-chown: $(fn-plugin-property-get "scheduler-docker-local" "$APP" "disable-chown" "")"
+  )
+
+  if [[ -z "$INFO_FLAG" ]]; then
+    dokku_log_info2_quiet "${APP} scheduler-docker-local information"
+    for flag in "${flag_map[@]}"; do
+      key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
+      dokku_log_verbose "$(printf "%-30s %-25s" "${key^}" "${flag#*: }")"
+    done
+  else
+    local match=false; local value_exists=false
+    for flag in "${flag_map[@]}"; do
+      valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
+      if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
+        value=${flag#*: }
+        size="${#value}"
+        if [[ "$size" -ne 0 ]]; then
+          echo "$value" && match=true && value_exists=true
+        else
+          match=true
+        fi
+      fi
+    done
+    [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
+    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
+  fi
+}
+
+scheduler_docker_local_help_content_func() {
+  declare desc="return scheduler-docker-local plugin help content"
+  cat<<help_content
+    scheduler-docker-local:report [<app>] [<flag>], Displays a scheduler-docker-local report for one or more apps
+    scheduler-docker-local:set <app> <property> (<value>), Set or clear a scheduler-docker-local property for an app
+help_content
+}
+
+cmd-scheduler-docker-local-help() {
+  if [[ $1 = "scheduler-docker-local:help" ]] ; then
+    echo -e 'Usage: dokku scheduler-docker-local[:COMMAND]'
+    echo ''
+    echo 'Manages the scheduler-docker-local integration for an app.'
+    echo ''
+    echo 'Additional commands:'
+    scheduler_docker_local_help_content_func | sort | column -c2 -t -s,
+    echo ''
+  elif [[ $(ps -o command= $PPID) == *"--all"* ]]; then
+    scheduler_docker_local_help_content_func
+  else
+    cat<<help_desc
+    scheduler-docker-local, Manages the scheduler-docker-local integration for an app
+help_desc
+  fi
+}

--- a/plugins/scheduler-docker-local/pre-deploy
+++ b/plugins/scheduler-docker-local/pre-deploy
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 scheduler-docker-local-pre-deploy() {
   declare desc="scheduler-docker-local pre-deploy plugin trigger"
   declare trigger="scheduler-docker-local pre-deploy"
   declare APP="$1" IMAGE_TAG="$2"
-  local IMAGE DOCKER_ARGS DOKKU_APP_TYPE DOKKU_APP_USER APP_PATHS CONTAINER_PATHS
+  local IMAGE DISABLE_CHOWN DOCKER_ARGS DOKKU_APP_TYPE DOKKU_APP_USER APP_PATHS CONTAINER_PATHS
   declare -a ARG_ARRAY
 
   local DOKKU_SCHEDULER=$(config_get "$APP" DOKKU_SCHEDULER || echo "docker-local")
@@ -30,10 +31,17 @@ scheduler-docker-local-pre-deploy() {
     eval "ARG_ARRAY=($DOCKER_ARGS)"
   fi
 
-  if [[ "$DOKKU_APP_TYPE" == "herokuish" ]] && [[ -n "$CONTAINER_PATHS" ]]; then
-    # shellcheck disable=SC2086
-    docker run $DOKKU_GLOBAL_RUN_ARGS "${ARG_ARRAY[@]}" $IMAGE /bin/bash -c "find $CONTAINER_PATHS -not -user $DOKKU_APP_USER -print0 | xargs -0 -r chown -R $DOKKU_APP_USER" || true
+  if [[ "$DOKKU_APP_TYPE" != "herokuish" ]] || [[ -z "$CONTAINER_PATHS" ]]; then
+    return
   fi
+
+  DISABLE_CHOWN="$(fn-plugin-property-get "scheduler-docker-local" "$APP" "disable-chown" "")"
+  if [[ "$DISABLE_CHOWN" == "true" ]]; then
+    return
+  fi
+
+  # shellcheck disable=SC2086
+  docker run $DOKKU_GLOBAL_RUN_ARGS "${ARG_ARRAY[@]}" $IMAGE /bin/bash -c "find $CONTAINER_PATHS -not -user $DOKKU_APP_USER -print0 | xargs -0 -r chown -R $DOKKU_APP_USER" || true
 }
 
 scheduler-docker-local-pre-deploy "$@"

--- a/plugins/scheduler-docker-local/report
+++ b/plugins/scheduler-docker-local/report
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/scheduler-docker-local/internal-functions"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+cmd-scheduler-docker-local-report-single "$@"

--- a/plugins/scheduler-docker-local/subcommands/default
+++ b/plugins/scheduler-docker-local/subcommands/default
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/scheduler-docker-local/internal-functions"
+
+cmd-scheduler-docker-local-help "scheduler-docker-local:help"

--- a/plugins/scheduler-docker-local/subcommands/report
+++ b/plugins/scheduler-docker-local/subcommands/report
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/scheduler-docker-local/internal-functions"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+cmd-scheduler-docker-local-report "$@"

--- a/plugins/scheduler-docker-local/subcommands/set
+++ b/plugins/scheduler-docker-local/subcommands/set
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+fn-in-array() {
+  declare desc="return true if value ($1) is in list (all other arguments)"
+
+  local e
+  for e in "${@:2}"; do
+    [[ "$e" == "$1" ]] && return 0
+  done
+  return 1
+}
+
+scheduler-docker-local-set-cmd() {
+  declare desc="set or clear a scheduler-docker-local property for an app"
+  local cmd="scheduler-docker-local:set" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
+  declare APP="$1" KEY="$2" VALUE="$3"
+  local VALID_KEYS=("disable-chown")
+  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+  [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
+
+  if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then
+    dokku_log_fail "Invalid key specified, valid keys include: disable-chown"
+  fi
+
+  if [[ -n "$VALUE" ]]; then
+    dokku_log_info2_quiet "Setting ${KEY} to ${VALUE}"
+    fn-plugin-property-write "scheduler-docker-local" "$APP" "$KEY" "$VALUE"
+  else
+    dokku_log_info2_quiet "Unsetting ${KEY}"
+    fn-plugin-property-delete "scheduler-docker-local" "$APP" "$KEY"
+  fi
+}
+
+scheduler-docker-local-set-cmd "$@"


### PR DESCRIPTION
Some systems - such as a mounted read-only CIFS filesystem - do not fully support chown, and chowning should be considered optional for cases when the host os has already taken care of permissioning. This commit allows users to disable chown by setting a property on the scheduler-docker-local plugin.
