### PR TITLE
Turn off logging for nginx validate configuration

### DIFF
--- a/plugins/nginx-vhosts/templates/validate.conf.sigil
+++ b/plugins/nginx-vhosts/templates/validate.conf.sigil
@@ -1,2 +1,6 @@
 events { worker_connections 768; }
-http { include {{ $.NGINX_CONF }}; }
+http {
+  access_log off;
+  error_log /dev/null;
+  include {{ $.NGINX_CONF }};
+}


### PR DESCRIPTION
This will allow validation to work if the default logging locations cannot be written to but the configuration is otherwise okay. This will be the case for users with custom nginx configurations that log to other places, such as syslog.
