### PR TITLE
Fix Dokku installer checkbox for WebKit and Edge browsers

### DIFF
--- a/contrib/dokku-installer.py
+++ b/contrib/dokku-installer.py
@@ -357,7 +357,7 @@ PAGE = """
         $("#example").textContent = "http://"+$("#hostname").value+":<app-port>"
       }
     }
-    $("#vhost").addEventListener("input", update);
+    $("#vhost").addEventListener("change", update);
     $("#hostname").addEventListener("input", update);
     update();
   </script>


### PR DESCRIPTION
The `input` event does not fire for checkboxes on WebKit and Edge browsers (see [Can I Use](https://caniuse.com/#feat=input-event)).

Use `change` for cross browser support.