### PR TITLE
fix: permission denied when dokku clone

### DIFF
--- a/plugins/apps/subcommands/clone
+++ b/plugins/apps/subcommands/clone
@@ -39,7 +39,7 @@ apps_clone_cmd() {
 
   apps_create "$NEW_APP"
   pushd "$DOKKU_ROOT/$OLD_APP/." >/dev/null
-  find ./* -not \( -name .cache \) | grep -v "./cache" | cpio -pdmu --quiet "$DOKKU_ROOT/$NEW_APP"
+  find . \( -name "cache" \) -prune -o -print | cpio -pdmu --quiet "$DOKKU_ROOT/$NEW_APP"
   popd >/dev/null 2>&1 || pushd "/tmp" >/dev/null
   plugn trigger post-app-clone-setup "$OLD_APP" "$NEW_APP"
 


### PR DESCRIPTION
- OS: 18.04.1 LTS (Bionic Beaver)
- Shell: GNU bash, version 4.4.19(1)-release (x86_64-pc-linux-gnu)
- find version: find (GNU findutils) 4.7.0-git