### PR TITLE
[config] sort config:show by key name

### DIFF
--- a/plugins/config/environment.go
+++ b/plugins/config/environment.go
@@ -240,9 +240,17 @@ func prettyPrintEnvEntries(prefix string, entries map[string]string) string {
 	colConfig := columnize.DefaultConfig()
 	colConfig.Prefix = prefix
 	colConfig.Delim = "\x00"
-	lines := make([]string, 0, len(entries))
-	for k, v := range entries {
-		lines = append(lines, fmt.Sprintf("%s:\x00%s", k, v))
+
+	//some keys may be prefixes of each other so we need to sort them rather than the resulting lines
+	keys := make([]string, 0, len(entries))
+	for k := range entries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	lines := make([]string, 0, len(keys))
+	for _, k := range keys {
+		lines = append(lines, fmt.Sprintf("%s:\x00%s", k, entries[k]))
 	}
 	return columnize.Format(lines, colConfig)
 }

--- a/plugins/config/environment_test.go
+++ b/plugins/config/environment_test.go
@@ -56,6 +56,7 @@ func TestExport(t *testing.T) {
 	Expect(e.Export(ExportFormatDockerArgs)).To(Equal("--env=BAR='BAZ' --env=BAZ='a\nb' --env=FOO='b'\\''ar '"))
 	Expect(e.Export(ExportFormatShell)).To(Equal("BAR='BAZ' BAZ='a\nb' FOO='b'\\''ar '"))
 	Expect(e.Export(ExportFormatExports)).To(Equal("export BAR='BAZ'\nexport BAZ='a\nb'\nexport FOO='b'\\''ar '"))
+	Expect(e.Export(ExportFormatPretty)).To(Equal("BAR:  BAZ\nBAZ:  a\nb\nFOO:  b'ar"))
 }
 
 func TestGet(t *testing.T) {

--- a/tests/unit/20_config.bats
+++ b/tests/unit/20_config.bats
@@ -145,3 +145,16 @@ teardown() {
   echo "status: "$status
   assert_success
 }
+
+@test "(config) config:show" {
+  run bash -c "dokku --app $TEST_APP config:set zKey=true bKey=true BKEY=true aKey=true"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run bash -c "dokku --app $TEST_APP config:show"
+  echo "output: "$output
+  echo "status: "$stat
+
+  assert_output "=====> $TEST_APP env vars"$'\nBKEY:  true\naKey:  true\nbKey:  true\nzKey:  true'
+}


### PR DESCRIPTION
resolves: #3293

Output of config:show now is sorted by key name to match the old config plugin (and common sense).

I checked and the rest of the things we do with outputting/saving are sorted as expected.