### PR TITLE
Remove outdated global resource setting

### DIFF
--- a/docs/advanced-usage/resource-management.md
+++ b/docs/advanced-usage/resource-management.md
@@ -83,64 +83,6 @@ dokku resource:limits node-js-app
        network-egress:
 ```
 
-#### Global Resource Limits
-
-By default, Dokku does not limit any resources, though these can be specified at the server level via the `--global` flag on the `resource:limit` command.
-
-```shell
-dokku resource:limit --global --memory 200
-```
-
-```
-=====> Setting default resource limits
-       memory: 200
-```
-
-This may also be combined with the `--process-type` flag to set global limits on a process-type level:
-
-```shell
-dokku resource:limit --global --memory 150 --process-type web node-js-app
-```
-
-```
-=====> Setting default resource limits (web)
-       memory: 150
-```
-
-#### Displaying Global Resource Limits
-
-Running the `resource:limit` command with only the `--global` flag will display the currently configured default limits.
-
-```shell
-dokku resource:limit --global
-```
-
-```
-=====> resource limits default information
-       cpu:
-       memory: 200
-       memory-swap:
-       network:
-       network-ingress:
-       network-egress:
-```
-
-This may also be combined with the `--process-type` flag to see global limits on a process-type level:
-
-```shell
-dokku resource:limit --global --process-type web
-```
-
-```
-=====> resource limits default information (web)
-       cpu:
-       memory-swap:
-       memory: 150
-       network-egress:
-       network-ingress:
-       network:
-```
-
 #### Clearing Resource Limits
 
 In cases where the values are incorrect - or there is no desire to limit resources - resource limits may be cleared using the `resource:limit-clear` command.
@@ -215,64 +157,6 @@ dokku resource:reserve node-js-app
        network:
        network-ingress:
        network-egress:
-```
-
-#### Global Resource Reservations
-
-By default, Dokku does not reserve any resources, though these can be specified at the server level via the `--global` flag on the `resource:reserve` command.
-
-```shell
-dokku resource:reserve --global --memory 200
-```
-
-```
-=====> Setting default resource reservation
-       memory: 200
-```
-
-This may also be combined with the `--process-type` flag to set global reservations on a process-type level:
-
-```shell
-dokku resource:reserve --global --memory 150 --process-type web node-js-app
-```
-
-```
-=====> Setting default resource reservation (web)
-       memory: 150
-```
-
-#### Displaying Global Resource Reservations
-
-Running the `resource:reserve` command with only the `--global` flag will display the currently configured default reservation.
-
-```shell
-dokku resource:reserve --global
-```
-
-```
-=====> resource reservation default information
-       cpu:
-       memory: 200
-       memory-swap:
-       network:
-       network-ingress:
-       network-egress:
-```
-
-This may also be combined with the `--process-type` flag to see global reservations on a process-type level:
-
-```shell
-dokku resource:reserve --global --process-type web
-```
-
-```
-=====> resource reservation default information (web)
-       cpu:
-       memory-swap:
-       memory: 150
-       network-egress:
-       network-ingress:
-       network:
 ```
 
 #### Clearing Resource Reservations


### PR DESCRIPTION
This was removed in c9bbddcfcbbcad64dd9453afec77ba614598fc67 as it was more complicated for operators to figure out _exactly_ which combination of limits/reservations would apply to their applications. Unfortunately, the documentation was never updated.

We may re-add this functionality in the future, but for now, cleaning up the docs is the best option.

[ci skip]
