### PR TITLE
add multi dockerfile plugin to plugins.md

### DIFF
--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -57,6 +57,7 @@ The following plugins are available and provided by Dokku maintainers. Where not
 [Aluxian]: https://github.com/Aluxian
 [Aomitayo]: https://github.com/Aomitayo
 [apmorton]: https://github.com/apmorton
+[artofrawr]: https://github.com/artofrawr
 [basgys]: https://github.com/basgys
 [Benjamin-Dobell]: https://github.com/Benjamin-Dobell
 [blag]: https://github.com/blag
@@ -229,6 +230,7 @@ The following plugins are available and provided by Dokku maintainers. Where not
 | [Long Timeout](https://github.com/investtools/dokku-long-timeout-plugin)                          | [investtools][]       | 0.4.0+                |
 | [Monit](https://github.com/cjblomqvist/dokku-monit)                                               | [cjblomqvist][]       | 0.3.x                 |
 | [Monorepo](https://github.com/iamale/dokku-monorepo)                                              | [iamale][]            | 0.4.0+                |
+| [Multi Dockerfile](https://github.com/artofrawr/dokku-multi-dockerfile)                           | [artofrawr][]         | 0.4.0+                |
 | [Node](https://github.com/ademuk/dokku-nodejs)                                                    | [ademuk][]            | 0.3.x                 |
 | [Node](https://github.com/pnegahdar/dokku-node)                                                   | [pnegahdar][]         | 0.3.x                 |
 | [Rollbar](https://github.com/iloveitaly/dokku-rollbar)                                            | [iloveitaly][]        | 0.5.0+                |


### PR DESCRIPTION
[ci skip]

This [plugin](https://github.com/artofrawr/dokku-multi-dockerfile) is useful for projects where you want to use multiple Dockerfiles and choose one based on which app you're deploying to. 

One use case would be a web app that has a main Dockerfile and a second to deploy the app's [storybook](https://storybook.js.org) using the same codebase. 

```
$ ls
.dokku-multi-dockerfile
Dockerfile
Dockerfile.storybook
```

The file .dokku-multi-dockerfile determines which Dockerfile is used for which app:
```
app=Dockerfile
stories=Dockerfile.storybook
```

The part before `=` is used to identify the dokku application. For example, here:
```
$ git remote -v
website             dokku@dokku.me:app
storybook         dokku@dokku.me:stories
```

The dokku application `app` will be built with `Dockerfile`.
The dokku application `stories` will be built with `Dockerfile.storybook`. 

When you push the code to an application's remote, the correct Dockerfile gets detected for you:
```
$ git push storybook master
Counting objects: 253, done.
Writing objects: 100% (253/253), 38.27 KiB | 0 bytes/s, done.
Total 253 (delta 117), reused 233 (delta 109)
=====> Multi Dockerfile Project detected
=====> Installing with Dockerfile.storybook
-----> Cleaning up...
       ...
```