### PR TITLE
Fix nginx template for https in "Connection" header

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -84,7 +84,7 @@ server {
     {{ if eq $.HTTP2_PUSH_SUPPORTED "true" }}http2_push_preload on; {{ end }}
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
+    proxy_set_header Connection $http_connection;
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
Change the nginx template to set the http header "Connection" to $http_connection.
This solves an issue with kestrel not going along with the "upgrade" setting.