### PR TITLE
Drop default dhparam key size to 2048

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -30,7 +30,7 @@ chmod 0440 /etc/sudoers.d/dokku-nginx
 
 # if dhparam.pem has not been created, create it the first time
 if [[ ! -f /etc/nginx/dhparam.pem ]]; then
-  openssl dhparam -out /etc/nginx/dhparam.pem 4096
+  openssl dhparam -out /etc/nginx/dhparam.pem 2048
   chown root:root /etc/nginx/dhparam.pem
 fi
 


### PR DESCRIPTION
4096 takes so long on a very fast machine - 32 core, 64 gb droplet - that most users will begin to believe that it will never complete.
