### PR TITLE
Normalize tests

### DIFF
--- a/tests/unit/10_apps.bats
+++ b/tests/unit/10_apps.bats
@@ -12,42 +12,42 @@ teardown () {
 
 @test "(apps) apps:create" {
   run /bin/bash -c "dokku apps:create $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku apps:list | grep $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output $TEST_APP
   destroy_app
 
   run /bin/bash -c "dokku apps:create 1994testapp"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku apps:create testapp:latest"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku apps:create testApp:latest"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku apps:create TestApp"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku --app $TEST_APP apps:create"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku apps:list | grep $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output $TEST_APP
 
   destroy_app
@@ -55,13 +55,13 @@ teardown () {
 
 @test "(apps) app autocreate disabled" {
   run /bin/bash -c "dokku config:set --no-restart --global DOKKU_DISABLE_APP_AUTOCREATION='true'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run deploy_app
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
   run /bin/bash -c "dokku config:unset --no-restart --global DOKKU_DISABLE_APP_AUTOCREATION"
 }
@@ -69,47 +69,47 @@ teardown () {
 @test "(apps) apps:destroy" {
   create_app
   run /bin/bash -c "dokku --force apps:destroy $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   create_app
   run /bin/bash -c "dokku --force --app $TEST_APP apps:destroy"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(apps) apps:rename" {
   deploy_app
   run /bin/bash -c "dokku apps:rename $TEST_APP great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku apps:list | grep $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
   run /bin/bash -c "curl --silent --write-out '%{http_code}\n' `dokku url great-test-name` | grep 404"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
   run /bin/bash -c "dokku --force apps:destroy great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku apps:create $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku apps:rename $TEST_APP great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku --force apps:destroy great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
@@ -117,82 +117,82 @@ teardown () {
   setup_test_tls
   deploy_app
   run /bin/bash -c "dokku apps:rename $TEST_APP great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku --force apps:destroy great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(apps) apps:clone" {
   deploy_app
   run /bin/bash -c "dokku apps:clone $TEST_APP great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku apps:list | grep $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "curl --silent --write-out '%{http_code}\n' `dokku url great-test-name` | grep 404"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
   run /bin/bash -c "dokku --force apps:destroy great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(apps) apps:clone --skip-deploy" {
   deploy_app
   run /bin/bash -c "dokku apps:clone --skip-deploy $TEST_APP great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "curl --silent --write-out '%{http_code}\n' `dokku url great-test-name` | grep 404"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
   run /bin/bash -c "dokku --force apps:destroy great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(apps) apps:clone --ignore-existing" {
   deploy_app
   run /bin/bash -c "dokku apps:create great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku apps:clone --ignore-existing $TEST_APP great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku --force apps:destroy great-test-name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(apps) apps:exists" {
   run /bin/bash -c "dokku apps:exists $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   create_app
   run /bin/bash -c "dokku apps:exists $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --force apps:destroy $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
 }
@@ -201,38 +201,38 @@ teardown () {
   create_app
 
   run /bin/bash -c "dokku apps:report $TEST_APP --locked"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "false"
 
   run /bin/bash -c "dokku apps:locked $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku apps:lock $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku apps:report $TEST_APP --locked"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "true"
 
   run /bin/bash -c "dokku apps:locked $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku apps:unlock $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku apps:report $TEST_APP --locked"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "false"
 
   destroy_app

--- a/tests/unit/10_certs.bats
+++ b/tests/unit/10_certs.bats
@@ -29,42 +29,42 @@ teardown() {
 
 @test "(certs) certs:add" {
   run /bin/bash -c "dokku certs:add $TEST_APP $BATS_TMPDIR/tls/server.crt $BATS_TMPDIR/tls/server.key"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(certs) certs:add with multiple dots in the filename" {
   run /bin/bash -c "dokku certs:add $TEST_APP $BATS_TMPDIR/tls/domain.com.crt $BATS_TMPDIR/tls/domain.com.key"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(certs) certs:add < tar" {
   run /bin/bash -c "dokku certs:add $TEST_APP < $BATS_TEST_DIRNAME/server_ssl.tar"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(certs) certs:add < tar should ignore OSX hidden files" {
   run /bin/bash -c "dokku certs:add $TEST_APP < $BATS_TEST_DIRNAME/osx_ssl_tarred.tar"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(certs) certs:info" {
   run /bin/bash -c "dokku certs:add $TEST_APP < $BATS_TEST_DIRNAME/server_ssl.tar && dokku certs:info $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(certs) certs:remove" {
   run /bin/bash -c "dokku certs:add $TEST_APP < $BATS_TEST_DIRNAME/server_ssl.tar && dokku certs:remove $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }

--- a/tests/unit/10_checks.bats
+++ b/tests/unit/10_checks.bats
@@ -18,227 +18,227 @@ teardown() {
 
 @test "(checks) checks" {
   run /bin/bash -c "dokku checks $TEST_APP 2> /dev/null | grep $TEST_APP | xargs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "$TEST_APP none none"
 }
 
 @test "(checks) checks:disable" {
   run /bin/bash -c "dokku checks:disable $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_DISABLED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "_all_"
 }
 
 @test "(checks) checks:disable -> checks:enable" {
   run /bin/bash -c "dokku checks:disable $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_DISABLED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "_all_"
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_SKIPPED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 
   run /bin/bash -c "dokku checks:enable $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_DISABLED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_SKIPPED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 }
 
 @test "(checks) checks:disable -> checks:skip" {
   run /bin/bash -c "dokku checks:disable $TEST_APP web,worker,urgentworker,notifications"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_DISABLED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "web,worker,urgentworker,notifications"
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_SKIPPED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 
   run /bin/bash -c "dokku checks:skip $TEST_APP urgentworker,worker"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_SKIPPED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "urgentworker,worker"
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_DISABLED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "web,notifications"
 }
 
 @test "(checks) checks:skip" {
   run /bin/bash -c "dokku checks:skip $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_SKIPPED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "_all_"
 }
 
 @test "(checks) checks:skip -> checks:enable" {
   run /bin/bash -c "dokku checks:skip $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_SKIPPED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "_all_"
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_DISABLED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 
   run /bin/bash -c "dokku checks:enable $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_SKIPPED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_DISABLED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 }
 
 @test "(checks) checks:skip -> checks:disable" {
   run /bin/bash -c "dokku checks:skip $TEST_APP web,worker,urgentworker,notifications"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_SKIPPED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "web,worker,urgentworker,notifications"
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_DISABLED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 
   run /bin/bash -c "dokku checks:disable $TEST_APP urgentworker,worker"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_DISABLED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "urgentworker,worker"
 
   run /bin/bash -c "dokku config:get $TEST_APP DOKKU_CHECKS_SKIPPED"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "web,notifications"
 }
 
 @test "(checks) checks:run" {
   run /bin/bash -c "dokku ps:scale $TEST_APP worker=1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app
 
   run /bin/bash -c "dokku checks:run $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku checks:run $TEST_APP web"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku checks:run $TEST_APP web,worker"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku checks:run $TEST_APP worker.1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku checks:run $TEST_APP web2"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku checks:run $TEST_APP web.2"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }
 
 @test "(checks) checks:disable -> app start with missing containers" {
   run /bin/bash -c "dokku ps:scale $TEST_APP worker=1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app
 
   run /bin/bash -c "dokku checks:disable $TEST_APP worker"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku ps:stop $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku cleanup"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku ps:start $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }

--- a/tests/unit/10_git.bats
+++ b/tests/unit/10_git.bats
@@ -14,29 +14,29 @@ teardown() {
 
 @test "(git) deploy specific branch" {
   run /bin/bash -c "dokku git:set --global deploy-branch global-branch"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   GIT_REMOTE_BRANCH=global-branch deploy_app
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku ps:rebuild $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku git:set $TEST_APP deploy-branch app-branch"
   GIT_REMOTE_BRANCH=app-branch deploy_app
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku ps:rebuild $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku git:set --global deploy-branch"
@@ -44,77 +44,77 @@ teardown() {
 
 @test "(git) ensure GIT_REV env var is set" {
   deploy_app
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP GIT_REV"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output_exists
 }
 
 @test "(git) disable GIT_REV" {
   run /bin/bash -c "dokku git:set $TEST_APP rev-env-var"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP GIT_REV"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 }
 
 @test "(git) customize the GIT_REV environment variable" {
   run /bin/bash -c "dokku git:set $TEST_APP rev-env-var GIT_REV_ALT"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP GIT_REV_ALT"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output_exists
 }
 
 @test "(git) git:initialize" {
   run /bin/bash -c "test -d $DOKKU_ROOT/$TEST_APP/refs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku git:initialize $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "test -d $DOKKU_ROOT/$TEST_APP/refs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(git) git:initialize via deploy" {
   run /bin/bash -c "test -d $DOKKU_ROOT/$TEST_APP/refs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   deploy_app
 
   run /bin/bash -c "test -d $DOKKU_ROOT/$TEST_APP/refs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }

--- a/tests/unit/10_ps-dockerfile.bats
+++ b/tests/unit/10_ps-dockerfile.bats
@@ -18,54 +18,54 @@ teardown() {
 #   # but we're using docker-under-lxc. I don't have an estimated time for the fix, sorry
 #   skip "circleci does not support docker exec at the moment."
 #   run /bin/bash -c "dokku ps $TEST_APP | grep -q \"node web.js\""
-#   echo "output: "$output
-#   echo "status: "$status
+#   echo "output: $output"
+#   echo "status: $status"
 #   assert_success
 # }
 
 @test "(ps) dockerfile" {
   deploy_app dockerfile
   run /bin/bash -c "dokku ps:stop $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_failure
   done
 
   run /bin/bash -c "dokku ps:start $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 
   run /bin/bash -c "dokku ps:restart $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 
   run /bin/bash -c "dokku ps:rebuild $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 }
@@ -87,8 +87,8 @@ teardown() {
 
 @test "(ps:scale) dockerfile" {
   run /bin/bash -c "dokku ps:scale $TEST_APP web=2"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app dockerfile
@@ -99,13 +99,13 @@ teardown() {
   done
   CIDS_PATTERN=$(echo $CIDS | sed -e "s: :|:g")
   run /bin/bash -c "docker ps -q --no-trunc | egrep \"$CIDS_PATTERN\" | wc -l | grep 2"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku ps:scale $TEST_APP web=1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   CIDS=""
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.web.*; do
@@ -114,13 +114,13 @@ teardown() {
   done
   CIDS_PATTERN=$(echo $CIDS | sed -e "s: :|:g")
   run /bin/bash -c "docker ps -q --no-trunc | egrep \"$CIDS_PATTERN\" | wc -l | grep 1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku ps:scale $TEST_APP web=0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   CIDS=""
   shopt -s nullglob
@@ -129,62 +129,62 @@ teardown() {
     CIDS+=" "
   done
   run /bin/bash -c "[[ -z \"$CIDS\" ]]"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(ps) dockerfile with procfile" {
   deploy_app dockerfile-procfile
   run /bin/bash -c "dokku ps:stop $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_failure
   done
 
   run /bin/bash -c "dokku ps:start $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 
   run /bin/bash -c "dokku ps:restart $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 
   run /bin/bash -c "dokku ps:rebuild $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 }
 
 @test "(ps) dockerfile with bad procfile" {
   run deploy_app dockerfile-procfile-bad
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run create_app
@@ -193,15 +193,15 @@ teardown() {
 
 @test "(ps:scale) dockerfile with procfile" {
   run /bin/bash -c "dokku ps:scale $TEST_APP web=2 worker=2"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app dockerfile-procfile
   for PROC_TYPE in web worker; do
     run /bin/bash -c "docker ps --format '{{.ID}} {{.Command}}' --no-trunc"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
     goodlines=""
     for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.$PROC_TYPE.*; do
@@ -214,13 +214,13 @@ teardown() {
   done
 
   run /bin/bash -c "dokku ps:scale $TEST_APP web=1 worker=1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for PROC_TYPE in web worker; do
     run /bin/bash -c "docker ps --format '{{.ID}} {{.Command}}' --no-trunc"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
     goodlines=""
     for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.$PROC_TYPE.*; do
@@ -233,8 +233,8 @@ teardown() {
   done
 
   run /bin/bash -c "dokku ps:scale $TEST_APP web=0 worker=0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for PROC_TYPE in web worker; do
     CIDS=""
@@ -245,8 +245,8 @@ teardown() {
     done
     shopt -u nullglob
     run /bin/bash -c "[[ -z \"$CIDS\" ]]"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 }

--- a/tests/unit/10_ps-general.bats
+++ b/tests/unit/10_ps-general.bats
@@ -17,8 +17,8 @@ teardown() {
 
   CID=$(< $DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "dokku ps:inspect $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   assert_output_contains "$CID" 6
 }
@@ -30,20 +30,20 @@ web: node web.js --port \$PORT
 worker: node worker.js
 EOF
   run get_cmd_from_procfile "$TEST_APP" web 5001
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "node web.js --port 5001"
 
   run get_cmd_from_procfile "$TEST_APP" worker
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "node worker.js"
 }
 
 @test "(ps:restart-policy) default policy" {
   run /bin/bash -c "dokku --quiet ps:restart-policy $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "on-failure:10"
 }
 
@@ -51,13 +51,13 @@ EOF
 @test "(ps:restart-policy) ps:set-restart-policy, ps:restart-policy" {
   for policy in no unless-stopped always on-failure on-failure:20; do
     run /bin/bash -c "dokku ps:set-restart-policy $TEST_APP $policy"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
 
     run /bin/bash -c "dokku --quiet ps:restart-policy $TEST_APP"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_output "$policy"
   done
 }
@@ -65,20 +65,20 @@ EOF
 @test "(ps:restart-policy) deployed policy" {
   test_restart_policy="on-failure:20"
   run /bin/bash -c "dokku ps:set-restart-policy $TEST_APP $test_restart_policy"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --quiet ps:restart-policy $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "$test_restart_policy"
 
   deploy_app dockerfile
 
   CID=$(< $DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect -f '{{ .HostConfig.RestartPolicy.Name }}:{{ .HostConfig.RestartPolicy.MaximumRetryCount }}' $CID"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "$test_restart_policy"
 }

--- a/tests/unit/10_ps-herokuish.bats
+++ b/tests/unit/10_ps-herokuish.bats
@@ -15,62 +15,62 @@ teardown() {
 
 @test "(ps) herokuish" {
   run /bin/bash -c "dokku ps $TEST_APP | grep -q \"node web.js\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(ps) herokuish" {
   deploy_app
   run /bin/bash -c "dokku ps:stop $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_failure
   done
 
   run /bin/bash -c "dokku ps:start $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 
   run /bin/bash -c "dokku ps:restart $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 
   run /bin/bash -c "dokku ps:rebuild $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 }
 
 @test "(ps:scale) herokuish" {
   run /bin/bash -c "dokku ps:scale $TEST_APP web=2 worker=2"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app
@@ -82,14 +82,14 @@ teardown() {
     done
     CIDS_PATTERN=$(echo $CIDS | sed -e "s: :|:g")
     run /bin/bash -c "docker ps -q --no-trunc | egrep \"$CIDS_PATTERN\" | wc -l | grep 2"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 
   run /bin/bash -c "dokku ps:scale $TEST_APP web=1 worker=1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for PROC_TYPE in web worker; do
     CIDS=""
@@ -99,14 +99,14 @@ teardown() {
     done
     CIDS_PATTERN=$(echo $CIDS | sed -e "s: :|:g")
     run /bin/bash -c "docker ps -q --no-trunc | egrep \"$CIDS_PATTERN\" | wc -l | grep 1"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 
   run /bin/bash -c "dokku ps:scale $TEST_APP web=0 worker=0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for PROC_TYPE in web worker; do
     CIDS=""
@@ -117,8 +117,8 @@ teardown() {
     done
     shopt -u nullglob
     run /bin/bash -c "[[ -z \"$CIDS\" ]]"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 }
@@ -129,22 +129,22 @@ teardown() {
   deploy_app
 
   run /bin/bash -c "dokku ps:stop $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku apps:list"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku ps:restore"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --quiet ps:report $TEST_APP | grep -q exited"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }

--- a/tests/unit/10_repo.bats
+++ b/tests/unit/10_repo.bats
@@ -14,20 +14,20 @@ teardown() {
 
 @test "(repo) repo:gc, repo:purge-cache" {
   run /bin/bash -c "dokku repo:gc $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "find $DOKKU_ROOT/$TEST_APP/cache -type f | wc -l | grep 0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
   run /bin/bash -c "dokku repo:purge-cache $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "find $DOKKU_ROOT/$TEST_APP/cache -type f | wc -l | grep 0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }

--- a/tests/unit/10_tar.bats
+++ b/tests/unit/10_tar.bats
@@ -29,8 +29,8 @@ deploy_app_tar() {
   deploy_app_tar nodejs-express --transform 's,^,prefix/,'
 
   run /bin/bash -c "response=\"$(curl -s -S ${TEST_APP}.dokku.me)\"; echo \$response; test \"\$response\" == \"nodejs/express\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
@@ -38,7 +38,7 @@ deploy_app_tar() {
   deploy_app_tar nodejs-express
 
   run /bin/bash -c "response=\"$(curl -s -S ${TEST_APP}.dokku.me)\"; echo \$response; test \"\$response\" == \"nodejs/express\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }

--- a/tests/unit/20_build-env.bats
+++ b/tests/unit/20_build-env.bats
@@ -14,8 +14,8 @@ teardown() {
 
 @test "(build-env) special characters" {
   run /bin/bash -c "dokku config:set --no-restart $TEST_APP NEWRELIC_APP_NAME='$TEST_APP (Staging)'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app
@@ -25,49 +25,49 @@ teardown() {
 
 @test "(build-env) default curl timeouts" {
   run /bin/bash -c "dokku config:unset --global CURL_CONNECT_TIMEOUT"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:unset --global CURL_TIMEOUT"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app
   run /bin/bash -c "dokku config:get --global CURL_CONNECT_TIMEOUT | grep 90"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get --global CURL_TIMEOUT | grep 600"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(build-env) buildpack failure" {
   run /bin/bash -c "dokku config:set --no-restart $TEST_APP BUILDPACK_URL='https://github.com/dokku/fake-buildpack'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run deploy_app
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }
 
 @test "(build-env) buildpack deploy with Dockerfile" {
   run /bin/bash -c "dokku config:set --no-restart $TEST_APP BUILDPACK_URL='https://github.com/heroku/heroku-buildpack-nodejs'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app dockerfile
   run /bin/bash -c "dokku --quiet config:get $TEST_APP DOKKU_APP_TYPE"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "herokuish"
 }
 
@@ -76,8 +76,8 @@ teardown() {
 
   BUILD_CID=$(docker ps -a |grep $TEST_APP |grep /bin/bash | awk '{print $1}')
   run /bin/bash -c "docker inspect --format '{{ .HostConfig.Binds }}' $BUILD_CID | tr -d '[]' | cut -f1 -d:"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "$DOKKU_ROOT/$TEST_APP/cache"
 }
 
@@ -89,8 +89,8 @@ teardown() {
 
   BUILD_CID=$(docker ps -a |grep $TEST_APP |grep /bin/bash | awk '{print $1}')
   run /bin/bash -c "docker inspect --format '{{ .HostConfig.Binds }}' $BUILD_CID | tr -d '[]' | cut -f1 -d:"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "$TMP_ROOT/$TEST_APP/cache"
 
   rm -rf $TMP_ROOT $DOKKU_ROOT/.dokkurc/HOST_ROOT

--- a/tests/unit/20_config.bats
+++ b/tests/unit/20_config.bats
@@ -20,140 +20,140 @@ teardown() {
 
 @test "(config) config:set --global" {
   run ssh dokku@dokku.me config:set --global test_var=true test_var2=\"hello world\" test_var3='double\"quotes'
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(config) config:get --global" {
   run ssh dokku@dokku.me config:set --global test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\" test_var4='double\"quotes'
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku config:get --global test_var2"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output 'hello world'
   run /bin/bash -c "dokku config:get --global test_var3"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output 'with\nnewline'
   run /bin/bash -c "dokku config:get --global test_var4 | grep 'double\"quotes'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output 'double"quotes'
 }
 
 @test "(config) config:unset --global" {
   run ssh dokku@dokku.me config:set --global test_var=true test_var2=\"hello world\"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku config:get --global test_var"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku config:unset --global test_var"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku config:get --global test_var"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 }
 
 @test "(config) config:set/get" {
   run ssh dokku@dokku.me config:set $TEST_APP test_var1=true test_var2=\"hello world\" test_var3='double\"quotes'
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:get $TEST_APP test_var1 | grep true"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "true"
   run /bin/bash -c "dokku config:get $TEST_APP test_var2 | grep 'hello world'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "hello world"
   run /bin/bash -c "dokku config:get $TEST_APP test_var3 | grep 'double\"quotes'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output 'double"quotes'
 }
 
 @test "(config) config:set/get (with --app)" {
   run /bin/bash -c "dokku --app $TEST_APP config:set test_var1=true test_var2=\"hello world\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --app $TEST_APP config:get test_var1 | grep true"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "true"
   run /bin/bash -c "dokku --app $TEST_APP config:get test_var2 | grep 'hello world'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "hello world"
 }
 
 @test "(config) config:unset" {
   run ssh dokku@dokku.me config:set $TEST_APP test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku config:get $TEST_APP test_var"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "true"
   run /bin/bash -c "dokku config:unset $TEST_APP test_var"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku config:get $TEST_APP test_var"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
   run /bin/bash -c "dokku config:get $TEST_APP test_var3"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output 'with\nnewline'
   run /bin/bash -c "dokku config:unset $TEST_APP test_var3"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku config:get $TEST_APP test_var3"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output ""
 }
 
 @test "(config) global config (herokuish)" {
   deploy_app
   run /bin/bash -c "dokku run $TEST_APP env | egrep '^global_test=true'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(config) global config (dockerfile)" {
   deploy_app dockerfile
   run /bin/bash -c "dokku run $TEST_APP env | egrep '^global_test=true'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(config) config:show" {
   run /bin/bash -c "dokku --app $TEST_APP config:set zKey=true bKey=true BKEY=true aKey=true"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --app $TEST_APP config:show"
-  echo "output: "$output
+  echo "output: $output"
   echo "status: "$stat
 
   assert_output "=====> $TEST_APP env vars"$'\nBKEY:  true\naKey:  true\nbKey:  true\nzKey:  true'

--- a/tests/unit/20_docker-options.bats
+++ b/tests/unit/20_docker-options.bats
@@ -14,169 +14,169 @@ teardown() {
 
 @test "(docker-options) docker-options:add (all phases)" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP build,deploy,run \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 3"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(docker-options) docker-options:add (build phase)" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP build \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP build | egrep '\-v /tmp' | wc -l | grep -q 1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(docker-options) docker-options:add (deploy phase)" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP deploy \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP deploy | egrep '\-v /tmp' | wc -l | grep -q 1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(docker-options) docker-options:add (run phase)" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP run \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP run | egrep '\-v /tmp' | wc -l | grep -q 1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(docker-options) docker-options:remove (all phases)" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP build,deploy,run \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 3"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options:remove $TEST_APP build,deploy,run \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP 2> /dev/null | xargs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "Deploy options: --restart=on-failure:10"
 }
 
 @test "(docker-options) docker-options:remove (build phase)" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP build,deploy,run \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 3"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options:remove $TEST_APP build \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP build 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "Build options: none"
 }
 
 @test "(docker-options) docker-options:remove (deploy phase)" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP build,deploy,run \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP deploy | egrep '\-v /tmp' | wc -l | grep -q 1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options:remove $TEST_APP deploy \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP deploy 2> /dev/null | xargs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "Deploy options: --restart=on-failure:10"
 }
 
 @test "(docker-options) docker-options:remove (run phase)" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP build,deploy,run \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP run | egrep '\-v /tmp' | wc -l | grep -q 1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options:remove $TEST_APP run \"-v /tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP run 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "Run options: none"
 }
 
 @test "(docker-options) deploy with options" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP deploy \"-v /var/tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "echo '-v /tmp' >> $DOKKU_ROOT/$TEST_APP/DOCKER_OPTIONS_DEPLOY"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "echo '# comment' >> $DOKKU_ROOT/$TEST_APP/DOCKER_OPTIONS_DEPLOY"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP deploy | egrep '\-v /tmp' | wc -l | grep -q 1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   deploy_app
 
   CID=$(< $DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect -f '{{ .Config.Volumes }}' $CID | sed -e 's:map::g' | tr -d '[]' | tr ' ' $'\n' | sort | xargs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "/tmp:{} /var/tmp:{}"
 }
 
 @test "(docker-options) docker-options:add (all phases over SSH)" {
   run ssh dokku@dokku.me docker-options:add $TEST_APP build,deploy,run "-v /tmp"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 3"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(docker-options) dockerfile deploy with link" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP deploy \"-v /var/tmp\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku docker-options:add $TEST_APP build \"--link postgres\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   deploy_app dockerfile
 }

--- a/tests/unit/20_domains.bats
+++ b/tests/unit/20_domains.bats
@@ -19,35 +19,35 @@ teardown() {
 @test "(domains) domains" {
   dokku domains:setup $TEST_APP
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null | grep ${TEST_APP}.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "${TEST_APP}.dokku.me"
 }
 
 @test "(domains) domains:add" {
   run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:add $TEST_APP test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:add $TEST_APP 2.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:add $TEST_APP a--domain.with--hyphens"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   assert_line www.test.app.dokku.me
   assert_line test.app.dokku.me
@@ -57,13 +57,13 @@ teardown() {
 
 @test "(domains) domains:add (multiple)" {
   run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me test.app.dokku.me 2.app.dokku.me a--domain.with--hyphens"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   assert_line www.test.app.dokku.me
   assert_line test.app.dokku.me
@@ -73,55 +73,55 @@ teardown() {
 
 @test "(domains) domains:add (duplicate)" {
   run /bin/bash -c "dokku domains:add $TEST_APP test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:add $TEST_APP test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(domains) domains:add (invalid)" {
   run /bin/bash -c "dokku domains:add $TEST_APP http://test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }
 
 @test "(domains) domains:remove" {
   run /bin/bash -c "dokku domains:add $TEST_APP test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:remove $TEST_APP test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   refute_line test.app.dokku.me
 }
 
 @test "(domains) domains:remove (multiple)" {
   run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me test.app.dokku.me 2.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:remove $TEST_APP www.test.app.dokku.me test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   refute_line www.test.app.dokku.me
   refute_line test.app.dokku.me
@@ -130,36 +130,36 @@ teardown() {
 
 @test "(domains) domains:remove (wildcard domain)" {
   run /bin/bash -c "dokku domains:add $TEST_APP *.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:remove $TEST_APP *.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   refute_line *.dokku.me
 }
 
 @test "(domains) domains:set" {
   run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:set $TEST_APP 2.app.dokku.me a--domain.with--hyphens"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   refute_line www.test.app.dokku.me
   refute_line test.app.dokku.me
@@ -169,79 +169,79 @@ teardown() {
 
 @test "(domains) domains:clear" {
   run /bin/bash -c "dokku domains:add $TEST_APP test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:clear $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   refute_line test.app.dokku.me
 }
 
 @test "(domains) domains:add-global" {
   run /bin/bash -c "dokku domains:add-global global.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains 2> /dev/null | egrep -qw '^global.dokku.me\$'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(domains) domains:add-global (multiple)" {
   run /bin/bash -c "dokku domains:add-global global1.dokku.me global2.dokku.me global3.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains 2> /dev/null | grep -q global1.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains 2> /dev/null | grep -q global2.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains 2> /dev/null | grep -q global3.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(domains) domains:remove-global" {
   run /bin/bash -c "dokku domains:add-global global.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:remove-global global.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   refute_line "global.dokku.me"
 }
 
 @test "(domains) domains (multiple global domains)" {
   run /bin/bash -c "dokku domains:add-global global1.dokku.me global2.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   dokku domains:setup $TEST_APP
 
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   assert_line ${TEST_APP}.global1.dokku.me
   assert_line ${TEST_APP}.global2.dokku.me
@@ -249,20 +249,20 @@ teardown() {
 
 @test "(domains) domains:set-global" {
   run /bin/bash -c "dokku domains:add-global global1.dokku.me global2.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku domains:set-global global3.dokku.me global4.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   dokku domains:setup $TEST_APP
 
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   refute_line ${TEST_APP}.global1.dokku.me
   refute_line ${TEST_APP}.global2.dokku.me

--- a/tests/unit/20_network.bats
+++ b/tests/unit/20_network.bats
@@ -25,8 +25,8 @@ assert_nonssl_domain() {
 assert_app_domain() {
   local domain=$1
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null | grep -xF ${domain}"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "${domain}"
 }
 
@@ -47,8 +47,8 @@ assert_external_port() {
 
   run /bin/bash -c "dokku network:set $TEST_APP bind-all-interfaces true"
   run /bin/bash -c "dokku ps:rebuild $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   assert_http_success "${TEST_APP}.dokku.me"
 
@@ -58,8 +58,8 @@ assert_external_port() {
 
   run /bin/bash -c "dokku network:set $TEST_APP bind-all-interfaces false"
   run /bin/bash -c "dokku ps:rebuild $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   assert_http_success "${TEST_APP}.dokku.me"
 

--- a/tests/unit/20_nginx-vhosts_1.bats
+++ b/tests/unit/20_nginx-vhosts_1.bats
@@ -36,8 +36,8 @@ teardown() {
 @test "(nginx-vhosts) nginx:build-config (domains:add pre deploy)" {
   create_app
   run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   deploy_app

--- a/tests/unit/20_storage.bats
+++ b/tests/unit/20_storage.bats
@@ -14,29 +14,29 @@ teardown() {
 
 @test "(storage) storage:mount, storage:list, storage:umount" {
   run /bin/bash -c "dokku storage:mount $TEST_APP /tmp/mount:/mount"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku storage:list $TEST_APP | grep -qe '^\s*/tmp/mount:/mount'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku storage:mount $TEST_APP /tmp/mount:/mount"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "Mount path already exists."
   assert_failure
   run /bin/bash -c "dokku storage:unmount $TEST_APP /tmp/mount:/mount"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku storage:list $TEST_APP | grep -vqe '^\s*/tmp/mount:/mount'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku storage:unmount $TEST_APP /tmp/mount:/mount"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "Mount path does not exist."
   assert_failure
 }

--- a/tests/unit/30_client.bats
+++ b/tests/unit/30_client.bats
@@ -17,28 +17,28 @@ teardown() {
 @test "(client) unconfigured DOKKU_HOST" {
   unset DOKKU_HOST
   run ./contrib/dokku_client.sh apps
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_exit_status 20
 }
 
 @test "(client) no args should print help" {
   run /bin/bash -c "./contrib/dokku_client.sh | head -1 | grep -E 'Usage: dokku \[.+\] COMMAND <app>.*'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(client) apps:create AND apps:destroy with random name" {
   setup_client_repo
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh apps:create"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   git remote | grep dokku
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh apps:destroy --force"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
@@ -46,88 +46,88 @@ teardown() {
   setup_client_repo
   local test_app_name=test-apps-create-with-name
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh apps:create $test_app_name"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   git remote | grep dokku
   git remote -v | grep $test_app_name
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh apps:destroy --force"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(client) config:set" {
   run ./contrib/dokku_client.sh config:set $TEST_APP test_var=true test_var2=\"hello world\"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "./contrib/dokku_client.sh config:get $TEST_APP test_var2 | grep -q 'hello world'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(client) config:unset" {
   run ./contrib/dokku_client.sh config:set $TEST_APP test_var=true test_var2=\"hello world\"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run ./contrib/dokku_client.sh config:get $TEST_APP test_var
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run ./contrib/dokku_client.sh config:unset $TEST_APP test_var
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "./contrib/dokku_client.sh config:get $TEST_APP test_var | grep test_var"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }
 
 @test "(client) domains" {
   run /bin/bash -c "./contrib/dokku_client.sh domains:setup $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "./contrib/dokku_client.sh domains $TEST_APP | grep -q ${TEST_APP}.dokku.me"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(client) domains:add" {
   run ./contrib/dokku_client.sh domains:add $TEST_APP www.test.app.dokku.me
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run ./contrib/dokku_client.sh domains:add $TEST_APP test.app.dokku.me
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(client) domains:remove" {
   run ./contrib/dokku_client.sh domains:add $TEST_APP test.app.dokku.me
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run ./contrib/dokku_client.sh domains:remove $TEST_APP test.app.dokku.me
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   refute_line "test.app.dokku.me"
 }
 
 @test "(client) domains:clear" {
   run ./contrib/dokku_client.sh domains:add $TEST_APP test.app.dokku.me
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run ./contrib/dokku_client.sh domains:clear $TEST_APP
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
@@ -138,25 +138,25 @@ teardown() {
 #   skip "circleci does not support docker exec at the moment."
 #   deploy_app
 #   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh ps $TEST_APP | grep -q 'node web.js'"
-#   echo "output: "$output
-#   echo "status: "$status
+#   echo "output: $output"
+#   echo "status: $status"
 #   assert_success
 # }
 
 @test "(client) ps:start" {
   deploy_app
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh ps:stop $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh ps:start $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 }
@@ -164,13 +164,13 @@ teardown() {
 @test "(client) ps:stop" {
   deploy_app
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh ps:stop $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_failure
   done
 }
@@ -178,13 +178,13 @@ teardown() {
 @test "(client) ps:restart" {
   deploy_app
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh ps:restart $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(< $CID_FILE)"
-    echo "output: "$output
-    echo "status: "$status
+    echo "output: $output"
+    echo "status: $status"
     assert_success
   done
 }

--- a/tests/unit/30_config-oddities.bats
+++ b/tests/unit/30_config-oddities.bats
@@ -20,15 +20,15 @@ teardown() {
 
 @test "(config-oddities) set-local/get with multiple spaces and $" {
   run /bin/bash -c "dokku config:set --global double_quotes=\"hello  world$\" single_quotes='hello$  world'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   run /bin/bash -c "dokku config:get --global double_quotes"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output 'hello  world$'
   run /bin/bash -c "dokku config:get --global single_quotes"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output 'hello$  world'
   assert_success
 }
@@ -37,11 +37,11 @@ teardown() {
   multiline='line one
   line two'
   run /bin/bash -c "dokku config:set --global double_quotes=\"$multiline\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   run /bin/bash -c "dokku config:get --global double_quotes"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "$multiline"
   assert_success
 }

--- a/tests/unit/30_core_1.bats
+++ b/tests/unit/30_core_1.bats
@@ -19,8 +19,8 @@ teardown() {
 assert_urls() {
   urls=$@
   run /bin/bash -c "dokku urls $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output < <(tr ' ' '\n' <<< "${urls}")
 }
 
@@ -29,31 +29,31 @@ assert_urls() {
 
   # make sure we have many exited containers of the same 'type'
   run /bin/bash -c "for cnt in 1 2 3; do dokku run $TEST_APP echo $TEST_APP; done"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "docker ps -a -f 'status=exited' --no-trunc=true | grep \"/exec echo $TEST_APP\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   RANDOM_RUN_CID="$(docker run -d gliderlabs/herokuish bash)"
   docker ps -a
   run /bin/bash -c "dokku cleanup"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   sleep 5  # wait for dokku cleanup to happen in the background
 
   docker ps -a
   run /bin/bash -c "docker ps -a -f 'status=exited' --no-trunc=true | grep \"/exec echo $TEST_APP\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "docker inspect $RANDOM_RUN_CID"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
@@ -61,50 +61,50 @@ assert_urls() {
   deploy_app
 
   run /bin/bash -c "dokku --rm-container run $TEST_APP echo $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "docker ps -a -f 'status=exited' --no-trunc=true | grep \"/exec echo $TEST_APP\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku config:set --no-restart $TEST_APP DOKKU_RM_CONTAINER=1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --rm-container run $TEST_APP echo $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "docker ps -a -f 'status=exited' --no-trunc=true | grep \"/exec echo $TEST_APP\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku config:unset --no-restart $TEST_APP DOKKU_RM_CONTAINER"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku config:set --global DOKKU_RM_CONTAINER=1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --rm-container run $TEST_APP echo $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "docker ps -a -f 'status=exited' --no-trunc=true | grep \"/exec echo $TEST_APP\""
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku config:unset --global DOKKU_RM_CONTAINER"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
@@ -113,18 +113,18 @@ assert_urls() {
 
   RANDOM_RUN_CID="$(dokku --detach run $TEST_APP sleep 300)"
   run /bin/bash -c "docker inspect -f '{{ .State.Status }}' $RANDOM_RUN_CID"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "running"
 
   run /bin/bash -c "docker stop $RANDOM_RUN_CID"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku cleanup"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   sleep 5  # wait for dokku cleanup to happen in the background
 }
@@ -132,24 +132,24 @@ assert_urls() {
 @test "(core) run (with tty)" {
   deploy_app
   run /bin/bash -c "dokku run $TEST_APP ls /app/package.json"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(core) run (without tty)" {
   deploy_app
   run /bin/bash -c ": |dokku run $TEST_APP ls /app/package.json"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(core) run command from Procfile" {
   deploy_app
   run /bin/bash -c "dokku run $TEST_APP custom 'hi dokku' | tail -n 1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
 
   assert_success
   assert_output 'hi dokku'
@@ -163,8 +163,8 @@ EXPOSE 3003
 EXPOSE  3000/tcp
 EOF
   run get_dockerfile_exposed_ports $DOCKERFILE
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "3001/udp 3003 3000/tcp"
 }
 
@@ -176,8 +176,8 @@ EXPOSE  3000/tcp
 EXPOSE 3003
 EOF
   run get_dockerfile_exposed_ports $DOCKERFILE
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "3001/udp 3000/tcp 3003"
 }
 
@@ -185,19 +185,19 @@ EOF
   deploy_app
 
   run /bin/bash -c "dokku run $TEST_APP ls /app/prebuild.test"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku run $TEST_APP ls /app/predeploy.test"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   CID=$(docker ps -a -q  -f "ancestor=dokku/${TEST_APP}" -f "label=dokku_phase_script=postdeploy")
   IMAGE_ID=$(docker commit $CID dokku-test/${TEST_APP})
   run /bin/bash -c "docker run -ti $IMAGE_ID ls /app/postdeploy.test"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }

--- a/tests/unit/30_events.bats
+++ b/tests/unit/30_events.bats
@@ -14,20 +14,20 @@ teardown() {
 
 @test "(events) check conffiles" {
   run /bin/bash -c "test -f /etc/logrotate.d/dokku"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "test -f /etc/rsyslog.d/99-dokku.conf"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "stat -c '%U:%G:%a' /var/log/dokku/"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "syslog:dokku:775"
   run /bin/bash -c "stat -c '%U:%G:%a' /var/log/dokku/events.log"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "syslog:dokku:664"
 }
 
@@ -35,8 +35,8 @@ teardown() {
   run /bin/bash -c "dokku events:on"
   deploy_app
   run /bin/bash -c "dokku events"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku events:off"
 }

--- a/tests/unit/30_ssh_keys.bats
+++ b/tests/unit/30_ssh_keys.bats
@@ -35,49 +35,49 @@ teardown() {
 
 @test "(ssh-keys) ssh-keys:add, ssh-keys:list, ssh-keys:remove" {
   run /bin/bash -c "dokku ssh-keys:add name1 /tmp/testkey.pub"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "cat /tmp/testkey.pub | dokku ssh-keys:add name2"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku ssh-keys:list | grep name1 && dokku ssh-keys:list | grep name2"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku ssh-keys:remove name1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku ssh-keys:list | grep name1"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
   run /bin/bash -c "dokku ssh-keys:list | grep name2"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku ssh-keys:add name3 /tmp/testkey-double.pub"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
   run /bin/bash -c "dokku ssh-keys:add name4 /tmp/testkey-invalid.pub"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
   run /bin/bash -c "dokku ssh-keys:add name4 /tmp/testkey.pub"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   # leave this as the last test in the sequence! It introduces an error in authorized_keys
   run /bin/bash -c 'echo invalid >> "${DOKKU_ROOT:-/home/dokku}/.ssh/authorized_keys"'
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku ssh-keys:add name5 /tmp/testkey.pub"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }

--- a/tests/unit/40_core_2.bats
+++ b/tests/unit/40_core_2.bats
@@ -16,8 +16,8 @@ teardown() {
 assert_urls() {
   urls=$@
   run /bin/bash -c "dokku urls $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   echo "urls:" $(tr ' ' '\n' <<< "${urls}" | sort)
   assert_output < <(tr ' ' '\n' <<< "${urls}" | sort)
 }
@@ -25,8 +25,8 @@ assert_urls() {
 assert_url() {
   url=$1
   run /bin/bash -c "dokku url $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   echo "url: ${url}"
   assert_output "${url}"
 }
@@ -34,25 +34,25 @@ assert_url() {
 @test "(core) run (with --options)" {
   deploy_app
   run /bin/bash -c "dokku --force --quiet run $TEST_APP node --version"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(core) unknown command" {
   run /bin/bash -c "dokku fakecommand"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku fakecommand 2>&1 | grep -q 'is not a dokku command'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku apps: 2>&1 | grep -q 'is not a dokku command'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
@@ -93,14 +93,14 @@ assert_url() {
 
 @test "(core) git-remote (off-port)" {
   run deploy_app nodejs-express ssh://dokku@127.0.0.1:22333/$TEST_APP
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(core) git-remote (bad name)" {
   run deploy_app nodejs-express ssh://dokku@127.0.0.1:22333/home/dokku/$TEST_APP
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }

--- a/tests/unit/40_nginx-vhosts_2.bats
+++ b/tests/unit/40_nginx-vhosts_2.bats
@@ -32,8 +32,8 @@ assert_error_log() {
 @test "(nginx-vhosts) nginx (no server tokens)" {
   deploy_app
   run /bin/bash -c "curl -s -D - $(dokku url $TEST_APP) -o /dev/null | egrep '^Server' | egrep '[0-9]+'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }
 
@@ -102,7 +102,7 @@ assert_error_log() {
 
 @test "(nginx-vhosts) nginx:build-config (failed validate_nginx)" {
   run deploy_app nodejs-express dokku@dokku.me:$TEST_APP bad_custom_nginx_template
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }

--- a/tests/unit/40_plugin.bats
+++ b/tests/unit/40_plugin.bats
@@ -19,91 +19,91 @@ teardown() {
 
 @test "(plugin) plugin:install, plugin:disable, plugin:update plugin:uninstall" {
   run /bin/bash -c "dokku plugin:install $TEST_PLUGIN_GIT_REPO --name $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku plugin:update $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "sudo -E -u nobody dokku plugin:uninstall $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku plugin:disable $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku plugin | grep disabled | grep $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku plugin:uninstall $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku plugin | grep $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }
 
 @test "(plugin) plugin:install plugin:update (with tag)" {
   run /bin/bash -c "dokku plugin:install $TEST_PLUGIN_GIT_REPO --committish v0.2.0 --name $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME | grep 0.2.0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku plugin:update $TEST_PLUGIN_NAME v0.3.0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME | grep 0.2.0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME | grep 0.3.0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(plugin) plugin:install, plugin:disable, plugin:uninstall as non-root user failure" {
   run /bin/bash -c "sudo -E -u nobody dokku plugin:install $TEST_PLUGIN_GIT_REPO"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 
   run /bin/bash -c "dokku plugin:install $TEST_PLUGIN_GIT_REPO"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "sudo -E -u nobody dokku plugin:disable $TEST_PLUGIN_NAME"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }

--- a/tests/unit/40_proxy.bats
+++ b/tests/unit/40_proxy.bats
@@ -25,8 +25,8 @@ assert_nonssl_domain() {
 assert_app_domain() {
   local domain=$1
   run /bin/bash -c "dokku domains $TEST_APP 2> /dev/null | grep -xF ${domain}"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "${domain}"
 }
 
@@ -46,8 +46,8 @@ assert_external_port() {
   assert_nonssl_domain "${TEST_APP}.dokku.me"
 
   run /bin/bash -c "dokku proxy:disable $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.web.*; do
@@ -55,8 +55,8 @@ assert_external_port() {
   done
 
   run /bin/bash -c "dokku proxy:enable $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   assert_http_success "${TEST_APP}.dokku.me"
 
@@ -67,71 +67,71 @@ assert_external_port() {
 
 @test "(proxy) proxy:ports (list/add/set/remove/clear)" {
   run /bin/bash -c "dokku proxy:ports-set $TEST_APP http:1234:5001"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --quiet proxy:ports $TEST_APP | xargs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "http 1234 5001"
 
   run /bin/bash -c "dokku proxy:ports-add $TEST_APP http:8080:5002 https:8443:5003"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --quiet proxy:ports $TEST_APP | xargs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "http 1234 5001 http 8080 5002 https 8443 5003"
 
   run /bin/bash -c "dokku proxy:ports-set $TEST_APP http:8080:5000 https:8443:5000 http:1234:5001"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --quiet proxy:ports $TEST_APP | xargs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "http 1234 5001 http 8080 5000 https 8443 5000"
 
   run /bin/bash -c "dokku proxy:ports-remove $TEST_APP 8080"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --quiet proxy:ports $TEST_APP | xargs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "http 1234 5001 https 8443 5000"
 
   run /bin/bash -c "dokku proxy:ports-remove $TEST_APP http:1234:5001"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --quiet proxy:ports $TEST_APP | xargs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "https 8443 5000"
 
   run /bin/bash -c "dokku proxy:ports-clear $TEST_APP"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku --quiet proxy:ports $TEST_APP | xargs"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_output "http 80 5000"
 }
 
 @test "(proxy) proxy:ports (post-deploy add)" {
   deploy_app
   run /bin/bash -c "dokku proxy:ports-add $TEST_APP http:8080:5000 http:8081:5000"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   URLS="$(dokku --quiet urls "$TEST_APP")"

--- a/tests/unit/40_tags.bats
+++ b/tests/unit/40_tags.bats
@@ -14,42 +14,42 @@ teardown() {
 
 @test "(tags) tags:create, tags, tags:destroy" {
   run /bin/bash -c "dokku tags:create $TEST_APP v0.9.0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku tags $TEST_APP | egrep -q 'v0.9.0'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 
   run /bin/bash -c "dokku tags:destroy $TEST_APP v0.9.0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku tags $TEST_APP | egrep -q 'v0.9.0'"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }
 
 @test "(tags) tags:deploy" {
   run /bin/bash -c "dokku tags:create $TEST_APP v0.9.0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "dokku tags:deploy $TEST_APP v0.9.0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
   run /bin/bash -c "docker ps | egrep '/start web'| egrep -q dokku/${TEST_APP}:v0.9.0"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_success
 }
 
 @test "(tags) tags:deploy (missing tag)" {
   run /bin/bash -c "dokku tags:deploy $TEST_APP missing-tag"
-  echo "output: "$output
-  echo "status: "$status
+  echo "output: $output"
+  echo "status: $status"
   assert_failure
 }


### PR DESCRIPTION
The tests sometimes used one syntax vs another for `run` statements and echoing output/status variables. This pull request normalizes them into a single, common format that can then just be reused at will.