### PR TITLE
Drop universe installation in debian

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,7 +32,13 @@ install-requirements() {
   echo "--> Ensuring we have the proper dependencies"
 
   case "$DOKKU_DISTRO" in
-    debian | ubuntu)
+    debian)
+      if ! dpkg -l | grep -q software-properties-common; then
+        apt-get update -qq >/dev/null
+        apt-get -qq -y install software-properties-common
+      fi
+      ;;
+    ubuntu)
       if ! dpkg -l | grep -q software-properties-common; then
         apt-get update -qq >/dev/null
         apt-get -qq -y install software-properties-common


### PR DESCRIPTION
This doesn't exist for debian, and is fine to skip.

[ci skip]

