### PR TITLE
chore: drop plugn package building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 DOKKU_VERSION ?= master
 
 PROCFILE_VERSION ?= 0.6.0
+PLUGN_VERSION ?= 0.3.2
 SSHCOMMAND_URL ?= https://raw.githubusercontent.com/dokku/sshcommand/v0.7.0/sshcommand
 PROCFILE_UTIL_URL ?= https://github.com/josegonzalez/go-procfile-util/releases/download/v${PROCFILE_VERSION}/procfile-util_${PROCFILE_VERSION}_linux_x86_64.tgz
-PLUGN_URL ?= https://github.com/dokku/plugn/releases/download/v0.3.0/plugn_0.3.0_linux_x86_64.tgz
+PLUGN_URL ?= https://github.com/dokku/plugn/releases/download/v${PLUGN_VERSION}/plugn_${PLUGN_VERSION}_linux_x86_64.tgz
 SIGIL_URL ?= https://github.com/gliderlabs/sigil/releases/download/v0.4.0/sigil_0.4.0_Linux_x86_64.tgz
 STACK_URL ?= https://github.com/gliderlabs/herokuish.git
 PREBUILT_STACK_URL ?= gliderlabs/herokuish:latest

--- a/contrib/build-dokku.Dockerfile
+++ b/contrib/build-dokku.Dockerfile
@@ -36,7 +36,7 @@ RUN PLUGIN_MAKE_TARGET=${PLUGIN_MAKE_TARGET} \
     SKIP_GO_CLEAN=true \
     make version copyfiles \
     && rm -rf plugins/common/*.go  plugins/common/glide*  plugins/common/vendor/ \
-    && make deb-dokku deb-plugn deb-sshcommand deb-sigil \
-            rpm-dokku rpm-plugn rpm-sshcommand rpm-sigil
+    && make deb-dokku deb-sshcommand deb-sigil \
+            rpm-dokku rpm-sshcommand rpm-sigil
 
 RUN ls -lha /tmp/

--- a/deb.mk
+++ b/deb.mk
@@ -16,18 +16,6 @@ DOKKU_UPDATE_VERSION ?= 0.1.0
 DOKKU_UPDATE_ARCHITECTURE = amd64
 DOKKU_UPDATE_PACKAGE_NAME = dokku-update_$(DOKKU_UPDATE_VERSION)_$(DOKKU_UPDATE_ARCHITECTURE).deb
 
-define PLUGN_DESCRIPTION
-Hook system that lets users extend your application with plugins
-Plugin triggers are simply scripts that are executed by the system.
-You can use any language you want, so long as the script is
-executable and has the proper language requirements installed
-endef
-PLUGN_REPO_NAME ?= dokku/plugn
-PLUGN_VERSION ?= 0.3.0
-PLUGN_ARCHITECTURE = amd64
-PLUGN_PACKAGE_NAME = plugn_$(PLUGN_VERSION)_$(PLUGN_ARCHITECTURE).deb
-PLUGN_URL = https://github.com/dokku/plugn/releases/download/v$(PLUGN_VERSION)/plugn_$(PLUGN_VERSION)_linux_x86_64.tgz
-
 define SSHCOMMAND_DESCRIPTION
 Turn SSH into a thin client specifically for your app
 Simplifies running a single command over SSH, and
@@ -56,11 +44,10 @@ ifndef IS_RELEASE
 	IS_RELEASE = true
 endif
 
-export PLUGN_DESCRIPTION
 export SIGIL_DESCRIPTION
 export SSHCOMMAND_DESCRIPTION
 
-.PHONY: install-from-deb deb-all deb-herokuish deb-dokku deb-dokku-update deb-plugn deb-setup deb-sshcommand deb-sigil
+.PHONY: install-from-deb deb-all deb-herokuish deb-dokku deb-dokku-update deb-setup deb-sshcommand deb-sigil
 
 install-from-deb:
 	@echo "--> Initial apt-get update"
@@ -76,7 +63,7 @@ install-from-deb:
 	sudo apt-get update -qq >/dev/null
 	sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -yy dokku
 
-deb-all: deb-setup deb-herokuish deb-dokku deb-plugn deb-sshcommand deb-sigil deb-dokku-update
+deb-all: deb-setup deb-herokuish deb-dokku deb-sshcommand deb-sigil deb-dokku-update
 	mv $(BUILD_DIRECTORY)/*.deb .
 	@echo "Done"
 
@@ -174,29 +161,6 @@ deb-dokku-update:
 			 --license 'MIT License' \
 			 contrib/dokku-update=/usr/local/bin/dokku-update \
 			 contrib/dokku-update-version=/var/lib/dokku-update/VERSION
-
-deb-plugn:
-	rm -rf /tmp/tmp /tmp/build $(PLUGN_PACKAGE_NAME)
-	mkdir -p /tmp/tmp /tmp/build /tmp/build/usr/bin
-
-	@echo "-> Downloading package"
-	wget -q -O /tmp/tmp/plugn-$(PLUGN_VERSION).tgz $(PLUGN_URL)
-	cd /tmp/tmp/ && tar zxf /tmp/tmp/plugn-$(PLUGN_VERSION).tgz
-
-	@echo "-> Copying files into place"
-	cp /tmp/tmp/plugn /tmp/build/usr/bin/plugn && chmod +x /tmp/build/usr/bin/plugn
-
-	@echo "-> Creating $(PLUGN_PACKAGE_NAME)"
-	sudo fpm -t deb -s dir -C /tmp/build -n plugn \
-			 --version $(PLUGN_VERSION) \
-			 --architecture $(PLUGN_ARCHITECTURE) \
-			 --package $(BUILD_DIRECTORY)/$(PLUGN_PACKAGE_NAME) \
-			 --url "https://github.com/$(PLUGN_REPO_NAME)" \
-			 --maintainer "Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>" \
-			 --category utils \
-			 --description "$$PLUGN_DESCRIPTION" \
-			 --license 'MIT License' \
-			 .
 
 deb-sshcommand:
 	rm -rf /tmp/tmp /tmp/build $(SSHCOMMAND_PACKAGE_NAME)

--- a/rpm.mk
+++ b/rpm.mk
@@ -2,13 +2,12 @@ RPM_ARCHITECTURE = x86_64
 DOKKU_RPM_PACKAGE_NAME = dokku-$(DOKKU_VERSION)-1.$(RPM_ARCHITECTURE).rpm
 DOKKU_UPDATE_RPM_PACKAGE_NAME = dokku-update-$(DOKKU_UPDATE_VERSION)-1.$(RPM_ARCHITECTURE).rpm
 HEROKUISH_RPM_PACKAGE_NAME = herokuish-$(HEROKUISH_VERSION)-1.$(RPM_ARCHITECTURE).rpm
-PLUGN_RPM_PACKAGE_NAME = plugn-$(PLUGN_VERSION)-1.$(RPM_ARCHITECTURE).rpm
 SSHCOMMAND_RPM_PACKAGE_NAME = sshcommand-$(SSHCOMMAND_VERSION)-1.$(RPM_ARCHITECTURE).rpm
 SIGIL_RPM_PACKAGE_NAME = gliderlabs-sigil-$(SIGIL_VERSION)-1.$(RPM_ARCHITECTURE).rpm
 
 .PHONY: rpm-all
 
-rpm-all: rpm-setup rpm-herokuish rpm-dokku rpm-plugn rpm-sshcommand rpm-sigil rpm-dokku-update
+rpm-all: rpm-setup rpm-herokuish rpm-dokku rpm-sshcommand rpm-sigil rpm-dokku-update
 	mv /tmp/*.rpm .
 	@echo "Done"
 
@@ -129,28 +128,6 @@ rpm-dokku-update:
 			 --license 'MIT License' \
 			 contrib/dokku-update=/usr/local/bin/dokku-update \
 			 contrib/dokku-update-version=/var/lib/dokku-update/VERSION
-
-rpm-plugn:
-	rm -rf /tmp/tmp /tmp/build $(BUILD_DIRECTORY)/$(PLUGN_RPM_PACKAGE_NAME)
-	mkdir -p /tmp/tmp /tmp/build /tmp/build/usr/bin
-
-	@echo "-> Downloading package"
-	wget -q -O /tmp/tmp/plugn-$(PLUGN_VERSION).tgz $(PLUGN_URL)
-	cd /tmp/tmp/ && tar zxf /tmp/tmp/plugn-$(PLUGN_VERSION).tgz
-
-	@echo "-> Copying files into place"
-	cp /tmp/tmp/plugn /tmp/build/usr/bin/plugn && chmod +x /tmp/build/usr/bin/plugn
-
-	@echo "-> Creating $(PLUGN_RPM_PACKAGE_NAME)"
-	sudo fpm -t rpm -s dir -C /tmp/build -n plugn \
-			 --version $(PLUGN_VERSION) \
-			 --architecture $(RPM_ARCHITECTURE) \
-			 --package $(BUILD_DIRECTORY)/$(PLUGN_RPM_PACKAGE_NAME) \
-			 --url "https://github.com/$(PLUGN_REPO_NAME)" \
-			 --category utils \
-			 --description "$$PLUGN_DESCRIPTION" \
-			 --license 'MIT License' \
-			 .
 
 rpm-sshcommand:
 	rm -rf /tmp/tmp /tmp/build $(BUILD_DIRECTORY)/$(SSHCOMMAND_RPM_PACKAGE_NAME)

--- a/tests/ci/setup.sh
+++ b/tests/ci/setup.sh
@@ -9,7 +9,7 @@ install_dependencies() {
   HEROKUISH_PACKAGE_NAME="herokuish_${HEROKUISH_VERSION}_amd64.deb"
   curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/herokuish_${HEROKUISH_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${HEROKUISH_PACKAGE_NAME}"
 
-  PLUGN_VERSION=$(grep PLUGN_VERSION "${ROOT_DIR}/deb.mk" | head -n1 | cut -d' ' -f3)
+  PLUGN_VERSION=$(grep PLUGN_VERSION "${ROOT_DIR}/Makefile" | head -n1 | cut -d' ' -f3)
   PLUGN_PACKAGE_NAME="plugn_${PLUGN_VERSION}_amd64.deb"
   curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/plugn_${PLUGN_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PLUGN_PACKAGE_NAME}"
 


### PR DESCRIPTION
The dokku/plugn project now builds and releases it's own packages on release creation.

Also upgrade to latest plugn version, 0.3.2
