### PR TITLE
Install stable docker when using bootstrap script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -138,14 +138,17 @@ install-dokku-from-deb-package() {
   apt-get update -qq >/dev/null
   apt-get -qq -y install apt-transport-https
 
-  echo "--> Installing docker"
-  if uname -r | grep -q linode; then
-    echo "--> NOTE: Using Linode? Docker may complain about missing AUFS support."
-    echo "    You can safely ignore this warning."
-    echo "    Installation will continue in 10 seconds."
-    sleep 10
+  if ! command -v docker &>/dev/null; then
+    echo "--> Installing docker"
+    if uname -r | grep -q linode; then
+      echo "--> NOTE: Using Linode? Docker may complain about missing AUFS support."
+      echo "    You can safely ignore this warning."
+      echo "    Installation will continue in 10 seconds."
+      sleep 10
+    fi
+    export CHANNEL=stable
+    wget -nv -O - https://get.docker.com/ | sh
   fi
-  wget -nv -O - https://get.docker.com/ | sh
 
   if [[ "$DOKKU_DISTRO_VERSION" == "14.04" ]]; then
     echo "--> Adding nginx PPA"


### PR DESCRIPTION
This script previously ran through the docker installation process with the edge channel on each run. Instead, we only run the docker installation if docker is not available. In addition, we force set the channel to stable, ensuring the script installs the correct channel for stable docker installations.

Closes #3269
