### PR TITLE
fix: keep track of failed containers regardless of docker kill output

### DIFF
--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -99,9 +99,9 @@ scheduler-docker-local-scheduler-deploy() {
       kill_new() {
         declare desc="wrapper function to kill newly started app container"
         declare CID="$1" PROC_TYPE="$2" CONTAINER_INDEX="$3"
-        docker inspect "$CID" &> /dev/null && docker stop "$CID" > /dev/null && docker kill "$CID" &> /dev/null
         mkdir -p "${DOKKU_LIB_ROOT}/data/scheduler-docker-local/$APP"
         echo "${CID} ${PROC_TYPE}.${CONTAINER_INDEX}" >> "${DOKKU_LIB_ROOT}/data/scheduler-docker-local/$APP/failed-containers"
+        docker inspect "$CID" &> /dev/null && docker stop "$CID" > /dev/null && docker kill "$CID" &> /dev/null
         trap - INT TERM EXIT
         kill -9 $$
       }


### PR DESCRIPTION
`docker kill` sometimes exits non-zero, meaning we don't keep track of logs for failed containers.