### PR TITLE
fix: use updated gpg key for apt repository

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -174,7 +174,7 @@ install-dokku-from-deb-package() {
   fi
 
   echo "--> Installing dokku"
-  wget -nv -O - https://packagecloud.io/gpg.key | apt-key add -
+  wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -
   echo "deb https://packagecloud.io/dokku/dokku/$DOKKU_DISTRO/ $OS_ID main" | tee /etc/apt/sources.list.d/dokku.list
   apt-get update -qq >/dev/null
 


### PR DESCRIPTION
Packagecloud recently updated legacy repositories to sign with a repository-specific gpg key.

Closes #3383
