### PR TITLE
feat: add ability to trigger an arbitrary plugin hook

### DIFF
--- a/docs/advanced-usage/plugin-management.md
+++ b/docs/advanced-usage/plugin-management.md
@@ -8,6 +8,7 @@ plugin:enable <name>                     # Enable a previously disabled plugin
 plugin:install [--core|git-url [--committish tag|branch|commit|--name custom-plugin-name]]           # Optionally download git-url (with custom tag/committish) & run install trigger for active plugins (or only core ones)
 plugin:install-dependencies [--core]     # Run install-dependencies trigger for active plugins (or only core ones)
 plugin:list                              # Print active plugins
+plugin:trigger <args...>.                # Trigger an arbitrary plugin hook
 plugin:uninstall <name>                  # Uninstall a plugin (third-party only)
 plugin:update [name [committish]]        # Optionally update named plugin from git (with custom tag/committish) & run update trigger for active plugins
 ```

--- a/plugins/plugin/commands
+++ b/plugins/plugin/commands
@@ -8,13 +8,14 @@ case "$1" in
     help_content_func() {
       declare desc="return plugin plugin help content"
       cat <<help_content
-    plugin:list, Print active plugins
+    plugin:disable <name>, Disable an installed plugin (third-party only)
+    plugin:enable <name>, Enable a previously disabled plugin
     plugin:install [--core|git-url [--committish tag|branch|commit|--name custom-plugin-name]], Optionally download git-url (with custom tag/committish) & run install trigger for active plugins (or only core ones)
     plugin:install-dependencies [--core], Run install-dependencies trigger for active plugins (or only core ones)
-    plugin:update [name [committish]], Optionally update named plugin from git (with custom tag/committish) & run update trigger for active plugins
-    plugin:enable <name>, Enable a previously disabled plugin
-    plugin:disable <name>, Disable an installed plugin (third-party only)
+    plugin:list, Print active plugins
+    plugin:trigger <args...>, Trigger an arbitrary plugin hook
     plugin:uninstall <name>, Uninstall a plugin (third-party only)
+    plugin:update [name [committish]], Optionally update named plugin from git (with custom tag/committish) & run update trigger for active plugins
 help_content
     }
 

--- a/plugins/plugin/subcommands/trigger
+++ b/plugins/plugin/subcommands/trigger
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+plugin_trigger_cmd() {
+  declare desc="trigger an arbitrary plugin hook"
+  local cmd="plugin:trigger"
+  [[ "$1" == "$cmd" ]] && shift 1
+
+  plugn trigger "$@"
+}
+
+plugin_trigger_cmd "$@"


### PR DESCRIPTION
This is useful in cases where the command output must be tested, but it is otherwise embedded in a specific part of the dokku core.

As the 'plugin' commands require root, this is safe to add to the core.
