### PR TITLE
Redirect ps:retire output to a log file

### DIFF
--- a/plugins/scheduler-docker-local/install
+++ b/plugins/scheduler-docker-local/install
@@ -46,7 +46,7 @@ else
 PATH=/usr/local/bin:/usr/bin:/bin
 SHELL=/bin/bash
 
-*/5 * * * * $DOKKU_SYSTEM_USER $DOKKU_PATH ps:retire
+*/5 * * * * $DOKKU_SYSTEM_USER $DOKKU_PATH ps:retire >> /var/log/dokku/retire.log 2>&1
 EOF
 fi
 }


### PR DESCRIPTION
This will allow systems to properly monitor whether retiring old containers works.

Note that the file will be logrotated by the `20_events` logrotate config.