### PR TITLE
Allow omitting resource args by setting DOKKU_OMIT_RESOURCE_ARGS

### DIFF
--- a/plugins/resource/src/triggers/docker-args-process-deploy/docker-args-process-deploy.go
+++ b/plugins/resource/src/triggers/docker-args-process-deploy/docker-args-process-deploy.go
@@ -21,6 +21,11 @@ func main() {
 	appName := flag.Arg(0)
 	processType := flag.Arg(3)
 
+	if os.Getenv("DOKKU_OMIT_RESOURCE_ARGS") == "1" {
+		fmt.Print(string(stdin))
+		return
+	}
+
 	resources, err := common.PropertyGetAll("resource", appName)
 	if err != nil {
 		fmt.Print(string(stdin))


### PR DESCRIPTION
This is useful for one-off containers that should have full-access to server resources.
