### PR TITLE
refactor: allow the scheduler to decide if an app is deployed

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1320,6 +1320,24 @@ DOKKU_SCHEDULER="$1"; APP="$2";
 # TODO
 ```
 
+### `scheduler-is-deployed`
+
+> Warning: The scheduler plugin trigger apis are under development and may change
+> between minor releases until the 1.0 release.
+
+- Description: Allows you to check if an app has been deployed
+- Invoked by: `dokku ps:rebuild`
+- Arguments: `$DOKKU_SCHEDULER $APP`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+DOKKU_SCHEDULER="$1"; APP="$2";
+
+# TODO
+```
 ### `scheduler-logs`
 
 > Warning: The scheduler plugin trigger apis are under development and may change

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -450,14 +450,10 @@ get_app_running_container_types() {
 is_deployed() {
   declare desc="return 0 if given app has a running container"
   local APP="$1"
-  if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]] || [[ $(
-    ls "$DOKKU_ROOT/$APP"/CONTAINER.* &>/dev/null
-    echo $?
-  ) -eq 0 ]]; then
-    return 0
-  else
-    return 1
-  fi
+  source "$PLUGIN_AVAILABLE_PATH/config/functions"
+
+  local DOKKU_SCHEDULER=$(get_app_scheduler "$APP")
+  plugn trigger scheduler-is-deployed "$DOKKU_SCHEDULER" "$APP"
 }
 
 is_container_running() {

--- a/plugins/scheduler-docker-local/scheduler-is-deployed
+++ b/plugins/scheduler-docker-local/scheduler-is-deployed
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+scheduler-docker-local-scheduler-is-deployed() {
+  declare desc="checks if an app is deployed"
+  declare DOKKU_SCHEDULER="$1" APP="$2"
+
+  if [[ "$DOKKU_SCHEDULER" != "docker-local" ]]; then
+    return
+  fi
+
+  if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]] || [[ $(
+    ls "$DOKKU_ROOT/$APP"/CONTAINER.* &>/dev/null
+    echo $?
+  ) -eq 0 ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+scheduler-docker-local-scheduler-is-deployed "$@"


### PR DESCRIPTION
Without moving this to the scheduler, all applications are assumed to not be deployed unless the scheduler is set to docker-local.

Closes #3531
