### PR TITLE
Select only default dokku network IP

### DIFF
--- a/plugins/network/network.go
+++ b/plugins/network/network.go
@@ -95,7 +95,7 @@ func GetContainerIpaddress(appName, procType, containerID string) (ipAddr string
 		return
 	}
 
-	b, err := common.DockerInspect(containerID, "'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'")
+	b, err := common.DockerInspect(containerID, "'{{.NetworkSettings.Networks.bridge.IPAddress}}'")
 	if err != nil || len(b) == 0 {
 		// docker < 1.9 compatibility
 		b, err = common.DockerInspect(containerID, "'{{ .NetworkSettings.IPAddress }}'")

--- a/tests/unit/20_nginx-vhosts_1.bats
+++ b/tests/unit/20_nginx-vhosts_1.bats
@@ -10,6 +10,7 @@ setup() {
 }
 
 teardown() {
+  detach_delete_network
   destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   [[ -f "$DOKKU_ROOT/HOSTNAME.bak" ]] && mv "$DOKKU_ROOT/HOSTNAME.bak" "$DOKKU_ROOT/HOSTNAME" && chown dokku:dokku "$DOKKU_ROOT/HOSTNAME"
@@ -129,4 +130,14 @@ teardown() {
   assert_http_success http://www.test.app.dokku.me:3000
   assert_http_success http://www.test.app.dokku.me:3003
 
+}
+
+@test "(nginx-vhosts) nginx:build-config (multiple networks)" {
+  deploy_app
+
+  create_attach_network
+  run dokku nginx:build-config "$TEST_APP"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
 }


### PR DESCRIPTION
When a container is connected to multiple networks (i.e. the default dokku `bridge` and a custom one) the `GetContainerIpaddress` from the network plugin returns a concatenation of those IPs :
i.e. `172.10.34.6172.10.34.4` instead of just `172.10.34.6`
I fixed the `GetContainerIpaddress` function to only return the default dokku network (named `bridge`) IP, however I have no idea how it might affect the rest of the codebase.

It might fix #3336 