### PR TITLE
Add support for pulling app status from scheduler plugins

### DIFF
--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -222,27 +222,9 @@ get_restart_policies() {
 
 fn-ps-app-status() {
   declare APP="$1"
-  local PROCS=0 RUNNING=""
-  local APP_CIDS=$(get_app_container_ids "$APP")
 
-  for CID in $APP_CIDS; do
-    if (is_container_status "$CID" "Running"); then
-      RUNNING+="0"
-    else
-      RUNNING+="1"
-    fi
-    PROCS=$((PROCS + 1))
-  done
-
-  if [[ "${#RUNNING}" -eq 0 ]] || [[ "${#RUNNING}" -ne 0 ]] && [[ "$RUNNING" != *"0"* ]]; then
-    RUNNING="false"
-  elif [[ "$RUNNING" != *"1"* ]] && [[ "${#RUNNING}" -ne 0 ]]; then
-    RUNNING="true"
-  else
-    RUNNING="mixed"
-  fi
-
-  echo "$PROCS $RUNNING"
+  local DOKKU_SCHEDULER=$(get_app_scheduler "$APP")
+  plugn trigger scheduler-app-status "$DOKKU_SCHEDULER" "$APP"
 }
 
 fn-ps-is-app-running() {

--- a/plugins/scheduler-docker-local/scheduler-app-status
+++ b/plugins/scheduler-docker-local/scheduler-app-status
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+
+scheduler-app-status() {
+  declare desc="fetches the status for a given app"
+  declare trigger="scheduler-docker-local scheduler-app-status"
+  declare DOKKU_SCHEDULER="$1" APP="$2"
+
+  if [[ "$DOKKU_SCHEDULER" != "docker-local" ]]; then
+    return
+  fi
+
+  local PROCS=0 RUNNING=""
+  local APP_CIDS=$(get_app_container_ids "$APP")
+
+  for CID in $APP_CIDS; do
+    if (is_container_status "$CID" "Running"); then
+      RUNNING+="0"
+    else
+      RUNNING+="1"
+    fi
+    PROCS=$((PROCS + 1))
+  done
+
+  if [[ "${#RUNNING}" -eq 0 ]] || [[ "${#RUNNING}" -ne 0 ]] && [[ "$RUNNING" != *"0"* ]]; then
+    RUNNING="false"
+  elif [[ "$RUNNING" != *"1"* ]] && [[ "${#RUNNING}" -ne 0 ]]; then
+    RUNNING="true"
+  else
+    RUNNING="mixed"
+  fi
+
+  echo "$PROCS $RUNNING"
+}
+
+scheduler-app-status "$@"


### PR DESCRIPTION
Previously, this was impossible to do if using an alternative scheduler.

