### PR TITLE
feat: upgrade herokuish to 0.5.0 (Ubuntu 18.04)

### DIFF
--- a/deb.mk
+++ b/deb.mk
@@ -2,7 +2,7 @@ BUILD_DIRECTORY ?= /tmp
 
 HEROKUISH_DESCRIPTION = 'Herokuish uses Docker and Buildpacks to build applications like Heroku'
 HEROKUISH_REPO_NAME ?= gliderlabs/herokuish
-HEROKUISH_VERSION ?= 0.4.9
+HEROKUISH_VERSION ?= 0.5.0
 HEROKUISH_ARCHITECTURE = amd64
 HEROKUISH_PACKAGE_NAME = herokuish_$(HEROKUISH_VERSION)_$(HEROKUISH_ARCHITECTURE).deb
 


### PR DESCRIPTION
This moves the base image from Xenial to Bionic, which is the latest supported LTS release of Ubuntu. Note that all previous releases of herokuish are no longer supported, and users are encouraged to upgrade where possible.

In the case of upgrades, a 'dokku repo:purge-cache APP' should be called for each app, or built applications may include code linked to non-ABI compatible libraries due to the OS upgrade.

This sort of change is usually performed _only_ during a minor release, but as the window since the release is fairly small, the risk to our users is negligible in comparison to the inability to stay on a maintained herokuish release.
