### PR TITLE
Create a 502 error page to automatically refresh if backend status changes

### DIFF
--- a/plugins/nginx-vhosts/templates/502-error.html
+++ b/plugins/nginx-vhosts/templates/502-error.html
@@ -43,7 +43,6 @@
             retry_current *= 2;
           }
 
-          console.dir('Trying', window.location.href, 'in', retry_current, 'seconds...');
           setTimeout(check_gateway, retry_current * 1000);
         }
       };

--- a/plugins/nginx-vhosts/templates/502-error.html
+++ b/plugins/nginx-vhosts/templates/502-error.html
@@ -34,8 +34,6 @@
 
       request.onload = function () {
 
-        console.dir(window.location.href, 'returned', request.status);
-
         if (request.status >= 200 && request.status < 400) {
           window.location.reload(true);
         } else {

--- a/plugins/nginx-vhosts/templates/502-error.html
+++ b/plugins/nginx-vhosts/templates/502-error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
+  <title>We're sorry, but something went wrong (502)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   body {

--- a/plugins/nginx-vhosts/templates/502-error.html
+++ b/plugins/nginx-vhosts/templates/502-error.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>We're sorry, but something went wrong (500)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #6CABF7;
+    color: #fff;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+  div {
+    position:absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateX(-50%) translateY(-50%);
+  }
+  p {
+    color: #eee;
+  }
+  </style>
+
+  <script>
+    /* Attempt to automatically reload, assuming there's a temporary gateway issue */
+    var retry_current = 2; // First refresh at 2 seconds
+    var retry_limit = 4096; // Maximum backoff time, ~68 minutes
+
+    check_gateway = function () {
+
+      var request = new XMLHttpRequest();
+      request.open('HEAD', window.location.href, true);
+
+      request.onload = function () {
+
+        console.dir(window.location.href, 'returned', request.status);
+
+        if (request.status >= 200 && request.status < 400) {
+          window.location.reload(true);
+        } else {
+          if (retry_current < retry_limit) {
+            retry_current *= 2;
+          }
+
+          console.dir('Trying', window.location.href, 'in', retry_current, 'seconds...');
+          setTimeout(check_gateway, retry_current * 1000);
+        }
+      };
+
+      request.send();
+    };
+
+    setTimeout(check_gateway, retry_current * 1000);
+  </script>
+</head>
+
+<body>
+  <div>
+    <h1>We're sorry, but something went wrong.</h1>
+    <p>If you are the application owner check the logs for more information.</p>
+  </div>
+</body>
+</html>

--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -105,8 +105,14 @@ server {
     internal;
   }
 
-  error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+  error_page 500 501 503 504 505 506 507 508 509 510 511 /500-error.html;
   location /500-error.html {
+    root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
+    internal;
+  }
+
+  error_page 502 /502-error.html;
+  location /502-error.html {
     root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
     internal;
   }


### PR DESCRIPTION
If a container goes down and the gateway timeout returns a 502, periodically check the backend using a HEAD request. If the 502 is resolved (container reboots, etc.) then automatically refresh the page. Also uses a backoff to increase the time between checks.