### PR TITLE
Scope docker-cleanup to specific app

### DIFF
--- a/docs/development/plugin-creation.md
+++ b/docs/development/plugin-creation.md
@@ -165,15 +165,26 @@ Certain systems may require a wrapper function around the `docker` binary for pr
 docker run -d $IMAGE /bin/bash -e -c "$COMMAND"
 ```
 
-## Include labels for all temporary containers
+## Include labels for all temporary containers and images
 
 > New as of 0.5.0
 
-As of 0.5.0, labels are used to help cleanup intermediate containers with `dokku cleanup`. Plugins that create containers should add the correct labels to `run` docker commands.
+As of 0.5.0, labels are used to help cleanup intermediate containers with `dokku cleanup`. Plugins that create containers and images should add the correct labels to the `build`, `commit`, and `run` docker commands.
+
+Note that where possible, a label `com.dokku.app-name=$APP` - where `$APP` is the name of the app - should also be included. This enables `dokku cleanup APP` to cleanup the specific containers for a given app.
 
 ```shell
+# `docker build` example
+"$DOCKER_BIN" build "--label=com.dokku.app-name=${APP}" $DOKKU_GLOBAL_BUILD_ARGS ...
+
+# `docker commit` example
+# Note that the arguments must be set as a local array
+# as arrays cannot be exported in shell
+local DOKKU_COMMIT_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL $DOKKU_CONTAINER_LABEL")
+"$DOCKER_BIN" commit --change "LABEL com.dokku.app-name=$APP" "${DOKKU_COMMIT_ARGS[@]}" ...
+
 # `docker run` example
-"$DOCKER_BIN" run "${DOKKU_GLOBAL_RUN_ARGS[@]}" ...
+"$DOCKER_BIN" run "--label=com.dokku.app-name=${APP}" $DOKKU_GLOBAL_RUN_ARGS ...
 ```
 
 ## Avoid calling the `dokku` binary directly

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -899,9 +899,10 @@ CMD="cat > gm && \
   dpkg -s CONTAINER_PACKAGE >/dev/null 2>&1 || \
   (apt-get update && apt-get install -y CONTAINER_PACKAGE && apt-get clean)"
 
-ID=$(docker run $DOKKU_GLOBAL_RUN_ARGS -i -a stdin $IMAGE /bin/bash -c "$CMD")
-test $(docker wait $ID) -eq 0
-docker commit $ID $IMAGE >/dev/null
+CID=$(docker run $DOKKU_GLOBAL_RUN_ARGS -i -a stdin $IMAGE /bin/bash -c "$CMD")
+test $(docker wait $CID) -eq 0
+DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
+docker commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" $CID $IMAGE >/dev/null
 ```
 
 ### `post-release-dockerfile`
@@ -988,7 +989,7 @@ APP="$1"; GULP_CACHE_DIR="$DOKKU_ROOT/$APP/gulp"; IMAGE=$(get_app_image_name $AP
 verify_app_name "$APP"
 
 if [[ -d $GULP_CACHE_DIR ]]; then
-  docker run $DOKKU_GLOBAL_RUN_ARGS --rm -v "$GULP_CACHE_DIR:/gulp" "$IMAGE" find /gulp -depth -mindepth 1 -maxdepth 1 -exec rm -Rf {} \; || true
+  docker run "${DOCKER_COMMIT_LABEL_ARGS[@]}" --rm -v "$GULP_CACHE_DIR:/gulp" "$IMAGE" find /gulp -depth -mindepth 1 -maxdepth 1 -exec rm -Rf {} \; || true
 fi
 ```
 
@@ -1009,10 +1010,10 @@ APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
 verify_app_name "$APP"
 
 dokku_log_info1 "Running gulp"
-id=$(docker run $DOKKU_GLOBAL_RUN_ARGS -d $IMAGE /bin/bash -c "cd /app && gulp default")
-test $(docker wait $id) -eq 0
-docker commit $id $IMAGE >/dev/null
-dokku_log_info1 "Building UI Complete"
+CID=$(docker run "${DOCKER_COMMIT_LABEL_ARGS[@]}" -d $IMAGE /bin/bash -c "cd /app && gulp default")
+test $(docker wait $CID) -eq 0
+DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
+docker commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" $CID $IMAGE >/dev/null
 ```
 
 ### `pre-disable-vhost`
@@ -1090,9 +1091,10 @@ CMD="cat > gm && \
   dpkg -s graphicsmagick >/dev/null 2>&1 || \
   (apt-get update && apt-get install -y graphicsmagick && apt-get clean)"
 
-ID=$(docker run $DOKKU_GLOBAL_RUN_ARGS -i -a stdin $IMAGE /bin/bash -c "$CMD")
-test $(docker wait $ID) -eq 0
-docker commit $ID $IMAGE >/dev/null
+CID=$(docker run "${DOCKER_COMMIT_LABEL_ARGS[@]}" -i -a stdin $IMAGE /bin/bash -c "$CMD")
+DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
+test $(docker wait $CID) -eq 0
+docker commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" $CID $IMAGE >/dev/null
 ```
 
 ### `pre-release-dockerfile`

--- a/dokku
+++ b/dokku
@@ -61,7 +61,8 @@ export DOKKU_LOGS_DIR=${DOKKU_LOGS_DIR:="/var/log/dokku"}
 export DOKKU_EVENTS_LOGFILE=${DOKKU_EVENTS_LOGFILE:="$DOKKU_LOGS_DIR/events.log"}
 
 export DOKKU_CONTAINER_LABEL=dokku
-export DOKKU_GLOBAL_RUN_ARGS="--label=$DOKKU_CONTAINER_LABEL"
+export DOKKU_GLOBAL_BUILD_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=$DOKKU_CONTAINER_LABEL"
+export DOKKU_GLOBAL_RUN_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=$DOKKU_CONTAINER_LABEL"
 
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 

--- a/plugins/00_dokku-standard/subcommands/report
+++ b/plugins/00_dokku-standard/subcommands/report
@@ -17,7 +17,7 @@ dokku_report_cmd() {
   "$DOCKER_BIN" -D info | sed "s/^/       /"
   dokku_log_info1 "sigil version: $(sigil -v)"
   dokku_log_info1 "herokuish version: "
-  "$DOCKER_BIN" run --rm "$DOKKU_IMAGE" herokuish version | sed "s/^/       /"
+  "$DOCKER_BIN" run $DOKKU_GLOBAL_RUN_ARGS --rm "$DOKKU_IMAGE" herokuish version | sed "s/^/       /"
   dokku_log_info1 "dokku version: $(dokku version)"
   dokku_log_info1 "dokku plugins: "
   dokku plugin:list | sed "s/^/       /"

--- a/plugins/app-json/internal-functions
+++ b/plugins/app-json/internal-functions
@@ -37,7 +37,7 @@ execute_script() {
   local IMAGE id SCRIPT_CMD
 
   local DOCKER_COMMIT_LABEL_ARGS=("--change" "\"LABEL org.label-schema.schema-version=1.0\"" "--change" "\"LABEL org.label-schema.vendor=dokku\"" "--change" "\"LABEL com.dokku.app-name=$APP\"")
-  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
 
   IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
   if [[ "$PHASE_SCRIPT_KEY" == "release" ]]; then
@@ -99,7 +99,7 @@ execute_script() {
   DOKKU_APP_SHELL="$(config_get "$APP" DOKKU_APP_SHELL || echo "$DOKKU_APP_SHELL")"
   [[ -z "$DOKKU_APP_SHELL" ]] && DOKKU_APP_SHELL="/bin/bash"
 
-  id=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -e DOKKU_TRACE="$DOKKU_TRACE" --label=dokku_phase_script="${PHASE_SCRIPT_KEY}" -d -v "$CACHE_HOST_DIR:/cache" "${ARG_ARRAY[@]}" "$IMAGE" "$DOKKU_APP_SHELL" -c "$COMMAND")
+  id=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -e DOKKU_TRACE="$DOKKU_TRACE" --label=dokku_phase_script="${PHASE_SCRIPT_KEY}" -d -v "$CACHE_HOST_DIR:/cache" "${ARG_ARRAY[@]}" "$IMAGE" "$DOKKU_APP_SHELL" -c "$COMMAND")
   if test "$("$DOCKER_BIN" wait "$id")" -ne 0; then
     dokku_container_log_verbose_quiet "$id"
     dokku_log_fail "execution of '$SCRIPT_CMD' failed!"

--- a/plugins/app-json/internal-functions
+++ b/plugins/app-json/internal-functions
@@ -36,6 +36,9 @@ execute_script() {
   declare APP="$1" IMAGE_TAG="$2" PHASE_SCRIPT_KEY="$3"
   local IMAGE id SCRIPT_CMD
 
+  local DOCKER_COMMIT_LABEL_ARGS=("--change" "\"LABEL org.label-schema.schema-version=1.0\"" "--change" "\"LABEL org.label-schema.vendor=dokku\"" "--change" "\"LABEL com.dokku.app-name=$APP\"")
+  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+
   IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
   if [[ "$PHASE_SCRIPT_KEY" == "release" ]]; then
     SCRIPT_CMD=$(get_release_cmd "$APP" "$IMAGE_TAG" 2>/dev/null || true)
@@ -96,7 +99,7 @@ execute_script() {
   DOKKU_APP_SHELL="$(config_get "$APP" DOKKU_APP_SHELL || echo "$DOKKU_APP_SHELL")"
   [[ -z "$DOKKU_APP_SHELL" ]] && DOKKU_APP_SHELL="/bin/bash"
 
-  id=$("$DOCKER_BIN" run "$DOKKU_GLOBAL_RUN_ARGS" -e DOKKU_TRACE="$DOKKU_TRACE" --label=dokku_phase_script="${PHASE_SCRIPT_KEY}" -d -v "$CACHE_HOST_DIR:/cache" "${ARG_ARRAY[@]}" "$IMAGE" "$DOKKU_APP_SHELL" -c "$COMMAND")
+  id=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -e DOKKU_TRACE="$DOKKU_TRACE" --label=dokku_phase_script="${PHASE_SCRIPT_KEY}" -d -v "$CACHE_HOST_DIR:/cache" "${ARG_ARRAY[@]}" "$IMAGE" "$DOKKU_APP_SHELL" -c "$COMMAND")
   if test "$("$DOCKER_BIN" wait "$id")" -ne 0; then
     dokku_container_log_verbose_quiet "$id"
     dokku_log_fail "execution of '$SCRIPT_CMD' failed!"
@@ -119,6 +122,5 @@ execute_script() {
     local DOCKER_COMMIT_ARGS="$DOCKER_COMMIT_ENTRYPOINT_CHANGE_ARG $DOCKER_COMMIT_CMD_CHANGE_ARG"
   fi
 
-  # shellcheck disable=SC2086
-  eval "$DOCKER_BIN" commit $DOCKER_COMMIT_ARGS "$id" "$IMAGE" >/dev/null
+  eval "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "${DOCKER_COMMIT_ARGS[@]}" "$id" "$IMAGE" >/dev/null
 }

--- a/plugins/apps/functions
+++ b/plugins/apps/functions
@@ -42,6 +42,7 @@ apps_destroy() {
   plugn trigger scheduler-stop "$DOKKU_SCHEDULER" "$APP" "$REMOVE_CONTAINERS"
   plugn trigger scheduler-post-delete "$DOKKU_SCHEDULER" "$APP" "$IMAGE_TAG"
   plugn trigger post-delete "$APP" "$IMAGE_TAG"
+  docker_cleanup "$APP" "true"
 }
 
 apps_exists() {

--- a/plugins/apps/subcommands/clone
+++ b/plugins/apps/subcommands/clone
@@ -22,6 +22,8 @@ apps_clone_cmd() {
   OLD_APP="$1" NEW_APP="$2"
   [[ -z "$OLD_APP" ]] && dokku_log_fail "Please specify an app to run the command on"
 
+  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$NEW_APP"
+
   is_valid_app_name "$OLD_APP"
   is_valid_app_name "$NEW_APP"
   apps_exists "$OLD_APP" >/dev/null 2>&1 || dokku_log_fail "App does not exist"
@@ -44,7 +46,7 @@ apps_clone_cmd() {
   plugn trigger post-app-clone-setup "$OLD_APP" "$NEW_APP"
 
   if [[ -d "$NEW_CACHE_DIR" ]] && ! rmdir "$NEW_CACHE_DIR"; then
-    "$DOCKER_BIN" run "$DOKKU_GLOBAL_RUN_ARGS" --rm -v "$NEW_CACHE_HOST_DIR:/cache" "dokku/$OLD_APP" chmod 777 -R /cache
+    "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" --rm -v "$NEW_CACHE_HOST_DIR:/cache" "dokku/$OLD_APP" chmod 777 -R /cache
   fi
   rm -rf "$NEW_CACHE_DIR"
 

--- a/plugins/apps/subcommands/clone
+++ b/plugins/apps/subcommands/clone
@@ -22,7 +22,7 @@ apps_clone_cmd() {
   OLD_APP="$1" NEW_APP="$2"
   [[ -z "$OLD_APP" ]] && dokku_log_fail "Please specify an app to run the command on"
 
-  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$NEW_APP"
+  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$NEW_APP"
 
   is_valid_app_name "$OLD_APP"
   is_valid_app_name "$NEW_APP"
@@ -46,7 +46,7 @@ apps_clone_cmd() {
   plugn trigger post-app-clone-setup "$OLD_APP" "$NEW_APP"
 
   if [[ -d "$NEW_CACHE_DIR" ]] && ! rmdir "$NEW_CACHE_DIR"; then
-    "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" --rm -v "$NEW_CACHE_HOST_DIR:/cache" "dokku/$OLD_APP" chmod 777 -R /cache
+    "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS --rm -v "$NEW_CACHE_HOST_DIR:/cache" "dokku/$OLD_APP" chmod 777 -R /cache
   fi
   rm -rf "$NEW_CACHE_DIR"
 

--- a/plugins/apps/subcommands/rename
+++ b/plugins/apps/subcommands/rename
@@ -30,6 +30,7 @@ apps_rename_cmd() {
   [[ -f "$DOKKU_ROOT/$NEW_APP/hooks/pre-receive" ]] && sed -i -e "s/git-hook $OLD_APP/git-hook $NEW_APP/g" "$DOKKU_ROOT/$NEW_APP/hooks/pre-receive"
   ps_rebuild "$NEW_APP"
   plugn trigger post-app-rename "$OLD_APP" "$NEW_APP"
+  docker_cleanup "$OLD_APP" "true"
   echo "Renaming $OLD_APP to $NEW_APP... done"
 }
 

--- a/plugins/apps/subcommands/rename
+++ b/plugins/apps/subcommands/rename
@@ -15,8 +15,10 @@ apps_rename_cmd() {
   local OLD_CACHE_DIR="$DOKKU_ROOT/$OLD_APP/cache"
   local OLD_CACHE_HOST_DIR="$DOKKU_HOST_ROOT/$OLD_APP/cache"
 
+  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$OLD_APP"
+
   if [[ -d "$OLD_CACHE_DIR" ]] && ! rmdir "$OLD_CACHE_DIR" >/dev/null 2>&1; then
-    "$DOCKER_BIN" run "$DOKKU_GLOBAL_RUN_ARGS" --rm -v "$OLD_CACHE_HOST_DIR:/cache" "dokku/$OLD_APP" chmod 777 -R /cache
+    "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" --rm -v "$OLD_CACHE_HOST_DIR:/cache" "dokku/$OLD_APP" chmod 777 -R /cache
   fi
   rm -rf "$OLD_CACHE_DIR"
   apps_create "$NEW_APP"

--- a/plugins/apps/subcommands/rename
+++ b/plugins/apps/subcommands/rename
@@ -15,10 +15,10 @@ apps_rename_cmd() {
   local OLD_CACHE_DIR="$DOKKU_ROOT/$OLD_APP/cache"
   local OLD_CACHE_HOST_DIR="$DOKKU_HOST_ROOT/$OLD_APP/cache"
 
-  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$OLD_APP"
+  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$OLD_APP"
 
   if [[ -d "$OLD_CACHE_DIR" ]] && ! rmdir "$OLD_CACHE_DIR" >/dev/null 2>&1; then
-    "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" --rm -v "$OLD_CACHE_HOST_DIR:/cache" "dokku/$OLD_APP" chmod 777 -R /cache
+    "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS --rm -v "$OLD_CACHE_HOST_DIR:/cache" "dokku/$OLD_APP" chmod 777 -R /cache
   fi
   rm -rf "$OLD_CACHE_DIR"
   apps_create "$NEW_APP"

--- a/plugins/build-env/pre-build-buildpack
+++ b/plugins/build-env/pre-build-buildpack
@@ -10,6 +10,9 @@ build_env_pre_build_buildpack() {
   local APP="$1"
   local IMAGE id
 
+  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
+  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+
   verify_app_name "$APP"
   IMAGE=$(get_app_image_name "$APP")
 
@@ -19,14 +22,16 @@ build_env_pre_build_buildpack() {
   dokku_log_info1 "Adding BUILD_ENV to build environment..."
   # create build env files for use in buildpacks like this:
   # https://github.com/niteoweb/heroku-buildpack-buildout/blob/5879fa3418f7d8e079f1aa5816ba1adde73f4948/bin/compile#L34
-  id=$(config_bundle --merged "$APP" | "$DOCKER_BIN" run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /tmp/env; cat | tar -x -C /tmp/env")
+  id=$(config_bundle --merged "$APP" | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /tmp/env; cat | tar -x -C /tmp/env")
   test "$("$DOCKER_BIN" wait "$id")" -eq 0
-  "$DOCKER_BIN" commit "$id" "$IMAGE" >/dev/null
+
+  "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$id" "$IMAGE" >/dev/null
 
   # create build env for 'old style' buildpacks and dokku plugins
-  id=$(config_export app "$APP" --format envfile --merged | "$DOCKER_BIN" run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$IMAGE" /bin/bash -c "cat >> /app/.env")
+  id=$(config_export app "$APP" --format envfile --merged | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -i -a stdin "$IMAGE" /bin/bash -c "cat >> /app/.env")
   test "$("$DOCKER_BIN" wait "$id")" -eq 0
-  "$DOCKER_BIN" commit "$id" "$IMAGE" >/dev/null
+
+  "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$id" "$IMAGE" >/dev/null
 }
 
 build_env_pre_build_buildpack "$@"

--- a/plugins/build-env/pre-build-buildpack
+++ b/plugins/build-env/pre-build-buildpack
@@ -11,7 +11,7 @@ build_env_pre_build_buildpack() {
   local IMAGE id
 
   local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
-  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
 
   verify_app_name "$APP"
   IMAGE=$(get_app_image_name "$APP")
@@ -22,13 +22,13 @@ build_env_pre_build_buildpack() {
   dokku_log_info1 "Adding BUILD_ENV to build environment..."
   # create build env files for use in buildpacks like this:
   # https://github.com/niteoweb/heroku-buildpack-buildout/blob/5879fa3418f7d8e079f1aa5816ba1adde73f4948/bin/compile#L34
-  id=$(config_bundle --merged "$APP" | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /tmp/env; cat | tar -x -C /tmp/env")
+  id=$(config_bundle --merged "$APP" | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /tmp/env; cat | tar -x -C /tmp/env")
   test "$("$DOCKER_BIN" wait "$id")" -eq 0
 
   "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$id" "$IMAGE" >/dev/null
 
   # create build env for 'old style' buildpacks and dokku plugins
-  id=$(config_export app "$APP" --format envfile --merged | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -i -a stdin "$IMAGE" /bin/bash -c "cat >> /app/.env")
+  id=$(config_export app "$APP" --format envfile --merged | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "cat >> /app/.env")
   test "$("$DOCKER_BIN" wait "$id")" -eq 0
 
   "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$id" "$IMAGE" >/dev/null

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -264,6 +264,10 @@ get_app_scheduler() {
   declare APP="$1"
   local DOKKU_APP_SCHEDULER DOKKU_GLOBAL_SCHEDULER DOKKU_SCHEDULER
 
+  if [[ "$APP" == "--global" ]]; then
+    APP=""
+  fi
+
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
   [[ -n "$APP" ]] && DOKKU_APP_SCHEDULER="$(config_get "$APP" DOKKU_SCHEDULER || true)"
   DOKKU_GLOBAL_SCHEDULER="$(config_get --global DOKKU_SCHEDULER || true)"
@@ -714,19 +718,44 @@ docker_cleanup() {
 
   dokku_log_info1 "Cleaning up..."
   local DOKKU_SCHEDULER=$(get_app_scheduler "$APP")
+
+  if [[ "$APP" == "--global" ]]; then
+    APP=""
+  fi
+
   plugn trigger scheduler-docker-cleanup "$DOKKU_SCHEDULER" "$APP" "$FORCE_CLEANUP"
 
-  # delete all non-running containers
-  # shellcheck disable=SC2046
-  "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=exited" -f "label=$DOKKU_CONTAINER_LABEL" -q) &>/dev/null || true
+  if [[ -n "$APP" ]]; then
+    # delete all non-running containers
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=exited" -f "label=$DOKKU_CONTAINER_LABEL" -f "label=com.dokku.app-name=$APP" -q) &>/dev/null || true
 
-  # delete all dead containers
-  # shellcheck disable=SC2046
-  "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=dead" -f "label=$DOKKU_CONTAINER_LABEL" -q) &>/dev/null || true
+    # delete all dead containers
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=dead" -f "label=$DOKKU_CONTAINER_LABEL" -f "label=com.dokku.app-name=$APP" -q) &>/dev/null || true
 
-  # delete unused images
-  # shellcheck disable=SC2046
-  "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -q) &>/dev/null &
+    # delete danging images
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -f "label=com.dokku.app-name=$APP" -q) &>/dev/null &
+
+    # delete unused images
+    docker image prune --all --filter "label=com.dokku.app-name=$APP" &>/dev/null &
+  else
+    # delete all non-running containers
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=exited" -f "label=$DOKKU_CONTAINER_LABEL" -q) &>/dev/null || true
+
+    # delete all dead containers
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=dead" -f "label=$DOKKU_CONTAINER_LABEL" -q) &>/dev/null || true
+
+    # delete danging images
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -q) &>/dev/null &
+
+    # delete unused images
+    docker image prune --all &>/dev/null &
+  fi
 }
 
 get_available_port() {

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -375,7 +375,7 @@ copy_from_image() {
   local WORK_DIR=""
   verify_app_name "$APP"
 
-  local DOCKER_CREATE_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  local DOCKER_CREATE_LABEL_ARGS="--label=com.dokku.app-name=$APP"
 
   if verify_image "$IMAGE"; then
     if ! is_abs_path "$SRC_FILE"; then
@@ -389,7 +389,7 @@ copy_from_image() {
         SRC_FILE="${WORKDIR}/${SRC_FILE}"
       fi
     fi
-    local CID=$("$DOCKER_BIN" create "${DOCKER_CREATE_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" "$IMAGE")
+    local CID=$("$DOCKER_BIN" create "${DOCKER_CREATE_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS "$IMAGE")
     if ! "$DOCKER_BIN" cp "$CID:$SRC_FILE" "$DST_DIR"; then
       "$DOCKER_BIN" rm -f "$CID" &>/dev/null
       return 1
@@ -528,7 +528,7 @@ dokku_build() {
 
   local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
   local DOCKER_BUILD_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
-  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
 
   eval "$(config_export app "$APP")"
   pushd "$TMP_WORK_DIR" &>/dev/null
@@ -536,7 +536,7 @@ dokku_build() {
   case "$IMAGE_SOURCE_TYPE" in
     herokuish)
       DOKKU_IMAGE="$(config_get "$APP" DOKKU_IMAGE || echo "$DOKKU_IMAGE")"
-      cid=$(tar -c . | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /app && tar -xC /app")
+      cid=$(tar -c . | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /app && tar -xC /app")
       test "$("$DOCKER_BIN" wait "$cid")" -eq 0
 
       "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$cid" "$IMAGE" >/dev/null
@@ -551,7 +551,7 @@ dokku_build() {
       declare -a ARG_ARRAY
       eval "ARG_ARRAY=($DOCKER_ARGS)"
       # shellcheck disable=SC2086
-      cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -d -v $DOKKU_APP_HOST_CACHE_DIR:/cache -e CACHE_PATH=/cache "${ARG_ARRAY[@]}" $IMAGE /build)
+      cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -d -v $DOKKU_APP_HOST_CACHE_DIR:/cache -e CACHE_PATH=/cache "${ARG_ARRAY[@]}" $IMAGE /build)
       "$DOCKER_BIN" attach "$cid"
       test "$("$DOCKER_BIN" wait "$cid")" -eq 0
 
@@ -582,7 +582,7 @@ dokku_build() {
       declare -a ARG_ARRAY
       eval "ARG_ARRAY=($DOCKER_ARGS)"
 
-      "$DOCKER_BIN" build "${DOCKER_BUILD_LABEL_ARGS[@]}" "${ARG_ARRAY[@]}" "${DOKKU_DOCKER_BUILD_OPTS[@]}" -t $IMAGE .
+      "$DOCKER_BIN" build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS "${ARG_ARRAY[@]}" "${DOKKU_DOCKER_BUILD_OPTS[@]}" -t $IMAGE .
 
       plugn trigger post-build-dockerfile "$APP"
       ;;
@@ -601,19 +601,19 @@ dokku_release() {
   local cid IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
 
   local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
-  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
 
   case "$IMAGE_SOURCE_TYPE" in
     herokuish)
       plugn trigger pre-release-buildpack "$APP" "$IMAGE_TAG"
       if [[ -n $(config_export global) ]]; then
-        cid=$(config_export global | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh")
+        cid=$(config_export global | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh")
         test "$("$DOCKER_BIN" wait "$cid")" -eq 0
 
         "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$cid" "$IMAGE" >/dev/null
       fi
       if [[ -n $(config_export app "$APP") ]]; then
-        cid=$(config_export app "$APP" | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh")
+        cid=$(config_export app "$APP" | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh")
         test "$("$DOCKER_BIN" wait "$cid")" -eq 0
 
         "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$cid" "$IMAGE" >/dev/null

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -371,6 +371,8 @@ copy_from_image() {
   local WORK_DIR=""
   verify_app_name "$APP"
 
+  local DOCKER_CREATE_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+
   if verify_image "$IMAGE"; then
     if ! is_abs_path "$SRC_FILE"; then
       if is_image_herokuish_based "$IMAGE"; then
@@ -383,7 +385,7 @@ copy_from_image() {
         SRC_FILE="${WORKDIR}/${SRC_FILE}"
       fi
     fi
-    local CID=$("$DOCKER_BIN" create "$DOKKU_GLOBAL_RUN_ARGS" "$IMAGE")
+    local CID=$("$DOCKER_BIN" create "${DOCKER_CREATE_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" "$IMAGE")
     if ! "$DOCKER_BIN" cp "$CID:$SRC_FILE" "$DST_DIR"; then
       "$DOCKER_BIN" rm -f "$CID" &>/dev/null
       return 1
@@ -511,17 +513,18 @@ is_app_running() {
 
 dokku_build() {
   declare desc="build phase"
+  declare APP="$1" IMAGE_SOURCE_TYPE="$2" TMP_WORK_DIR="$3"
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
-  local APP="$1"
-  local IMAGE_SOURCE_TYPE="$2"
-  local TMP_WORK_DIR="$3"
-  local IMAGE=$(get_app_image_name "$APP")
-  local cid
   verify_app_name "$APP"
 
+  local cid IMAGE=$(get_app_image_name "$APP")
   local DOKKU_APP_CACHE_DIR="$DOKKU_ROOT/$APP/cache"
   local DOKKU_APP_HOST_CACHE_DIR="$DOKKU_HOST_ROOT/$APP/cache"
+
+  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
+  local DOCKER_BUILD_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
 
   eval "$(config_export app "$APP")"
   pushd "$TMP_WORK_DIR" &>/dev/null
@@ -529,9 +532,10 @@ dokku_build() {
   case "$IMAGE_SOURCE_TYPE" in
     herokuish)
       DOKKU_IMAGE="$(config_get "$APP" DOKKU_IMAGE || echo "$DOKKU_IMAGE")"
-      cid=$(tar -c . | "$DOCKER_BIN" run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /app && tar -xC /app")
+      cid=$(tar -c . | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /app && tar -xC /app")
       test "$("$DOCKER_BIN" wait "$cid")" -eq 0
-      "$DOCKER_BIN" commit "$cid" "$IMAGE" >/dev/null
+
+      "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$cid" "$IMAGE" >/dev/null
       [[ -d $DOKKU_APP_CACHE_DIR ]] || mkdir -p "$DOKKU_APP_CACHE_DIR"
       plugn trigger pre-build-buildpack "$APP"
 
@@ -543,10 +547,11 @@ dokku_build() {
       declare -a ARG_ARRAY
       eval "ARG_ARRAY=($DOCKER_ARGS)"
       # shellcheck disable=SC2086
-      cid=$("$DOCKER_BIN" run $DOKKU_GLOBAL_RUN_ARGS -d -v $DOKKU_APP_HOST_CACHE_DIR:/cache -e CACHE_PATH=/cache "${ARG_ARRAY[@]}" $IMAGE /build)
+      cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -d -v $DOKKU_APP_HOST_CACHE_DIR:/cache -e CACHE_PATH=/cache "${ARG_ARRAY[@]}" $IMAGE /build)
       "$DOCKER_BIN" attach "$cid"
       test "$("$DOCKER_BIN" wait "$cid")" -eq 0
-      "$DOCKER_BIN" commit "$cid" "$IMAGE" >/dev/null
+
+      "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$cid" "$IMAGE" >/dev/null
 
       plugn trigger post-build-buildpack "$APP"
       ;;
@@ -573,8 +578,7 @@ dokku_build() {
       declare -a ARG_ARRAY
       eval "ARG_ARRAY=($DOCKER_ARGS)"
 
-      # shellcheck disable=SC2086
-      "$DOCKER_BIN" build "${ARG_ARRAY[@]}" $DOKKU_DOCKER_BUILD_OPTS -t $IMAGE .
+      "$DOCKER_BIN" build "${DOCKER_BUILD_LABEL_ARGS[@]}" "${ARG_ARRAY[@]}" "${DOKKU_DOCKER_BUILD_OPTS[@]}" -t $IMAGE .
 
       plugn trigger post-build-dockerfile "$APP"
       ;;
@@ -587,27 +591,28 @@ dokku_build() {
 
 dokku_release() {
   declare desc="release phase"
+  declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3"
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
-  local APP="$1"
-  local IMAGE_SOURCE_TYPE="$2"
-  local IMAGE_TAG="$3"
-  local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
-  local cid
-  verify_app_name "$APP"
+  local cid IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
+
+  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
+  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
 
   case "$IMAGE_SOURCE_TYPE" in
     herokuish)
       plugn trigger pre-release-buildpack "$APP" "$IMAGE_TAG"
       if [[ -n $(config_export global) ]]; then
-        cid=$(config_export global | "$DOCKER_BIN" run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh")
+        cid=$(config_export global | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh")
         test "$("$DOCKER_BIN" wait "$cid")" -eq 0
-        "$DOCKER_BIN" commit "$cid" "$IMAGE" >/dev/null
+
+        "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$cid" "$IMAGE" >/dev/null
       fi
       if [[ -n $(config_export app "$APP") ]]; then
-        cid=$(config_export app "$APP" | "$DOCKER_BIN" run "$DOKKU_GLOBAL_RUN_ARGS" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh")
+        cid=$(config_export app "$APP" | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh")
         test "$("$DOCKER_BIN" wait "$cid")" -eq 0
-        "$DOCKER_BIN" commit "$cid" "$IMAGE" >/dev/null
+
+        "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$cid" "$IMAGE" >/dev/null
       fi
       plugn trigger post-release-buildpack "$APP" "$IMAGE_TAG"
       ;;

--- a/plugins/repo/repo.go
+++ b/plugins/repo/repo.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -20,9 +21,10 @@ func PurgeCache(appName string) error {
 	dokkuGlobalRunArgs := common.MustGetEnv("DOKKU_GLOBAL_RUN_ARGS")
 	image := config.GetWithDefault(appName, "DOKKU_IMAGE", os.Getenv("DOKKU_IMAGE"))
 	if info, _ := os.Stat(cacheDir); info != nil && info.IsDir() {
+		dockerLabelArgs := fmt.Sprintf("--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=%s", appName)
 		purgeCacheCmd := common.NewShellCmd(strings.Join([]string{
 			common.DockerBin(),
-			"run --rm", dokkuGlobalRunArgs,
+			"run --rm", dockerLabelArgs, dokkuGlobalRunArgs,
 			"-v", strings.Join([]string{cacheHostDir, ":/cache"}, ""), image,
 			`find /cache -depth -mindepth 1 -maxdepth 1 -exec rm -Rf {} ;`}, " "))
 		purgeCacheCmd.Execute()

--- a/plugins/repo/repo.go
+++ b/plugins/repo/repo.go
@@ -21,7 +21,7 @@ func PurgeCache(appName string) error {
 	dokkuGlobalRunArgs := common.MustGetEnv("DOKKU_GLOBAL_RUN_ARGS")
 	image := config.GetWithDefault(appName, "DOKKU_IMAGE", os.Getenv("DOKKU_IMAGE"))
 	if info, _ := os.Stat(cacheDir); info != nil && info.IsDir() {
-		dockerLabelArgs := fmt.Sprintf("--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=%s", appName)
+		dockerLabelArgs := fmt.Sprintf("--label=com.dokku.app-name=%s", appName)
 		purgeCacheCmd := common.NewShellCmd(strings.Join([]string{
 			common.DockerBin(),
 			"run --rm", dockerLabelArgs, dokkuGlobalRunArgs,

--- a/plugins/scheduler-docker-local/pre-deploy
+++ b/plugins/scheduler-docker-local/pre-deploy
@@ -17,7 +17,7 @@ scheduler-docker-local-pre-deploy() {
     return
   fi
 
-  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
 
   IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
 
@@ -44,7 +44,7 @@ scheduler-docker-local-pre-deploy() {
   fi
 
   # shellcheck disable=SC2086
-  "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" "${ARG_ARRAY[@]}" $IMAGE /bin/bash -c "find $CONTAINER_PATHS -not -user $DOKKU_APP_USER -print0 | xargs -0 -r chown -R $DOKKU_APP_USER" || true
+  "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS "${ARG_ARRAY[@]}" $IMAGE /bin/bash -c "find $CONTAINER_PATHS -not -user $DOKKU_APP_USER -print0 | xargs -0 -r chown -R $DOKKU_APP_USER" || true
 }
 
 scheduler-docker-local-pre-deploy "$@"

--- a/plugins/scheduler-docker-local/pre-deploy
+++ b/plugins/scheduler-docker-local/pre-deploy
@@ -17,6 +17,8 @@ scheduler-docker-local-pre-deploy() {
     return
   fi
 
+  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+
   IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
 
   DOKKU_APP_TYPE=$(config_get "$APP" DOKKU_APP_TYPE || true)
@@ -42,7 +44,7 @@ scheduler-docker-local-pre-deploy() {
   fi
 
   # shellcheck disable=SC2086
-  "$DOCKER_BIN" run $DOKKU_GLOBAL_RUN_ARGS "${ARG_ARRAY[@]}" $IMAGE /bin/bash -c "find $CONTAINER_PATHS -not -user $DOKKU_APP_USER -print0 | xargs -0 -r chown -R $DOKKU_APP_USER" || true
+  "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" "${ARG_ARRAY[@]}" $IMAGE /bin/bash -c "find $CONTAINER_PATHS -not -user $DOKKU_APP_USER -print0 | xargs -0 -r chown -R $DOKKU_APP_USER" || true
 }
 
 scheduler-docker-local-pre-deploy "$@"

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -18,6 +18,7 @@ scheduler-docker-local-scheduler-deploy() {
 
   rm -f "${DOKKU_LIB_ROOT}/data/scheduler-docker-local/$APP/failed-containers"
 
+  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
   local DOKKU_DOCKER_STOP_TIMEOUT DOKKU_HEROKUISH DOKKU_NETWORK_BIND_ALL IMAGE
   DOKKU_HEROKUISH=false
   IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
@@ -94,16 +95,16 @@ scheduler-docker-local-scheduler-deploy() {
         START_CMD=$(fn-scheduler-docker-local-extract-start-cmd "$APP" "$PROC_TYPE" "$START_CMD" "$DOKKU_HEROKUISH" "$DOKKU_PORT")
         if [[ "$DOKKU_NETWORK_BIND_ALL" == "false" ]]; then
           # shellcheck disable=SC2086
-          cid=$("$DOCKER_BIN" run $DOKKU_GLOBAL_RUN_ARGS -d -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
+          cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -d -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
         else
           # shellcheck disable=SC2086
-          cid=$("$DOCKER_BIN" run $DOKKU_GLOBAL_RUN_ARGS -d $DOKKU_DOCKER_PORT_ARGS -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
+          cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -d $DOKKU_DOCKER_PORT_ARGS -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
         fi
       else
         START_CMD=$(fn-scheduler-docker-local-extract-start-cmd "$APP" "$PROC_TYPE" "$START_CMD" "$DOKKU_HEROKUISH")
 
         # shellcheck disable=SC2086
-        cid=$("$DOCKER_BIN" run $DOKKU_GLOBAL_RUN_ARGS -d "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
+        cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -d "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
       fi
 
       ipaddr=$(plugn trigger network-get-ipaddr "$APP" "$PROC_TYPE" "$cid")

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -18,7 +18,7 @@ scheduler-docker-local-scheduler-deploy() {
 
   rm -f "${DOKKU_LIB_ROOT}/data/scheduler-docker-local/$APP/failed-containers"
 
-  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
   local DOKKU_DOCKER_STOP_TIMEOUT DOKKU_HEROKUISH DOKKU_NETWORK_BIND_ALL IMAGE
   DOKKU_HEROKUISH=false
   IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
@@ -95,16 +95,16 @@ scheduler-docker-local-scheduler-deploy() {
         START_CMD=$(fn-scheduler-docker-local-extract-start-cmd "$APP" "$PROC_TYPE" "$START_CMD" "$DOKKU_HEROKUISH" "$DOKKU_PORT")
         if [[ "$DOKKU_NETWORK_BIND_ALL" == "false" ]]; then
           # shellcheck disable=SC2086
-          cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -d -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
+          cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -d -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
         else
           # shellcheck disable=SC2086
-          cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -d $DOKKU_DOCKER_PORT_ARGS -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
+          cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -d $DOKKU_DOCKER_PORT_ARGS -e PORT=$DOKKU_PORT "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
         fi
       else
         START_CMD=$(fn-scheduler-docker-local-extract-start-cmd "$APP" "$PROC_TYPE" "$START_CMD" "$DOKKU_HEROKUISH")
 
         # shellcheck disable=SC2086
-        cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" -d "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
+        cid=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -d "${ARG_ARRAY[@]}" $IMAGE $START_CMD)
       fi
 
       ipaddr=$(plugn trigger network-get-ipaddr "$APP" "$PROC_TYPE" "$cid")

--- a/plugins/scheduler-docker-local/scheduler-docker-cleanup
+++ b/plugins/scheduler-docker-local/scheduler-docker-cleanup
@@ -12,17 +12,37 @@ scheduler-docker-local-scheduler-docker-cleanup() {
     return
   fi
 
-  # delete all non-running containers
-  # shellcheck disable=SC2046
-  "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=exited" -f "label=$DOKKU_CONTAINER_LABEL" -q) &>/dev/null || true
+  if [[ -n "$APP" ]]; then
+    # delete all non-running containers
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=exited" -f "label=$DOKKU_CONTAINER_LABEL" -f "label=com.dokku.app-name=$APP" -q) &>/dev/null || true
 
-  # delete all dead containers
-  # shellcheck disable=SC2046
-  "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=dead" -f "label=$DOKKU_CONTAINER_LABEL" -q) &>/dev/null || true
+    # delete all dead containers
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=dead" -f "label=$DOKKU_CONTAINER_LABEL" -f "label=com.dokku.app-name=$APP" -q) &>/dev/null || true
 
-  # delete unused images
-  # shellcheck disable=SC2046
-  "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -q) &>/dev/null &
+    # delete danging images
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -f "label=com.dokku.app-name=$APP" -q) &>/dev/null &
+
+    # delete unused images
+    docker image prune --all --filter "label=com.dokku.app-name=$APP" &>/dev/null &
+  else
+    # delete all non-running containers
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=exited" -f "label=$DOKKU_CONTAINER_LABEL" -q) &>/dev/null || true
+
+    # delete all dead containers
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rm $("$DOCKER_BIN" ps -a -f "status=dead" -f "label=$DOKKU_CONTAINER_LABEL" -q) &>/dev/null || true
+
+    # delete danging images
+    # shellcheck disable=SC2046
+    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -q) &>/dev/null &
+
+    # delete unused images
+    docker image prune --all &>/dev/null &
+  fi
 }
 
 scheduler-docker-local-scheduler-docker-cleanup "$@"

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -18,6 +18,7 @@ scheduler-docker-local-scheduler-run() {
     return
   fi
 
+  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
   local IMAGE_TAG=$(get_running_image_tag "$APP")
   local IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
 
@@ -66,7 +67,7 @@ scheduler-docker-local-scheduler-run() {
   fi
 
   # shellcheck disable=SC2086
-  "$DOCKER_BIN" run $DOKKU_GLOBAL_RUN_ARGS "${DOCKER_ARGS_ARRAY[@]}" $IMAGE $EXEC_CMD "$@"
+  "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" "${DOCKER_ARGS_ARRAY[@]}" $IMAGE $EXEC_CMD "$@"
 }
 
 scheduler-docker-local-scheduler-run "$@"

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -18,7 +18,7 @@ scheduler-docker-local-scheduler-run() {
     return
   fi
 
-  local DOCKER_RUN_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
   local IMAGE_TAG=$(get_running_image_tag "$APP")
   local IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
 
@@ -67,7 +67,7 @@ scheduler-docker-local-scheduler-run() {
   fi
 
   # shellcheck disable=SC2086
-  "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" "${DOKKU_GLOBAL_RUN_ARGS[@]}" "${DOCKER_ARGS_ARRAY[@]}" $IMAGE $EXEC_CMD "$@"
+  "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS "${DOCKER_ARGS_ARRAY[@]}" $IMAGE $EXEC_CMD "$@"
 }
 
 scheduler-docker-local-scheduler-run "$@"

--- a/tests/ci/setup.sh
+++ b/tests/ci/setup.sh
@@ -135,4 +135,3 @@ case "$1" in
     exit $?
     ;;
 esac
-

--- a/tests/unit/40_app-json.bats
+++ b/tests/unit/40_app-json.bats
@@ -30,7 +30,8 @@ teardown() {
   assert_success
 
   CID=$(docker ps -a -q  -f "ancestor=dokku/${TEST_APP}" -f "label=dokku_phase_script=postdeploy")
-  IMAGE_ID=$(docker commit $CID dokku-test/${TEST_APP})
+  DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$TEST_APP")
+  IMAGE_ID=$(docker commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" $CID dokku-test/${TEST_APP})
   run /bin/bash -c "docker run -ti $IMAGE_ID ls /app/postdeploy.test"
   echo "output: $output"
   echo "status: $status"


### PR DESCRIPTION
This is an incomplete WIP. Still thinking about how we might properly test this, and it doesn't cover image-based deploys.

- feat: add labels to all build, commit, create, and run docker calls
   This will allow us to further filter containers and images by application when cleaning up containers.

Closes #3515