### PR TITLE
feat: silence dokku run 'errors'

### DIFF
--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -47,11 +47,11 @@ scheduler-docker-local-scheduler-run() {
   DOKKU_QUIET_OUTPUT=1 extract_procfile "$APP"
 
   POTENTIAL_PROCFILE_KEY="$1"
-  PROC_CMD=$(get_cmd_from_procfile "$APP" "$POTENTIAL_PROCFILE_KEY" || echo '')
+  PROC_CMD=$(get_cmd_from_procfile "$APP" "$POTENTIAL_PROCFILE_KEY" 2>/dev/null || echo '')
   remove_procfile "$APP"
 
   if [[ -n "$PROC_CMD" ]]; then
-    dokku_log_info1 "Found '$POTENTIAL_PROCFILE_KEY' in Procfile, running that command"
+    dokku_log_info1_quiet "Found '$POTENTIAL_PROCFILE_KEY' in Procfile, running that command"
     set -- "$PROC_CMD" "${@:2}"
   fi
 


### PR DESCRIPTION
In certain cases, a command can be specified but found - or not - in the Procfile, resulting in unnecessary output for cron tasks.

Closes #3522

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
