### PR TITLE
feat: allow skipping aws releases for plugins

### DIFF
--- a/contrib/release-plugin
+++ b/contrib/release-plugin
@@ -53,7 +53,7 @@ fn-require-bin() {
 }
 
 main() {
-  local RELEASE="$1"
+  local RELEASE="$1" AWS_RELEASE="$2"
   local CURRENT_VERSION FILENAME NEXT_VERSION ORG_REPO_NAME REPO_NAME major minor patch
 
   if [[ -z "$RELEASE" ]]; then
@@ -91,20 +91,24 @@ EOF
 
   fn-require-bin "git"
 
+  if [[ "$AWS_RELEASE" != "true" ]] && [[ "$AWS_RELEASE" != "false" ]]; then
+    local AWS_RELEASE=true
+  fi
+
   if [[ "$CI" != "true" ]] && [[ -z "$DOKKU_PLUGIN_GITHUB_ACCESS_TOKEN" ]]; then
     log-info "You are running this without a DOKKU_PLUGIN_GITHUB_ACCESS_TOKEN environment variable."
     log-info "Doing so disables uploading releases to S3, which may be necessary for installing private plugins."
     while true; do
       read -rp "Do you wish to continue? " yn
       case $yn in
-        [Yy]*) break ;;
-        [Nn]*) exit ;;
-        *) echo "Please answer yes or no." ;;
+      [Yy]*) break ;;
+      [Nn]*) exit ;;
+      *) echo "Please answer yes or no." ;;
       esac
     done
   fi
 
-  if [[ -n "$DOKKU_PLUGIN_GITHUB_ACCESS_TOKEN" ]]; then
+  if [[ "$AWS_RELEASE" == "true" ]]; then
     fn-require-bin "aws"
     fn-require-bin "curl"
     if [[ -z "$DOKKU_PLUGIN_S3_BUCKET" ]]; then
@@ -156,7 +160,7 @@ EOF
   REPO_NAME="$(echo "$ORG_REPO_NAME" | cut -d'/' -f2)"
   FILENAME="${REPO_NAME}-${NEXT_VERSION}.tar.gz"
 
-  if [[ -n "$DOKKU_PLUGIN_GITHUB_ACCESS_TOKEN" ]]; then
+  if [[ "$AWS_RELEASE" == "true" ]]; then
     DOKKU_PLUGIN_S3_BUCKET="${DOKKU_PLUGIN_S3_BUCKET%/}"
     DOKKU_PLUGIN_S3_PATH="${DOKKU_PLUGIN_S3_PATH%/}"
     if [[ "$DOKKU_PLUGIN_S3_PATH" != "/" ]]; then


### PR DESCRIPTION
If there is no configured s3 bucket/path, avoid attempting to push when `true` is passed as the second argument.
