### PR TITLE
Use correct container id variable for killing containers

### DIFF
--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -103,8 +103,8 @@ fn-scheduler-docker-local-retire-container() {
   # to not send SIGKILL as the docs would indicate. If that fails, move
   # on to the next.
   # shellcheck disable=SC2086
-  docker stop $DOCKER_STOP_TIME_ARG "$oldid" \
-  || docker kill "$oldid" \
+  docker stop $DOCKER_STOP_TIME_ARG "$CID" \
+  || docker kill "$CID" \
   || dokku_log_warn "Unable to kill container ${CID}"
 
   if ! docker kill "$CID"; then


### PR DESCRIPTION
This will allow systems to properly monitor whether retiring old containers works.