### PR TITLE
Switch from rawgit to jsdelivr

### DIFF
--- a/docs/assets/favicons/browserconfig.xml
+++ b/docs/assets/favicons/browserconfig.xml
@@ -2,10 +2,10 @@
 <browserconfig>
   <msapplication>
     <tile>
-      <square70x70logo src="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/mstile-70x70.png"/>
-      <square150x150logo src="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/mstile-150x150.png"/>
-      <square310x310logo src="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/mstile-310x310.png"/>
-      <wide310x150logo src="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/mstile-310x150.png"/>
+      <square70x70logo src="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/mstile-70x70.png"/>
+      <square150x150logo src="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/mstile-150x150.png"/>
+      <square310x310logo src="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/mstile-310x310.png"/>
+      <wide310x150logo src="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/mstile-310x150.png"/>
       <TileColor>#da532c</TileColor>
     </tile>
   </msapplication>

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -39,13 +39,13 @@ h1 {
   font-size: 1.6em;
 }
 .header .navbar-brand a {
-  background-image: url(https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/dokku.png);
+  background-image: url(https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/dokku.png);
   text-indent: 40px;
 }
 .blurb {
   color: #424242;
   background-color: #ededed;
-  background-image: url(https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/gplaypattern.png);
+  background-image: url(https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/gplaypattern.png);
   padding: 45px 0;
   text-align: center;
 }

--- a/docs/home.html
+++ b/docs/home.html
@@ -10,30 +10,30 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <title>Dokku - The smallest PaaS implementation you've ever seen</title>
 
-    <link rel="apple-touch-icon" sizes="57x57" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-180x180.png">
-    <link rel="icon" type="image/png" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/android-chrome-192x192.png" sizes="192x192">
-    <link rel="icon" type="image/png" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/favicon-96x96.png" sizes="96x96">
-    <link rel="icon" type="image/png" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/manifest.json">
-    <link rel="shortcut icon" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/favicon.ico">
+    <link rel="apple-touch-icon" sizes="57x57" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-180x180.png">
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/android-chrome-192x192.png" sizes="192x192">
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/favicon-96x96.png" sizes="96x96">
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/manifest.json">
+    <link rel="shortcut icon" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/favicon.ico">
     <meta name="apple-mobile-web-app-title" content="Dokku">
     <meta name="application-name" content="Dokku">
     <meta name="msapplication-TileColor" content="#da532c">
-    <meta name="msapplication-TileImage" content="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/mstile-144x144.png">
-    <meta name="msapplication-config" content="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/browserconfig.xml">
+    <meta name="msapplication-TileImage" content="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/mstile-144x144.png">
+    <meta name="msapplication-config" content="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/style.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/style.css" rel="stylesheet">
     <!-- <link href="/dokku/docs/assets/style.css" rel="stylesheet"> -->
     <style>
     </style>

--- a/docs/template.html
+++ b/docs/template.html
@@ -9,26 +9,26 @@
     <meta name="author" content="">
     <title>Dokku - The smallest PaaS implementation you've ever seen</title>
 
-    <link rel="apple-touch-icon" sizes="57x57" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/apple-touch-icon-180x180.png">
-    <link rel="icon" type="image/png" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" type="image/png" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/android-chrome-192x192.png" sizes="192x192">
-    <link rel="icon" type="image/png" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/favicon-96x96.png" sizes="96x96">
-    <link rel="icon" type="image/png" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/manifest.json">
-    <link rel="shortcut icon" href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/favicon.ico">
+    <link rel="apple-touch-icon" sizes="57x57" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/apple-touch-icon-180x180.png">
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/android-chrome-192x192.png" sizes="192x192">
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/favicon-96x96.png" sizes="96x96">
+    <link rel="icon" type="image/png" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/manifest.json">
+    <link rel="shortcut icon" href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/favicon.ico">
     <meta name="apple-mobile-web-app-title" content="Dokku">
     <meta name="application-name" content="Dokku">
     <meta name="msapplication-TileColor" content="#da532c">
-    <meta name="msapplication-TileImage" content="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/mstile-144x144.png">
-    <meta name="msapplication-config" content="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/favicons/browserconfig.xml">
+    <meta name="msapplication-TileImage" content="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/mstile-144x144.png">
+    <meta name="msapplication-config" content="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/favicons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
 
     <script>
@@ -42,7 +42,7 @@
     </script>
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.rawgit.com/dokku/dokku/v0.13.4/docs/assets/style.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.13.4/docs/assets/style.css" rel="stylesheet">
     <!-- <link href="/dokku/docs/assets/style.css" rel="stylesheet"> -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet">
     <style>


### PR DESCRIPTION
Rawgit is no longer being offered due to spammers, but jsdelivr has graciously allowed folks to use their cdn to mirror assets from github.

Closes #3284
