### PR TITLE
Quiet ps:retire where possible

### DIFF
--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -93,24 +93,39 @@ help_desc
 
 fn-scheduler-docker-local-retire-container() {
   declare APP="$1" CID="$2" DEAD_TIME="$3"
+  local STATE
 
-  if ! docker inspect "${CID}" >/dev/null; then
+  STATE="$(docker inspect -f "{{ .State.Status }}" "$CID" 2>/dev/null || true)"
+  if [[ -z "$STATE" ]]; then
     return
   fi
 
   DOKKU_DOCKER_STOP_TIMEOUT="$(config_get "$APP" DOKKU_DOCKER_STOP_TIMEOUT || true)"
   [[ $DOKKU_DOCKER_STOP_TIMEOUT ]] && DOCKER_STOP_TIME_ARG="--time=${DOKKU_DOCKER_STOP_TIMEOUT}"
 
-  # Attempt to stop, if that fails, then force a kill as docker seems
-  # to not send SIGKILL as the docs would indicate. If that fails, move
-  # on to the next.
-  # shellcheck disable=SC2086
-  docker stop $DOCKER_STOP_TIME_ARG "$CID" \
-    || docker kill "$CID" \
-    || dokku_log_warn "Unable to kill container ${CID}"
+  if [[ "$STATE" == "restarting" ]]; then
+    docker update --restart=no "$CID" >/dev/null 2>&1
+  fi
 
-  if ! docker kill "$CID"; then
-    dokku_log_warn "Unable to kill container ${CID}"
+  if [[ "$STATE" != "dead" ]] && [[ "$STATE" != "exited" ]]; then
+    # Attempt to stop, if that fails, then force a kill as docker seems
+    # to not send SIGKILL as the docs would indicate. If that fails, move
+    # on to the next.
+    # shellcheck disable=SC2086
+    docker stop $DOCKER_STOP_TIME_ARG "$CID" \
+      || docker kill "$CID" \
+      || dokku_log_warn "Unable to kill container ${CID}"
+  fi
+
+  STATE="$(docker inspect -f "{{ .State.Status }}" "$CID" 2>/dev/null || true)"
+  if [[ -z "$STATE" ]]; then
+    return
+  fi
+
+  if [[ "$STATE" != "dead" ]] && [[ "$STATE" != "exited" ]]; then
+    if ! docker kill "$CID"; then
+      dokku_log_warn "Unable to kill container ${CID}"
+    fi
   fi
 }
 

--- a/plugins/scheduler-docker-local/scheduler-retire
+++ b/plugins/scheduler-docker-local/scheduler-retire
@@ -9,7 +9,7 @@ scheduler-docker-local-scheduler-retire() {
   declare trigger="scheduler-docker-local scheduler-retire"
 
   local DEAD_CONTAINER_FILE="${DOKKU_LIB_ROOT}/data/scheduler-docker-local/dead-containers"
-  local APP CID CURRENT_TIME DEAD_TIME
+  local APP CID CURRENT_TIME DEAD_TIME STATE
 
   if [[ ! -f "$DEAD_CONTAINER_FILE" ]]; then
     return
@@ -27,7 +27,13 @@ scheduler-docker-local-scheduler-retire() {
     fi
 
     fn-scheduler-docker-local-retire-container "$APP" "$CID" "$DEAD_TIME"
-    if docker ps -aq -f "id=${CID}" -f "status=running" >/dev/null 2>&1; then
+    STATE="$(docker inspect -f "{{ .State.Status }}" "$CID" 2>/dev/null || true)"
+    if [[ -z "$STATE" ]]; then
+      DEAD_CONTAINERS+=("$CID")
+      continue
+    fi
+
+    if [[ "$STATE" == "running" ]]; then
       dokku_log_warn "Container ${CID} still running"
       continue
     fi


### PR DESCRIPTION
- if a container doesn't exist, remove it from the dead container list
- ensure a restarting container is properly killed
- only attempt to stop/kill if the state is not dead or exited
- do not attempt to do anything if the container doesn't exist

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
