### PR TITLE
Add message indicating that the user is looking at default limits/reservations

### DIFF
--- a/docs/advanced-usage/resource-management.md
+++ b/docs/advanced-usage/resource-management.md
@@ -70,11 +70,31 @@ dokku resource:limit --cpu 100 --memory 100 --process-type worker node-js-app
 
 #### Displaying Resource Limits
 
-Running the `resource:limits` command without any flags will display the currently configured app reservation.
+Running the `resource:limit` command without any flags will display the currently configured default app limits.
 
 ```shell
-dokku resource:limits node-js-app
-=====> resource limits node-js-app information
+dokku resource:limit node-js-app
+```
+
+```
+=====> resource limits node-js-app information [defaults]
+       cpu:
+       memory:
+       memory-swap: 100
+       network: 100
+       network-ingress:
+       network-egress:
+```
+
+This may also be combined with the `--process-type` flag to see app limits on a process-type level. Note that the displayed values are not merged with the defaults.
+
+
+```shell
+dokku resource:limit --process-type web node-js-app
+```
+
+```
+=====> resource limits node-js-app information (web)
        cpu: 100
        memory: 100
        memory-swap:
@@ -146,11 +166,30 @@ dokku resource:reserve --cpu 100 --memory 100 --process-type worker node-js-app
 
 #### Displaying Resource Reservations
 
-Running the `resource:reserve` command without any flags will display the currently configured app reservation.
+Running the `resource:reserve` command without any flags will display the currently configured default app reservations.
 
 ```shell
 dokku resource:reserve node-js-app
-=====> resource reservation node-js-app information
+```
+
+```
+=====> resource reservation node-js-app information [defaults]
+       cpu: 100
+       memory: 100
+       memory-swap:
+       network:
+       network-ingress:
+       network-egress:
+```
+
+This may also be combined with the `--process-type` flag to see app reservations on a process-type level. Note that the displayed values are not merged with the defaults.
+
+```shell
+dokku resource:reserve --process-type web node-js-app
+```
+
+```
+=====> resource reservation node-js-app information (web)
        cpu: 100
        memory: 100
        memory-swap:

--- a/plugins/resource/subcommands.go
+++ b/plugins/resource/subcommands.go
@@ -142,7 +142,9 @@ func reportResourceType(appName string, processType string, resourceType string)
 	}
 
 	message := fmt.Sprintf("resource %v %v information", noun, appName)
-	if processType != "_default_" {
+	if processType == "_default_" {
+		message = fmt.Sprintf("%v [defaults]", message)
+	} else {
 		message = fmt.Sprintf("%v (%v)", message, processType)
 	}
 	common.LogInfo2Quiet(message)


### PR DESCRIPTION
Without this bit of metadata, it appears to the user that the resource limits are just that, whereas this is actually scoped to per-process-type.
