### PR TITLE
Only override the `WORKDIR` in copy_from_image if the image is `gliderlabs/herokuish` based

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -275,9 +275,13 @@ get_running_image_tag() {
 
 is_image_herokuish_based() {
   declare desc="returns true if app image is based on herokuish"
-  # circleci can't support --rm as they run lxc in lxc
-  [[ ! -f "/home/ubuntu/.circlerc" ]] && local DOCKER_ARGS="--rm"
-  docker run "$DOKKU_GLOBAL_RUN_ARGS" --entrypoint="/bin/sh" $DOCKER_ARGS "$@" -c "test -f /exec" &>/dev/null
+  declare IMAGE="$1"
+  local USER_VALUE
+
+  # due to how the build process works, all herokuish images have the Environment variable USER=herokuishuser
+  USER_VALUE="$(docker inspect -f '{{range .Config.Env}}{{if eq . "USER=herokuishuser" }}{{println .}}{{end}}{{end}}' "$IMAGE")"
+  [[ "$USER_VALUE" == "" ]] && return 1
+  return 0
 }
 
 get_docker_version() {
@@ -346,16 +350,21 @@ parse_args() {
 
 copy_from_image() {
   declare desc="copy file from named image to destination"
-  local IMAGE="$1"
-  local SRC_FILE="$2"
-  local DST_DIR="$3"
+  declare IMAGE="$1" SRC_FILE="$2" DST_DIR="$3"
+  local WORK_DIR=""
   verify_app_name "$APP"
 
   if verify_image "$IMAGE"; then
     if ! is_abs_path "$SRC_FILE"; then
-      local WORKDIR=$(docker inspect -f '{{.Config.WorkingDir}}' "$IMAGE")
-      [[ -z "$WORKDIR" ]] && local WORKDIR=/app
-      local SRC_FILE="$WORKDIR/$SRC_FILE"
+      if is_image_herokuish_based "$IMAGE"; then
+        WORKDIR="/app"
+      else
+        WORKDIR="$(docker inspect -f '{{.Config.WorkingDir}}' "$IMAGE")"
+      fi
+
+      if [[ -n "$WORKDIR" ]]; then
+        SRC_FILE="${WORKDIR}/${SRC_FILE}"
+      fi
     fi
     local CID=$(docker create "$DOKKU_GLOBAL_RUN_ARGS" "$IMAGE")
     docker cp "$CID:$SRC_FILE" "$DST_DIR"


### PR DESCRIPTION
Rather than always assuming a missing `WORKDIR` means herokuish, we instead inspect the image to verify that it is. If it is, then and _only_ then do we set WORKDIR. Otherwise, we respect the decision of `docker cp` to execute from within the last known `WORKDIR` context, which is inherited at the image level, not image metadata level.

Additionally, speed up `is_image_herokuish_based` by inspecting the environment variables on the image. When there is a "USER=herokuishuser", we can more or less safely assume it is an image that Dokku built, and is therefore a herokuish image. While possible, it would be very strange if a non-herokuish image had this environment variable set, so it is a relatively safe change.

Closes #3263
Closes #3274