### PR TITLE
Fix capitalization and formatting in installation guides

### DIFF
--- a/docs/getting-started/install/azure.md
+++ b/docs/getting-started/install/azure.md
@@ -2,10 +2,10 @@
 
 - If you don't already have one [generate an SSH key pair](https://help.github.com/articles/generating-ssh-keys/).
 
-- Go to the [Dokku on azure deployment page](https://github.com/azure/azure-quickstart-templates/tree/master/dokku-vm) and click **Deploy to Azure**.
+- Go to the [Dokku on Azure deployment page](https://github.com/azure/azure-quickstart-templates/tree/master/dokku-vm) and click **Deploy to Azure**.
 
-- You'll be prompted to enter a few parameters, including a unique storage account name and a unique name for the sub-domain used for your public IP address. For the `sshKeyData` parameter, copy and paste the contents of the **public** key file you just created. After a few minutes the Dokku instance will be deployed.
+- You'll be prompted to enter a few parameters, including a unique storage account name and a unique name for the sub-domain used for your public IP address. For the `sshKeyData` parameter, copy and paste the contents of the *public* key file you just created. After a few minutes the Dokku instance will be deployed.
 
-- In your browser of choice, navigate to `http://[[dnsNameForPublicIP]].[[location]].cloudapp.azure.com`. Where `[[dnsNameForPublicIP]]` and `[[location]]` are template parameters you used to deploy the template.
+- In your browser of choice, navigate to `http://[dnsNameForPublicIP].[location].cloudapp.azure.com`. Where `[dnsNameForPublicIP]` and `[location]` are template parameters you used to deploy the template.
 
-- Finish your Dokku setup like you normally would by creating a **new** public/private key pair for your deployments using `ssh-keygen` (don't use the same one as you created in the first step). You should select 'Use Virtual Host Naming' and set the `Hostname` to a **public dns name** that you own such as one you would purchase from [namecheap](http://namecheap.com). Alternatively thanks to [xip.io]( http://xip.io/) you can just use yourAzurePublicIP.xip.io for free. For example, if your public IP is `44.44.44.44` then you would set it to `44.44.44.44.xip.io`.
+- Finish your Dokku setup like you normally would by creating a *new* public/private key pair for your deployments using `ssh-keygen` (don't use the same one as you created in the first step). You should select **Use Virtual Host Naming** and set the **Hostname** to a *public DNS name* that you own such as one you would purchase from [Namecheap](http://namecheap.com). Alternatively thanks to [xip.io](http://xip.io/) you can just use `[yourAzurePublicIP].xip.io` for free. For example, if your public IP is `44.44.44.44` then you would set it to `44.44.44.44.xip.io`.

--- a/docs/getting-started/install/debian.md
+++ b/docs/getting-started/install/debian.md
@@ -1,6 +1,6 @@
 # Debian Package Installation Notes
 
-As of 0.3.18, Dokku defaults to being installed via debian package. While certain hosts may require extra work to get running, you may optionally wish to automate the installation of Dokku without the use of our `bootstrap.sh` bash script. The following are the steps run by said script:
+As of 0.3.18, Dokku defaults to being installed via Debian package. While certain hosts may require extra work to get running, you may optionally wish to automate the installation of Dokku without the use of our `bootstrap.sh` Bash script. The following are the steps run by said script:
 
 ```shell
 # install prerequisites
@@ -22,7 +22,7 @@ sudo dokku plugin:install-dependencies --core
 
 ## Unattended installation
 
-In case you want to perform an unattended installation of dokku, this is made possible through [debconf](https://en.wikipedia.org/wiki/Debconf_%28software_package%29), which allows you to configure a package before installing it.
+In case you want to perform an unattended installation of Dokku, this is made possible through [debconf](https://en.wikipedia.org/wiki/Debconf_%28software_package%29), which allows you to configure a package before installing it.
 
 You can set any of the below options through the `debconf-set-selections` command, for example to enable vhost-based deployments:
 
@@ -37,7 +37,7 @@ After setting the desired options, proceed with the installation as described ab
 | Name               | Type    | Default               | Description                                                              |
 | ------------------ | ------- | --------------------- | ------------------------------------------------------------------------ |
 | dokku/web_config   | boolean | true                  | Use web-based config for below options                                   |
-| dokku/vhost_enable | boolean | false                 | Use vhost-based deployments (e.g., <app>.dokku.me)                        |
+| dokku/vhost_enable | boolean | false                 | Use vhost-based deployments (e.g. `[yourapp].dokku.me`)                        |
 | dokku/hostname     | string  | dokku.me              | Hostname, used as vhost domain and for showing app URL after deploy      |
 | dokku/skip_key_file| boolean | false                 | Don't check for the existence of the dokku/key_file. Warning: Setting this to true, will require you to manually add an SSH key later on. |
 | dokku/key_file     | string  | /root/.ssh/id_rsa.pub | Path on disk to an SSH key to add to the Dokku user (Will be ignored on `dpkg-reconfigure`) |

--- a/docs/getting-started/install/digitalocean.md
+++ b/docs/getting-started/install/digitalocean.md
@@ -1,22 +1,22 @@
 # Digital Ocean Droplet
 
-[Digital Ocean](https://www.digitalocean.com/products/compute/) offers a pre-installed Dokku image. You can run this image on any sized droplet, although larger droplets will allow you to run larger applications.
+[Digital Ocean](https://www.digitalocean.com/products/compute/) offers a pre-installed Dokku image. You can run this image on any sized Droplet, although larger Droplets will allow you to run larger applications.
 
 > **Please disable IPv6**. There are known issues with IPv6 on Digital Ocean and Docker. If you would like to run Dokku on an IPv6 Digital Ocean Droplet, please consult [this guide](https://jeffloughridge.wordpress.com/2015/01/17/native-ipv6-functionality-in-docker/).
 
-1. Login to your [Digital Ocean](https://m.do.co/c/fe06b043a083) account
+1. Login to your [Digital Ocean](https://m.do.co/c/fe06b043a083) account.
 2. Click **Create a Droplet**.
 3. Under **Choose an image > One-click apps** and choose the latest **Dokku** release for 16.04 _(version numbers may vary)_.
 4. Under **Choose a size** and select your a machine spec. We recommend a machine with _at least_ 1GB of memory.
 5. Under **Choose a datacenter region** select your region.
-6. Add an SSH Key
+6. Add an SSH Key.
    * New Keys
-     1. Under **Add your SSH keys** click **New SSH Key** _(this opens a dialog)_
-     2. From your terminal, execute `cat $HOME/.ssh/id_rsa.pub`
-     3. Copy the output and paste it into the **New SSH Key** dialog, provide a name and click **Add SSH Key**
+     1. Under **Add your SSH keys** click **New SSH Key** _(this opens a dialog)_.
+     2. From your terminal, execute `cat $HOME/.ssh/id_rsa.pub`.
+     3. Copy the output and paste it into the **New SSH Key** dialog, provide a name and click **Add SSH Key**.
    * Existing Keys
      1. Simply add a checkmark next to the existing keys you'd like to add.
-7. Under **Finalize and create**, give your droplet a hostname _(not required)_ and click **Create**.
+7. Under **Finalize and create**, give your Droplet a hostname _(not required)_ and click **Create**.
 8. Once created, copy the IP address to your clipboard.
-9. In a browser, go to the IP address you copied above and fill out the presented form to complete configuration. **Failure to do so may allow others to reconfigure SSH access on your server.**
-10. Once the web ui has been submitted, you will be redirected to our [application deployment tutorial](/docs/deployment/application-deployment.md), which will guide you through deploying a sample application to your Dokku server.
+9. In a browser, go to the IP address you copied above and fill out the presented form to complete configuration. _Failure to do so may allow others to reconfigure SSH access on your server._
+10. Once the web UI has been submitted, you will be redirected to our [application deployment tutorial](/docs/deployment/application-deployment.md), which will guide you through deploying a sample application to your Dokku server.

--- a/docs/getting-started/install/dreamhost.md
+++ b/docs/getting-started/install/dreamhost.md
@@ -5,9 +5,9 @@ Dreamhost (or any other OpenStack-compatible cloud with minimal
 changes).
 
 A new server instance can be created on DreamHost Cloud from the command line
-using openstack client or from the web UI and with the same command
-use a cloud-init script to install Dokku. Install the [openstack
-cli](https://help.dreamhost.com/hc/en-us/articles/216185658-How-to-Install-the-OpenStack-command-line-clients),
+using OpenStack client or from the web UI and with the same command
+use a cloud-init script to install Dokku. Install the [OpenStack
+CLI](https://help.dreamhost.com/hc/en-us/articles/216185658-How-to-Install-the-OpenStack-command-line-clients),
 download the [DreamHost Cloud credentials
 file](https://iad2.dreamcompute.com/project/access_and_security/api_access/openrc/)
 before proceeding and make sure your public SSH key is added to the
@@ -17,10 +17,10 @@ cloud.
 source openrc.sh # Set the environment variables for DreamHost Cloud
 ```
 
-This allows openstack client to connect to DreamHost API endpoints.
+This allows OpenStack client to connect to DreamHost API endpoints.
 The command below creates a new server instance named `my-dokku-instance`
 based on Ubuntu 14.04, with 2GB RAM and 1CPU (the flavor called
-`supersonic`), opening network port access to http and ssh (the
+`supersonic`), opening network port access to HTTP and SSH (the
 `default` security group), and the name of the chosen SSH key. This
 key will be automatically added to the new server in the
 `authorized_keys` for the default SSH user (`ubuntu`), and it will

--- a/docs/getting-started/install/rpm.md
+++ b/docs/getting-started/install/rpm.md
@@ -4,7 +4,7 @@
 
 >**Warning:** Web installer is not available on CentOS. You will need to configure [SSH keys](/docs/deployment/user-management.md#adding-ssh-keys) and [virtual hosts](/docs/configuration/domains.md#customizing-hostnames) using dokku command line interface.
 
-Dokku defaults to being installed via RPM package on CentOS 7. While certain hosts may require extra work to get running, you may optionally wish to automate the installation of Dokku without the use of our `bootstrap.sh` bash script. The following are the steps run by said script:
+Dokku defaults to being installed via RPM package on CentOS 7. While certain hosts may require extra work to get running, you may optionally wish to automate the installation of Dokku without the use of our `bootstrap.sh` Bash script. The following are the steps run by said script:
 
 ```shell
 # Install docker

--- a/docs/getting-started/install/vagrant.md
+++ b/docs/getting-started/install/vagrant.md
@@ -34,11 +34,10 @@
         Port 22
     ```
 
-    > For users that have customized the IP address of their VM - either in a custom `Vagrantfile` or via the `DOKKU_IP` environment variable - and are not using `10.0.0.2` for the Vagrant IP, you'll need to instead use the output of `vagrant ssh-config dokku` for your ~/.ssh/config entry. 
+    > For users that have customized the IP address of their VM - either in a custom `Vagrantfile` or via the `DOKKU_IP` environment variable - and are not using `10.0.0.2` for the Vagrant IP, you'll need to instead use the output of `vagrant ssh-config dokku` for your `~/.ssh/config` entry. 
 
-- Copy your SSH key via `cat ~/.ssh/id_rsa.pub | pbcopy` and paste it into the dokku-installer at http://dokku.me . Change the `Hostname` field on the Dokku Setup screen to your domain and then check the box that says `Use virtualhost naming`. Then click *Finish Setup* to install your key. You'll be directed to application deployment instructions from here.
+- Copy your SSH key via `cat ~/.ssh/id_rsa.pub | pbcopy` and paste it into the dokku-installer at http://dokku.me . Change the `Hostname` field on the Dokku Setup screen to your domain and then check the box that says **Use virtualhost naming**. Then click **Finish Setup** to install your key. You'll be directed to application deployment instructions from here.
 
-Please note, the `dokku.me` domain is setup to point to `10.0.0.2` along with all subdomains (ie yourapp.dokku.me). If you change the `DOKKU_IP` in your vagrant setup you'll need to update your `/etc/hosts` file to point your reconfigured ip address.
+Please note, the `dokku.me` domain is setup to point to `10.0.0.2` along with all subdomains (i.e. `yourapp.dokku.me`). If you change the `DOKKU_IP` in your Vagrant setup you'll need to update your `/etc/hosts` file to point your reconfigured ip address.
 
 You are now ready to deploy an app or install plugins.
-

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ Dokku is designed for usage on a fresh VM installation, and should install all n
 
 #### 1. Install dokku
 
-To install the latest stable version of dokku, you can run the following shell commands:
+To install the latest stable version of Dokku, you can run the following shell commands:
 
 ```shell
 # for debian systems, installs Dokku via apt-get


### PR DESCRIPTION
Properly capitalise names and acronyms. Consistently use **bold** for UI text and _italics_ for general emphasis.

[ci skip]