### PR TITLE
Simplify hostname_regex

### DIFF
--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -312,7 +312,7 @@ is_global_vhost_enabled() {
 is_valid_hostname() {
   declare desc="return 0 if argument is a valid hostname; else return 1"
   local hostname_string="${1,,}"
-  local hostname_regex='^([a-z0-9\.\*-]+\.)*[a-z0-9\*-]+$'
+  local hostname_regex='^[a-z0-9\.\*-]*[a-z0-9\*-]$'
   if [[ $hostname_string =~ $hostname_regex ]]; then
     return 0
   else


### PR DESCRIPTION
`[a-z0-9\.\*-]+` includes `\.` and `[a-z0-9\*-]+`.
So I think `^([a-z0-9\.\*-]+\.)*[a-z0-9\*-]+$` means last char is `[a-z0-9\*-]`
and other optional chars are `[a-z0-9\.\*-]*`.