### PR TITLE
Support installing plugins via file:// scheme

### DIFF
--- a/plugins/plugin/subcommands/install
+++ b/plugins/plugin/subcommands/install
@@ -13,7 +13,7 @@ plugin_install_cmd() {
       [[ "$#" -gt 2 ]] && dokku_log_info1_quiet "Cannot install additional core plugins, running core plugin install trigger"
       PLUGIN_PATH="$PLUGIN_CORE_PATH" plugn trigger install
       ;;
-    https:* | git* | ssh:* | *.tar.gz | *.tgz)
+    https:* | git* | ssh:* | file:* | *.tar.gz | *.tgz)
       shift
       download_and_enable_plugin "$@"
       plugn trigger install

--- a/tests/unit/40_plugin.bats
+++ b/tests/unit/40_plugin.bats
@@ -3,13 +3,20 @@
 load test_helper
 TEST_PLUGIN_NAME=smoke-test-plugin
 TEST_PLUGIN_GIT_REPO=https://github.com/dokku/${TEST_PLUGIN_NAME}.git
+TEST_PLUGIN_LOCAL_REPO="$(mktemp -d)/$TEST_PLUGIN_NAME"
+
+clone_test_plugin() {
+  git clone "$TEST_PLUGIN_GIT_REPO" "$TEST_PLUGIN_LOCAL_REPO"
+}
 
 setup() {
   global_setup
+  clone_test_plugin
 }
 
 remove_test_plugin() {
   rm -rf $PLUGIN_ENABLED_PATH/$TEST_PLUGIN_NAME $PLUGIN_AVAILABLE_PATH/$TEST_PLUGIN_NAME
+  rm -rf $TEST_PLUGIN_LOCAL_REPO
 }
 
 teardown() {
@@ -19,6 +26,48 @@ teardown() {
 
 @test "(plugin) plugin:install, plugin:disable, plugin:update plugin:uninstall" {
   run /bin/bash -c "dokku plugin:install $TEST_PLUGIN_GIT_REPO --name $TEST_PLUGIN_NAME"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku plugin:update $TEST_PLUGIN_NAME"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "sudo -E -u nobody dokku plugin:uninstall $TEST_PLUGIN_NAME"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+
+  run /bin/bash -c "dokku plugin:disable $TEST_PLUGIN_NAME"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku plugin | grep disabled | grep $TEST_PLUGIN_NAME"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku plugin:uninstall $TEST_PLUGIN_NAME"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku plugin | grep $TEST_PLUGIN_NAME"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+}
+
+@test "(plugin) plugin:install, plugin:disable, plugin:update plugin:uninstall (with file://)" {
+  run /bin/bash -c "dokku plugin:install file://$TEST_PLUGIN_LOCAL_REPO --name $TEST_PLUGIN_NAME"
   echo "output: $output"
   echo "status: $status"
   assert_success


### PR DESCRIPTION
This commit make it possible to install plugins via local git repositories that are accessed with the `file:` scheme.

In that case one has to point to the `.git` folder:
```
dokku plugin:install file:///path/to/the/repo/.git --name my-best-plugin
```