### PR TITLE
Ensure chowned properties always have a user and group set

### DIFF
--- a/plugins/common/properties.go
+++ b/plugins/common/properties.go
@@ -144,6 +144,13 @@ func setPermissions(path string, fileMode os.FileMode) (err error) {
 
 	systemGroup := os.Getenv("DOKKU_SYSTEM_GROUP")
 	systemUser := os.Getenv("DOKKU_SYSTEM_USER")
+	if systemGroup == "" {
+		systemGroup = "dokku"
+	}
+	if systemUser == "" {
+		systemUser = "dokku"
+	}
+
 	group, err := user.LookupGroup(systemGroup)
 	if err != nil {
 		return

--- a/plugins/common/property-functions
+++ b/plugins/common/property-functions
@@ -67,7 +67,10 @@ fn-plugin-property-setup() {
 
   mkdir -p "${DOKKU_LIB_ROOT}/config/${PLUGIN}"
   chmod 0755 "${DOKKU_LIB_ROOT}/config/${PLUGIN}"
-  chown "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/config/${PLUGIN}"
+
+  local dokku_system_group=${DOKKU_SYSTEM_GROUP:="dokku"}
+  local dokku_system_user=${DOKKU_SYSTEM_USER:="dokku"}
+  chown "${dokku_system_user}:${dokku_system_group}" "${DOKKU_LIB_ROOT}/config/${PLUGIN}"
 }
 
 fn-plugin-property-read() {


### PR DESCRIPTION
Depending on the execution path, the variables may not be set at the top-level.

Closes #3328

