### PR TITLE
feat: Add support for docker.io package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.12.13
 Section: web
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, gcc, man-db, netcat, sshcommand (>= 0.6.0), gliderlabs-sigil, docker-engine-cs (>= 1.7.1) | docker-engine (>= 1.7.1) | docker-io (>= 1.7.1)  | docker-ce | docker-ee, net-tools, software-properties-common, procfile-util, python-software-properties | python3-software-properties, rsyslog
+Depends: locales, git, make, curl, gcc, man-db, netcat, sshcommand (>= 0.6.0), gliderlabs-sigil, docker-engine-cs (>= 1.7.1) | docker-engine (>= 1.7.1) | docker-io (>= 1.7.1)  | docker.io (>= 1.7.1) | docker-ce | docker-ee, net-tools, software-properties-common, procfile-util, python-software-properties | python3-software-properties, rsyslog
 Recommends: herokuish (>= 0.3.4), parallel, dokku-update
 Pre-Depends: nginx (>= 1.8.0) | openresty, dnsutils, cgroupfs-mount | cgroup-lite, plugn (>= 0.3.0), sudo, python2.7, debconf
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>


### PR DESCRIPTION
This is new in Ubuntu Bionic, and should allow users to install without using upstream docker.

Note that we recommend installing from upstream where possible.

Closes #3297
