### PR TITLE
Add a trigger to fetch the git revision

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -381,6 +381,21 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 since it does not get called for commands that use `git-upload-archive` such
 as `git archive`. Instead, use the [`user-auth`](#user-auth) trigger.
 
+### `git-revision`
+
+- Description: Allows you to fetch the current git revision for a given application
+- Invoked by:
+- Arguments: `$APP`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+# TODO
+```
+
 ### `install`
 
 - Description: Used to setup any files/configuration for a plugin.

--- a/plugins/git/git-revision
+++ b/plugins/git/git-revision
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-git-git-revision() {
+  declare desc="fetches the current git revision value for an application"
+  declare APP="$1"
+
+  ENV_VAR_NAME="$(fn-plugin-property-get "git" "$APP" "rev-env-var")"
+  if [[ -z "$ENV_VAR_NAME" ]] && ! fn-plugin-property-exists "git" "$APP" "rev-env-var"; then
+    ENV_VAR_NAME="GIT_REV"
+  fi
+
+  if [[ -z "$ENV_VAR_NAME" ]]; then
+    return
+  fi
+
+  config_get "$APP" "$ENV_VAR_NAME" || true
+}
+
+trigger-git-git-revision "$@"


### PR DESCRIPTION
This allows other plugins to fetch the current git revision without needing to duplicate logic from the git plugin.

Closes #3484
