### PR TITLE
Add a way to cleanup apps for specific schedulers

### DIFF
--- a/plugins/apps/functions
+++ b/plugins/apps/functions
@@ -40,6 +40,7 @@ apps_destroy() {
   local DOKKU_SCHEDULER=$(get_app_scheduler "$APP")
   local REMOVE_CONTAINERS="true"
   plugn trigger scheduler-stop "$DOKKU_SCHEDULER" "$APP" "$REMOVE_CONTAINERS"
+  plugn trigger scheduler-post-delete "$DOKKU_SCHEDULER" "$APP" "$IMAGE_TAG"
   plugn trigger post-delete "$APP" "$IMAGE_TAG"
 }
 


### PR DESCRIPTION
The post-delete hook will delete config, and thus scheduler-post-delete is the best place to actually delete resources where some local config may be necessary in order to reference resources.
