### PR TITLE
Image tag deploy workflow cleanup

### DIFF
--- a/docs/deployment/methods/images.md
+++ b/docs/deployment/methods/images.md
@@ -65,7 +65,7 @@ dokku/node-js-app   v1                  936a42f25901        About a minute ago  
 
 ### Deploying an image tag
 
-Finally, you can also deploy a local image using the `tags:deploy` command.
+Finally, you can also deploy a local image using the `tags:deploy` command. When specifying a tag that is not `latest`, the released image will be retagged as the `latest` image tag for the app.
 
 ```shell
 dokku tags:deploy node-js-app v1

--- a/docs/deployment/methods/images.md
+++ b/docs/deployment/methods/images.md
@@ -67,6 +67,8 @@ dokku/node-js-app   v1                  936a42f25901        About a minute ago  
 
 Finally, you can also deploy a local image using the `tags:deploy` command. When specifying a tag that is not `latest`, the released image will be retagged as the `latest` image tag for the app.
 
+> Warning: For images based on herokuish, using the `tags:deploy` subcommand will reset environment variables written into the image, causing a retag to occur. This will - on average - add two extra layers to your deployed image. Note that this does not affect dockerfile-based images, which are the majority of images deployed via the `tags` command.
+
 ```shell
 dokku tags:deploy node-js-app v1
 ```

--- a/plugins/tags/subcommands/deploy
+++ b/plugins/tags/subcommands/deploy
@@ -12,7 +12,13 @@ tags_deploy_cmd() {
 
   IMAGE="$(get_app_image_name "$APP" "$IMAGE_TAG")"
   verify_image "$IMAGE" || return 1
-  release_and_deploy "$APP" "$IMAGE_TAG"  
+  release_and_deploy "$APP" "$IMAGE_TAG"
+
+  if [[  "$IMAGE_TAG" != "latest" ]]; then
+    local DOKKU_SCHEDULER="$(get_app_scheduler "$APP")"
+    local LATEST_IMAGE="$(get_app_image_name "$APP")"
+    plugn trigger scheduler-tags-create "$DOKKU_SCHEDULER" "$APP" "$IMAGE" "$LATEST_IMAGE"
+  fi
 }
 
 tags_deploy_cmd "$@"

--- a/plugins/tar/deploy-source
+++ b/plugins/tar/deploy-source
@@ -10,8 +10,8 @@ tar_deploy_source() {
 
   # bail if another source is detected
   if [[ -n "$STDIN" ]]; then
-  	echo "$STDIN"
-  	return
+    echo "$STDIN"
+    return
   fi
 
   if [[ -f "$DOKKU_ROOT/$APP/src.tar" ]]; then

--- a/tests/unit/40_tags.bats
+++ b/tests/unit/40_tags.bats
@@ -45,6 +45,10 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+  run /bin/bash -c "docker images | egrep "dokku/${TEST_APP}"| egrep -q latest"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 }
 
 @test "(tags) tags:deploy (missing tag)" {


### PR DESCRIPTION
- If the image tag being deployed is not `latest`, we'll retag it as such once the deploy is complete.
- Add a warning concerning herokuish-based images

Closes #3355.