### PR TITLE
Start long running containers with --init

### DIFF
--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -91,16 +91,16 @@ scheduler-docker-local-scheduler-deploy() {
         START_CMD=$(fn-scheduler-docker-local-extract-start-cmd "$APP" "$PROC_TYPE" "$START_CMD" "$DOKKU_HEROKUISH" "$DOKKU_PORT")
         if [[ "$DOKKU_NETWORK_BIND_ALL" == "false" ]]; then
           # shellcheck disable=SC2086
-          cid=$(docker run $DOKKU_GLOBAL_RUN_ARGS -d -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
+          cid=$(docker run $DOKKU_GLOBAL_RUN_ARGS -d --init -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
         else
           # shellcheck disable=SC2086
-          cid=$(docker run $DOKKU_GLOBAL_RUN_ARGS -d $DOKKU_DOCKER_PORT_ARGS -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
+          cid=$(docker run $DOKKU_GLOBAL_RUN_ARGS -d --init $DOKKU_DOCKER_PORT_ARGS -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
         fi
       else
         START_CMD=$(fn-scheduler-docker-local-extract-start-cmd "$APP" "$PROC_TYPE" "$START_CMD" "$DOKKU_HEROKUISH")
 
         # shellcheck disable=SC2086
-        cid=$(docker run $DOKKU_GLOBAL_RUN_ARGS -d "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
+        cid=$(docker run $DOKKU_GLOBAL_RUN_ARGS -d --init "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
       fi
 
       ipaddr=$(plugn trigger network-get-ipaddr "$APP" "$PROC_TYPE" "$cid")


### PR DESCRIPTION
Processes not designed to run as PID 1 can leave zombie processes and not handle SIGTERM properly.

Start `docker run` with `--init` for deploys (long running containers) so child processes are properly reaped and the main process can shutdown gracefully.

See,
- [Official docs](https://docs.docker.com/engine/reference/run/#specify-an-init-process) for `--init`
- https://github.com/krallin/tini/issues/8#issuecomment-146135930 Great explanation of Tini, which powers `--init`
- [Best Practices for Building Containers](https://cloud.google.com/solutions/best-practices-for-building-containers#signal-handling) by Google