### PR TITLE
feat: check if script is executable when a full path is specified

### DIFF
--- a/plugins/00_dokku-standard/exec-app-json-scripts
+++ b/plugins/00_dokku-standard/exec-app-json-scripts
@@ -44,6 +44,15 @@ execute_script() {
     COMMAND+="   rm -rf /tmp/cache ; "
     COMMAND+="   ln -sf /cache /tmp/cache ; "
     COMMAND+=" fi ; "
+    
+    if [[ "$SCRIPT_CMD" == /* ]]; then
+      local SCRIPT_BIN="$(echo "$SCRIPT_CMD" | cut -d' ' -f1)"
+      COMMAND+=" if [[ ! -x $SCRIPT_BIN ]]; then "
+      COMMAND+="   echo specified binary is not executable ; "
+      COMMAND+="   exit 1 ; "
+      COMMAND+=" fi "
+    fi
+    
     COMMAND+=" $SCRIPT_CMD || exit 1;"
     COMMAND+=" if [[ -d '/cache' ]]; then "
     COMMAND+="   echo removing installation cache... ; "


### PR DESCRIPTION
This fixes issues where developers may specify a binary to run but haven't given that binary executable permissions.