### PR TITLE
Always allow ps:scale proc=0

### DIFF
--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -100,7 +100,7 @@ set_scale() {
   for procscale in "${SCALE_SETTINGS[@]}"; do
     local PROC_NAME=${procscale%%=*}
     local PROC_COUNT=${procscale#*=}
-    if [[ -f "$DOKKU_PROCFILE" ]] && ! procfile-util exists --procfile "$DOKKU_PROCFILE" --process-type "$PROC_NAME" >/dev/null 2>&1; then
+    if [[ -f "$DOKKU_PROCFILE" ]] && [[ "$PROC_COUNT" != "0" ]] && ! procfile-util exists --procfile "$DOKKU_PROCFILE" --process-type "$PROC_NAME" >/dev/null 2>&1; then
       dokku_log_fail "${PROC_NAME} is not a valid process name"
     fi
     is_number "$PROC_COUNT" || dokku_log_fail "ps:scale $PROC_COUNT is not a number"

--- a/tests/unit/10_ps-herokuish.bats
+++ b/tests/unit/10_ps-herokuish.bats
@@ -109,11 +109,11 @@ teardown() {
     assert_success
   done
 
-  run /bin/bash -c "dokku ps:scale $TEST_APP web=0 worker=0"
+  run /bin/bash -c "dokku ps:scale $TEST_APP web=0 worker=0 invalid-process=0"
   echo "output: $output"
   echo "status: $status"
   assert_success
-  for PROC_TYPE in web worker; do
+  for PROC_TYPE in web worker invalid-process; do
     CIDS=""
     shopt -s nullglob
     for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.$PROC_TYPE.*; do


### PR DESCRIPTION
With the introduciton of procfile-util, scaling a non-existent process to 0 was disabled. This brings back that functionality, allowing users to scale all processes to 0. This is especially useful when a user has accidentally scaled a non-existent process up, causing deploys to fail without any way to revert outside of manually editing files.

Closes #3428
