### PR TITLE
Sanitize docker inspect output with ps:inspect

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -27,8 +27,9 @@
 
 ### Additional information
 
-- `docker inspect CONTAINER_ID` (if applicable):
-  (BEWARE: `docker inspect` will print environment variables for some commands, be sure you're not exposing any sensitive information when posting issues. You may replace these values with XXXXXXX):
+- Container Inspect Output (if applicable):
+  - 0.13.0+: `dokku inspect APP_NAME`
+  - <0.13.0: `docker inspect CONTAINER_ID`: WARNING, `docker inspect` will print environment variables for some commands, be sure you're not exposing any sensitive information when posting issues. You may replace these values with XXXXXXX.
 - `cat /home/dokku/<app>/nginx.conf` (if applicable):
 - Link to the exact repository being deployed (if possible/applicable):
 - If a deploy is failing or behaving unexpectedly:

--- a/docs/deployment/process-management.md
+++ b/docs/deployment/process-management.md
@@ -4,6 +4,7 @@
 
 ```
 ps <app>                                       # List processes running in app container(s)
+ps:inspect <app>                               # Displays a sanitized version of docker inspect for an app
 ps:rebuild <app>                               # Rebuild an app from source
 ps:rebuildall                                  # Rebuild all apps from source
 ps:report [<app>] [<flag>]                     # Displays a process report for one or more apps
@@ -31,6 +32,18 @@ To find out if your application's containers are running the commands you expect
 ```shell
 dokku ps node-js-app
 ```
+
+### Inspecting app containers
+
+> New as of 0.13.0
+
+A common administrative task to perform is calling `docker inspect` on the containers that are running for an application. This can be an error-prone task to perform, and may also reveal sensitive environment variables if not done correctly. Dokku provides a wrapper around this command via the `ps:inspect` subcommand:
+
+```shell
+dokku ps:inspect node-js-app
+```
+
+This command will gather all the running container IDs for your application and call `docker inspect`, sanitizing the output data so it can be copy-pasted elsewhere safely.
 
 ### Rebuilding applications
 

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1213,6 +1213,25 @@ DOKKU_SCHEDULER="$1"; APP="$2"; FORCE_CLEANUP="$3";
 # TODO
 ```
 
+### `scheduler-inspect`
+
+> Warning: The scheduler plugin trigger apis are under development and may change
+> between minor releases until the 1.0 release.
+
+- Description: Allows you to run inspect commands for all containers for a given app
+- Invoked by: `dokku ps:inspect`
+- Arguments: `$DOKKU_SCHEDULER $APP`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+DOKKU_SCHEDULER="$1"; APP="$2";
+
+# TODO
+```
+
 ### `scheduler-logs-failed`
 
 > Warning: The scheduler plugin trigger apis are under development and may change

--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -8,6 +8,7 @@ case "$1" in
       declare desc="return ps plugin help content"
       cat<<help_content
     ps <app>, List processes running in app container(s)
+    ps:inspect <app>, Displays a sanitized version of docker inspect for an app
     ps:scale <app> <proc>=<count> [<proc>=<count>...], Get/Set how many instances of a given process to run
     ps:start <app>, Start app container(s)
     ps:startall, Starts all apps via command line

--- a/plugins/ps/internal-functions
+++ b/plugins/ps/internal-functions
@@ -4,6 +4,16 @@ source "$PLUGIN_AVAILABLE_PATH/docker-options/functions"
 source "$PLUGIN_AVAILABLE_PATH/ps/functions"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
+cmd-ps-inspect() {
+  declare desc="displays a sanitized version of docker inspect for an app"
+  local cmd="ps:inspect"
+  local APP="$2"
+
+  verify_app_name "$APP"
+  local DOKKU_SCHEDULER=$(get_app_scheduler "$APP")
+  plugn trigger scheduler-inspect "$DOKKU_SCHEDULER" "$APP"
+}
+
 cmd-ps-report() {
   declare desc="displays a ps report for one or more apps"
   local cmd="ps:report"

--- a/plugins/ps/subcommands/inspect
+++ b/plugins/ps/subcommands/inspect
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/ps/internal-functions"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+cmd-ps-inspect "$@"

--- a/plugins/scheduler-docker-local/scheduler-inspect
+++ b/plugins/scheduler-docker-local/scheduler-inspect
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+
+scheduler-docker-local-scheduler-inspect() {
+  declare desc="scheduler-docker-local scheduler-inspect plugin trigger"
+  declare trigger="scheduler-docker-local scheduler-inspect"
+  declare DOKKU_SCHEDULER="$1" APP="$2"
+
+  if [[ "$DOKKU_SCHEDULER" != "docker-local" ]]; then
+    return
+  fi
+
+  local TMP_INSPECT_CMD=$(mktemp "/tmp/${FUNCNAME[0]}.XXXX")
+  trap 'rm -rf "$TMP_INSPECT_CMD" > /dev/null' RETURN INT TERM EXIT
+  cat > "$TMP_INSPECT_CMD" <<EOF
+import json
+import sys
+
+output = []
+data = json.load(sys.stdin)
+for container in data:
+    env = []
+    whitelist = ['CACHE_PATH=', 'DOCKER_', 'DOKKU_', 'DYNO=', 'PATH=', 'PORT=', 'USER=']
+    for e in container['Config']['Env']:
+        append = False
+        for w in whitelist:
+            if e.startswith(w):
+                append = True
+                break
+        if append:
+            env.append(e)
+            continue
+
+        k, v = e.split('=', 2)
+        env.append('{0}=XXXXXX'.format(k))
+
+    container['Config']['Env'] = env
+    output.append(container)
+
+print json.dumps(data, sort_keys=True, indent=4)
+EOF
+
+  local CONTAINER_FILES="$(find "$DOKKU_ROOT/$APP" -maxdepth 1 -name "CONTAINER.*" -printf "%f\n" 2>/dev/null | sort -t . -k 2 -n | xargs)"
+  local CIDS=()
+  for CONTAINER_FILE in $CONTAINER_FILES; do
+    CIDS+="$(< "$DOKKU_ROOT/$APP/$CONTAINER_FILE")"
+  done
+  docker inspect "${CIDS[@]}" | python2.7 "$TMP_INSPECT_CMD"
+
+}
+
+scheduler-docker-local-scheduler-inspect "$@"

--- a/tests/unit/10_ps-general.bats
+++ b/tests/unit/10_ps-general.bats
@@ -12,6 +12,17 @@ teardown() {
   global_teardown
 }
 
+@test "(ps) ps:inspect" {
+  deploy_app dockerfile
+
+  CID=$(< $DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
+  run bash -c "dokku ps:inspect $TEST_APP"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  assert_output_contains "$CID" 6
+}
+
 @test "(ps:scale) procfile commands extraction" {
   source "$PLUGIN_CORE_AVAILABLE_PATH/ps/functions"
   cat <<EOF > "$DOKKU_ROOT/$TEST_APP/DOKKU_PROCFILE"


### PR DESCRIPTION
Often-times, we will want to have the container inspect output for debugging purposes, but this process is:

- error prone, as the user needs to know what their containers are
- potentially insecure, as the output must be sanitized of sensitive data

Instead of making users wade through this process, we provide a helper `ps:inspect` command, that can be used to diagnose problems associated with containers that may or may not exist for an application.