### PR TITLE
Update all gpgkey paths to the new url

### DIFF
--- a/deb.mk
+++ b/deb.mk
@@ -71,7 +71,7 @@ install-from-deb:
 	wget -nv -O - https://get.docker.com/ | sh
 
 	@echo "--> Installing dokku"
-	wget -nv -O - https://packagecloud.io/gpg.key | apt-key add -
+	wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -
 	@echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ $(shell lsb_release -cs 2> /dev/null || echo "trusty") main" | sudo tee /etc/apt/sources.list.d/dokku.list
 	sudo apt-get update -qq > /dev/null
 	sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -yy dokku

--- a/docs/getting-started/install/debian.md
+++ b/docs/getting-started/install/debian.md
@@ -11,7 +11,7 @@ sudo apt-get install -qq -y apt-transport-https
 wget -nv -O - https://get.docker.com/ | sh
 
 # install dokku
-wget -nv -O - https://packagecloud.io/gpg.key | apt-key add -
+wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -
 OS_ID="$(lsb_release -cs 2> /dev/null || echo "trusty")"
 echo "trusty utopic vivid wily xenial yakkety zesty artful bionic" | grep -q "$OS_ID" || OS_ID="trusty"
 echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ ${OS_ID} main" | sudo tee /etc/apt/sources.list.d/dokku.list

--- a/docs/home.html
+++ b/docs/home.html
@@ -154,7 +154,7 @@
           <p class="line">
             <span class="path"></span>
             <span class="prompt">$</span>
-            <span class="command">wget -nv -O - https://packagecloud.io/gpg.key | apt-key add -</span>
+            <span class="command">wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -</span>
           </p>
           <p class="line">
             <span class="path"></span>


### PR DESCRIPTION
PackageCloud automatically switched our key earlier this week but some docs were still referencing the old path.

Closes #3390

