### PR TITLE
Allow reporting domains when there are none specified

### DIFF
--- a/plugins/domains/internal-functions
+++ b/plugins/domains/internal-functions
@@ -63,7 +63,6 @@ cmd-domains-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/tests/unit/20_domains.bats
+++ b/tests/unit/20_domains.bats
@@ -173,6 +173,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
+  run /bin/bash -c "dokku domains:report $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku domains:clear $TEST_APP"
   echo "output: $output"
   echo "status: $status"
@@ -183,6 +188,11 @@ teardown() {
   echo "status: $status"
   assert_success
   refute_line test.app.dokku.me
+
+  run /bin/bash -c "dokku domains:report $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 }
 
 @test "(domains) domains:add-global" {


### PR DESCRIPTION
This previously bailed if the response was empty, which in this case is incorrect, as the response isn't based on whether the app is deployed or not.
