### PR TITLE
Make installs quieter

### DIFF
--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -43,7 +43,7 @@ ExecStart=$dokku_path ps:restore
 WantedBy=docker.service
 EOF
   if command -v systemctl &>/dev/null; then
-    systemctl reenable dokku-redeploy
+    systemctl --quiet reenable dokku-redeploy
   fi
 fi
 

--- a/plugins/checks/install
+++ b/plugins/checks/install
@@ -12,15 +12,14 @@ migrate_checks_vars_0_5_0() {
 
   local app
 
-  dokku_log_info1 "Migrating zero downtime env variables to 0.5.x. The following variables have been deprecated"
-  dokku_log_info2 "DOKKU_SKIP_ALL_CHECKS DOKKU_SKIP_DEFAULT_CHECKS"
-  dokku_log_info2 "Please use dokku checks:[disable|enable] <app> to control zero downtime functionality"
-
   for app in $APPS; do
     local APP_SKIP_ALL_CHECKS=$(config_get "$app" DOKKU_SKIP_ALL_CHECKS || true)
     local APP_SKIP_DEFAULT_CHECKS=$(config_get "$app" DOKKU_SKIP_DEFAULT_CHECKS || true)
 
     if [[ "$APP_SKIP_ALL_CHECKS" == "true" ]] || [[ "$APP_SKIP_DEFAULT_CHECKS" == "true" ]] || [[ "$GLOBAL_SKIP_ALL_CHECKS" == "true" ]] || [[ "$GLOBAL_SKIP_DEFAULT_CHECKS" == "true" ]]; then
+      dokku_log_info1 "Migrating zero downtime env variables to 0.5.x. The following variables have been deprecated"
+      dokku_log_info2 "DOKKU_SKIP_ALL_CHECKS DOKKU_SKIP_DEFAULT_CHECKS"
+      dokku_log_info2 "Please use dokku checks:[disable|enable] <app> to control zero downtime functionality"
       dokku_log_info2 ""
       dokku_log_info2 "zero downtime checks disabled for app ($app)"
       config_set --no-restart "$app" DOKKU_CHECKS_ENABLED=0
@@ -34,11 +33,7 @@ migrate_checks_vars_0_5_0() {
     dokku_log_info1 "Removing global zero downtime settings"
     config_unset --global DOKKU_SKIP_ALL_CHECKS DOKKU_SKIP_DEFAULT_CHECKS
   fi
-  dokku_log_info2 "Migration complete"
-  dokku_log_info2 ""
 }
-
-migrate_checks_vars_0_5_0 "$@"
 
 migrate_checks_vars_0_6_0() {
   declare desc="migrates CHECKS config variables from 0.5.x to support fully-disabled zero-downtime checks"
@@ -46,11 +41,11 @@ migrate_checks_vars_0_6_0() {
 
   local app
 
-  dokku_log_info1 "Migrating zero downtime env variables to 0.6.x. The following variables will be migrated"
-  dokku_log_info2 "DOKKU_CHECKS_ENABLED -> DOKKU_CHECKS_SKIPPED"
   for app in $APPS; do
     local APP_DOKKU_CHECKS_ENABLED=$(config_get "$app" DOKKU_CHECKS_ENABLED || true)
     if [[ $APP_DOKKU_CHECKS_ENABLED ]]; then
+      dokku_log_info1 "Migrating zero downtime env variables to 0.6.x. The following variables will be migrated"
+      dokku_log_info2 "DOKKU_CHECKS_ENABLED -> DOKKU_CHECKS_SKIPPED"
       if [[ "$APP_DOKKU_CHECKS_ENABLED" == "0" ]]; then
         dokku_log_info2 ""
         dokku_log_info2 "zero downtime checks disabled for app ($app)"
@@ -59,8 +54,7 @@ migrate_checks_vars_0_6_0() {
       config_unset --no-restart "$app" DOKKU_CHECKS_ENABLED || true
     fi
   done
-  dokku_log_info2 "Migration complete"
-  dokku_log_info2 ""
 }
 
+migrate_checks_vars_0_5_0 "$@"
 migrate_checks_vars_0_6_0 "$@"

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -59,7 +59,7 @@ fi
 
 # revert dokku group changes
 gpasswd -a dokku adm
-chgrp -R adm /var/log/nginx
+chgrp --quiet -R adm /var/log/nginx
 gpasswd -M "$(egrep ^dokku: /etc/group | awk -F ":" '{ print $4 }')" dokku
 [[ -f /etc/logrotate.d/nginx ]] && sed -i -e 's/create 0640 www-data dokku/create 0640 www-data adm/g' /etc/logrotate.d/nginx
 
@@ -73,12 +73,14 @@ cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/500-error.html" "${DOKK
 [[ -f /etc/logrotate.d/nginx ]] && sed -i -e 's/invoke-rc.d/service/g' /etc/logrotate.d/nginx
 
 # @TODO: Remove this after a few versions
-dokku_log_info1 "Migrating DOKKU_NGINX env variables. The following variables will be migrated"
-dokku_log_info2 "DOKKU_NGINX_PORT -> DOKKU_PROXY_PORT"
-dokku_log_info2 "DOKKU_NGINX_SSL_PORT -> DOKKU_PROXY_SSL_PORT"
 for app in $(dokku_apps); do
   nginx_port="$(config_get "$app" DOKKU_NGINX_PORT || true)"
   nginx_ssl_port="$(config_get "$app" DOKKU_NGINX_SSL_PORT || true)"
+  if [[ -n "$nginx_port" ]] || [[ -n "$nginx_ssl_port" ]]; then
+    dokku_log_info1 "Migrating DOKKU_NGINX env variables. The following variables will be migrated"
+    dokku_log_info2 "DOKKU_NGINX_PORT -> DOKKU_PROXY_PORT"
+    dokku_log_info2 "DOKKU_NGINX_SSL_PORT -> DOKKU_PROXY_SSL_PORT"
+  fi
   if [[ -n "$nginx_port" ]]; then
     dokku_log_info1 "Migrating DOKKU_NGINX_PORT to DOKKU_PROXY_PORT for $app"
     config_set --no-restart "$app" DOKKU_PROXY_PORT="$nginx_port"
@@ -90,7 +92,6 @@ for app in $(dokku_apps); do
     config_unset --no-restart "$app" DOKKU_NGINX_SSL_PORT
   fi
 done
-dokku_log_info2 "Migration complete"
 
 case "$DOKKU_DISTRO" in
   debian)

--- a/plugins/scheduler-docker-local/install
+++ b/plugins/scheduler-docker-local/install
@@ -40,7 +40,7 @@ Description=Run dokku-retire.service every 5 minutes
 OnCalendar=*:0/5
 EOF
     if command -v systemctl &>/dev/null; then
-      systemctl reenable dokku-redeploy
+      systemctl --quiet reenable dokku-retire
     fi
   else
     cat <<EOF >/etc/cron.d/dokku-retire


### PR DESCRIPTION
This removes output from commands that otherwise should be silent - such as when not needing to migrate data.
