### PR TITLE
Fix GitLab CI examples

### DIFF
--- a/docs/community/tutorials/deploying-with-gitlab-ci.md
+++ b/docs/community/tutorials/deploying-with-gitlab-ci.md
@@ -65,7 +65,7 @@ review_app:
   image: ilyasemenov/gitlab-ci-git-push
   stage: deploy
   environment:
-    name: review/$CI_ENVIRONMENT_SLUG
+    name: review/$CI_COMMIT_REF_NAME
     url: https://$CI_ENVIRONMENT_SLUG.dokku.me/
     on_stop: stop_review_app
   only:
@@ -88,7 +88,7 @@ stop_review_app:
   image: ilyasemenov/gitlab-ci-git-push
   stage: deploy
   environment:
-    name: review/$CI_ENVIRONMENT_SLUG
+    name: review/$CI_COMMIT_REF_NAME
     action: stop
   when: manual
   script:


### PR DESCRIPTION
The GitLab CI examples used `$CI_ENVIRONMENT_SLUG` for defining the environment names
of the deploy jobs. But this variable is actually the OUTPUT of setting the environment name,
thus, it tries to reference itself, but does not exist in that moment.

The correct way to set this is to use `$CI_COMMIT_REF_NAME` as based on the documentation
of GitLab's dynamic environments.
