### PR TITLE
Move storage directory into DOKKU_LIB_ROOT

### DIFF
--- a/plugins/storage/install
+++ b/plugins/storage/install
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-mkdir -p /var/lib/dokku/data/storage
-chown dokku:dokku /var/lib/dokku/data/storage
+mkdir -p "${DOKKU_LIB_ROOT}/data/storage"
+chown dokku:dokku "${DOKKU_LIB_ROOT}/data/storage"


### PR DESCRIPTION
Should this path change in the future, the storage plugin will respect the variable value.

[ci skip]
