### PR TITLE
Correct early exit 1 in apps:report

### DIFF
--- a/plugins/apps/internal-functions
+++ b/plugins/apps/internal-functions
@@ -55,7 +55,7 @@ cmd-apps-report-single() {
       if [[ "$use_echo" ]]; then
         echo "not deployed"
       else
-        dokku_log_fail "not deployed"
+        dokku_log_exit "not deployed"
       fi
     fi
   else

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -108,6 +108,22 @@ dokku_log_warn() {
   echo " !     $*" 1>&2
 }
 
+dokku_log_exit_quiet() {
+  declare desc="log exit formatter"
+  if [[ -z "$DOKKU_QUIET_OUTPUT" ]]; then
+    echo "$@" 1>&2
+  fi
+  exit 0
+}
+
+dokku_log_exit() {
+  declare desc="log exit formatter"
+  if [[ -z "$DOKKU_QUIET_OUTPUT" ]]; then
+    echo "$@" 1>&2
+  fi
+  exit 0
+}
+
 dokku_log_fail_quiet() {
   declare desc="log fail formatter"
   if [[ -z "$DOKKU_QUIET_OUTPUT" ]]; then


### PR DESCRIPTION
Previously, if running 'dokku report --all', the early exit 1 in apps:report would cause the entire process to bail, resulting in a partial report. Instead, we exit 0, allowing plugn to continue.

Technically a non-deployed app is not an error case at this position.
