### PR TITLE
Remove SPONSORS doc in favor of OpenCollective

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,7 +1,0 @@
-# Sponsors
-
-[Deis](http://deis.io)
-
-[DigitalOcean](https://www.digitalocean.com/)
-
-[Melvin Lammerts](http://dokku.net)


### PR DESCRIPTION
This was a very incomplete list. Public sponsors for the project can be found on OpenCollective.
