### PR TITLE
Do not append the global domain for matching subdomains

### DIFF
--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -27,21 +27,10 @@ scheme://subdomain.domain.tld
 
 The `subdomain` is inferred from the pushed application name, while the `domain.tld` is set during initial dokku configuration. It can then be modified with `dokku domains:add-global` and `dokku domains:remove-global`. This value is used as a default TLD for all applications on a host.
 
-If a FQDN such as `other.tld` is used as the application name, the global virtualhost will be ignored and the resulting vhost URL for that application will be `other.tld`. The exception to this rule being that if the FQDN has the same ending as the default vhost (such as `subdomain.domain.tld`), then the entire FQDN will be treated as a subdomain. The application will therefore be deployed at `subdomain.domain.tld.domain.tld`.
+If an FQDN such as `dokku.org` is used as the application name, the global virtualhost will be ignored and the resulting vhost URL for that application will be `dokku.org`.
 
-You can optionally override this in a plugin by implementing the `nginx-hostname` plugin trigger. For example, you can reverse the subdomain with the following sample `nginx-hostname` plugin trigger:
+You can optionally override this in a plugin by implementing the `nginx-hostname` plugin trigger. If the `nginx-hostname` plugin has no output, the normal hostname algorithm will be executed. See the [plugin trigger documentation](/docs/development/plugin-triggers.md#nginx-hostname) for more information.
 
-```shell
-#!/usr/bin/env bash
-set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-
-APP="$1"; SUBDOMAIN="$2"; VHOST="$3"
-
-NEW_SUBDOMAIN=`echo $SUBDOMAIN | rev`
-echo "$NEW_SUBDOMAIN.$VHOST"
-```
-
-If the `nginx-hostname` plugin has no output, the normal hostname algorithm will be executed.
 
 ## Disabling VHOSTS
 

--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -249,7 +249,7 @@ get_default_vhosts() {
         local SUBDOMAIN=${APP/%\.${VHOST}/}
         local hostname=$(: | plugn trigger nginx-hostname "$APP" "$SUBDOMAIN" "$VHOST")
         if [[ -z $hostname ]]; then
-          if [[ "$APP" == *.* ]] && [[ "$SUBDOMAIN" == "$APP" ]]; then
+          if [[ "$APP" == *.* ]]; then
             local hostname="${APP/\//-}"
           else
             local hostname="${APP/\//-}.$VHOST"

--- a/plugins/domains/internal-functions
+++ b/plugins/domains/internal-functions
@@ -44,13 +44,13 @@ cmd-domains-report-single() {
     verify_app_name "$APP"
     app_flags=(
       "--domains-app-enabled: $(fn-domains-app-enabled "$APP")"
-      "--domains-app-vhosts: $(fn-domains-app-vhosts "$APP")"
+      "--domains-app-vhosts: $(fn-domains-app-vhosts "$APP" | awk '{$1=$1};1')"
     )
   fi
 
   global_flags=(
     "--domains-global-enabled: $(fn-domains-global-enabled)"
-    "--domains-global-vhosts: $(fn-domains-global-vhosts)"
+    "--domains-global-vhosts: $(fn-domains-global-vhosts | awk '{$1=$1};1')"
   )
 
   flag_map=("${app_flags[@]}" "${global_flags[@]}")

--- a/tests/unit/20_domains.bats
+++ b/tests/unit/20_domains.bats
@@ -284,3 +284,22 @@ teardown() {
   assert_line ${TEST_APP}.global3.dokku.me
   assert_line ${TEST_APP}.global4.dokku.me
 }
+
+@test "(domains) app name overlaps with global domain.tld" {
+  run /bin/bash -c "dokku domains:set-global dokku.test"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # run domains:clear in order to invoke default vhost creation
+  dokku --quiet apps:create test.dokku.test
+  dokku --quiet domains:clear test.dokku.test
+
+  run /bin/bash -c "dokku domains:report test.dokku.test --domains-app-vhosts"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "test.dokku.test"
+
+  dokku --force apps:destroy test.dokku.test
+}


### PR DESCRIPTION
If the subdomain is url-like, assume it is a valid url and use it for the default domain name. This allows users to specify the default domain for an app even if that is a subdomain of a global vhost.

Closes #3529
