### PR TITLE
feat: update golang in use for binary building

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,4 +1,4 @@
 GO_REPO_ROOT := /go/src/github.com/dokku/dokku
-BUILD_IMAGE := golang:1.9.1
+BUILD_IMAGE := golang:1.12
 
 .PHONY: build-in-docker build clean src-clean


### PR DESCRIPTION
This change is not necessary other than for good house-keeping. All dokku-related binaries should _also_ be built with the latest golang.
