### PR TITLE
Add GitLab GIT_STRATEGY for stop_preview_app

### DIFF
--- a/docs/community/tutorials/deploying-with-gitlab-ci.md
+++ b/docs/community/tutorials/deploying-with-gitlab-ci.md
@@ -87,6 +87,8 @@ The above only runs for non-master branches, and will _also_ trigger an `on_stop
 stop_review_app:
   image: ilyasemenov/gitlab-ci-git-push
   stage: deploy
+  variables:
+    GIT_STRATEGY: none
   environment:
     name: review/$CI_COMMIT_REF_NAME
     action: stop


### PR DESCRIPTION
Use `GIT_STRATEGY: none` in `stop_review_app` to make job work after successful
merges and when the branch was deleted.

Without this, the application is not stopped when the branch is deleted on merge as the runner pulls the git repository by default, but cannot find the tree in this moment.