### PR TITLE
Run tests from built artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 DOKKU_VERSION ?= master
 
+PROCFILE_VERSION ?= 0.4.0
 SSHCOMMAND_URL ?= https://raw.githubusercontent.com/dokku/sshcommand/v0.7.0/sshcommand
-PROCFILE_UTIL_URL ?= https://github.com/josegonzalez/go-procfile-util/releases/download/v0.4.0/procfile-util_0.4.0_linux_x86_64.tgz
+PROCFILE_UTIL_URL ?= https://github.com/josegonzalez/go-procfile-util/releases/download/v${PROCFILE_VERSION}/procfile-util_${PROCFILE_VERSION}_linux_x86_64.tgz
 PLUGN_URL ?= https://github.com/dokku/plugn/releases/download/v0.3.0/plugn_0.3.0_linux_x86_64.tgz
 SIGIL_URL ?= https://github.com/gliderlabs/sigil/releases/download/v0.4.0/sigil_0.4.0_Linux_x86_64.tgz
 STACK_URL ?= https://github.com/gliderlabs/herokuish.git

--- a/contrib/release-dokku-update
+++ b/contrib/release-dokku-update
@@ -155,7 +155,6 @@ main() {
     fn-publish-package "$IS_RELEASE" "deb" "build/dokku-update_${NEXT_VERSION}_amd64.deb" || log-fail "Error publishing deb package"
     fn-publish-package "$IS_RELEASE" "rpm" "build/dokku-update-${NEXT_VERSION}-1.x86_64.rpm" || log-fail "Error publishing rpm package"
   fi
-
 }
 
 main "$@"

--- a/tests/ci/setup.sh
+++ b/tests/ci/setup.sh
@@ -1,6 +1,58 @@
 #!/usr/bin/env bash
 
 set -eo pipefail
+readonly ROOT_DIR="$(cd "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")" && pwd)"
+
+install_dependencies() {
+  mkdir -p "$ROOT_DIR/build/"
+  HEROKUISH_VERSION=$(grep HEROKUISH_VERSION "${ROOT_DIR}/deb.mk" | head -n1 | cut -d' ' -f3)
+  HEROKUISH_PACKAGE_NAME="herokuish_${HEROKUISH_VERSION}_amd64.deb"
+  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/herokuish_${HEROKUISH_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${HEROKUISH_PACKAGE_NAME}"
+
+  PLUGN_VERSION=$(grep PLUGN_VERSION "${ROOT_DIR}/deb.mk" | head -n1 | cut -d' ' -f3)
+  PLUGN_PACKAGE_NAME="plugn_${PLUGN_VERSION}_amd64.deb"
+  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/plugn_${PLUGN_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PLUGN_PACKAGE_NAME}"
+
+  SSHCOMMAND_VERSION=$(grep SSHCOMMAND_VERSION "${ROOT_DIR}/deb.mk" | head -n1 | cut -d' ' -f3)
+  SSHCOMMAND_PACKAGE_NAME="sshcommand_${SSHCOMMAND_VERSION}_amd64.deb"
+  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/sshcommand_${SSHCOMMAND_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${SSHCOMMAND_PACKAGE_NAME}"
+
+  SIGIL_VERSION=$(grep SIGIL_VERSION "${ROOT_DIR}/deb.mk" | head -n1 | cut -d' ' -f3)
+  SIGIL_PACKAGE_NAME="gliderlabs-sigil_${SIGIL_VERSION}_amd64.deb"
+  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/gliderlabs-sigil_${SIGIL_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${SIGIL_PACKAGE_NAME}"
+
+  PROCFILE_VERSION=$(grep PROCFILE_VERSION "${ROOT_DIR}/Makefile" | head -n1 | cut -d' ' -f3)
+  PROCFILE_UTIL_PACKAGE_NAME="procfile-util_${PROCFILE_VERSION}_amd64.deb"
+  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/procfile-util_${PROCFILE_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PROCFILE_UTIL_PACKAGE_NAME}"
+
+  sudo add-apt-repository -y ppa:nginx/stable
+  sudo apt-get update
+  sudo apt-get -qq -y install nginx
+  sudo cp "${ROOT_DIR}/tests/dhparam.pem" /etc/nginx/dhparam.pem
+
+  sudo dpkg -i "${ROOT_DIR}/build/$HEROKUISH_PACKAGE_NAME"
+  sudo dpkg -i "${ROOT_DIR}/build/$PLUGN_PACKAGE_NAME"
+  sudo dpkg -i "${ROOT_DIR}/build/$SSHCOMMAND_PACKAGE_NAME"
+  sudo dpkg -i "${ROOT_DIR}/build/$SIGIL_PACKAGE_NAME"
+  sudo dpkg -i "${ROOT_DIR}/build/$PROCFILE_UTIL_PACKAGE_NAME"
+}
+
+install_dokku() {
+  if [[ "$FROM_SOURCE" == "true" ]]; then
+    sudo -E CI=true make -e install
+    return
+  fi
+
+  "${ROOT_DIR}/contrib/release" build
+
+  echo "dokku dokku/hostname string dokku.me"              | sudo debconf-set-selections
+  echo "dokku dokku/key_file string /root/.ssh/id_rsa.pub" | sudo debconf-set-selections
+  echo "dokku dokku/nginx_enable boolean true"             | sudo debconf-set-selections
+  echo "dokku dokku/skip_key_file boolean true"            | sudo debconf-set-selections
+  echo "dokku dokku/vhost_enable boolean true"             | sudo debconf-set-selections
+  echo "dokku dokku/web_config boolean false"              | sudo debconf-set-selections
+  sudo dpkg -i "$(cat "${ROOT_DIR}/build/deb-filename")"
+}
 
 # shellcheck disable=SC2120
 setup_circle() {
@@ -10,12 +62,9 @@ setup_circle() {
   sudo usermod -G docker dokku
   [[ "$1" == "buildstack" ]] && BUILD_STACK=true make -e stack
 
-  sudo add-apt-repository -y ppa:nginx/stable
-  sudo apt-get update
-  sudo apt-get -qq -y install nginx
-  sudo cp tests/dhparam.pem /etc/nginx/dhparam.pem
+  install_dependencies
+  install_dokku
 
-  sudo -E CI=true make -e install
   sudo -E make -e setup-deploy-tests
   bash --version
   docker version


### PR DESCRIPTION
Rather than testing against an install from source, ensure that all tests run from what _would_ be installed on a user's server. This ensures that the build process is sound, regardless of what code changes are implemented.
