### PR TITLE
feat: upgrade herokuish to 0.4.5 version

### DIFF
--- a/deb.mk
+++ b/deb.mk
@@ -1,6 +1,6 @@
 HEROKUISH_DESCRIPTION = 'Herokuish uses Docker and Buildpacks to build applications like Heroku'
 HEROKUISH_REPO_NAME ?= gliderlabs/herokuish
-HEROKUISH_VERSION ?= 0.4.4
+HEROKUISH_VERSION ?= 0.4.5
 HEROKUISH_ARCHITECTURE = amd64
 HEROKUISH_PACKAGE_NAME = herokuish_$(HEROKUISH_VERSION)_$(HEROKUISH_ARCHITECTURE).deb
 


### PR DESCRIPTION
The new version was released https://github.com/gliderlabs/herokuish/releases/tag/v0.4.5

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
