### PR TITLE
fix: handle case where there are empty newlines in the authorized_keys file

### DIFF
--- a/plugins/ssh-keys/functions
+++ b/plugins/ssh-keys/functions
@@ -20,6 +20,7 @@ verify_ssh_key_file() {
 
   while read -r key; do
     line=$((line + 1))
+    [[ -z "$key" ]] && continue
     echo "$key" >"$TMP_KEY_FILE"
     ssh-keygen -lf "$TMP_KEY_FILE" &>/dev/null || dokku_log_fail "${DOKKU_ROOT}/.ssh/authorized_keys line $line failed ssh-keygen check."
   done <"${DOKKU_ROOT}/.ssh/authorized_keys"

--- a/tests/unit/30_ssh_keys.bats
+++ b/tests/unit/30_ssh_keys.bats
@@ -53,6 +53,10 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+  run /bin/bash -c 'echo "" >> "${DOKKU_ROOT:-/home/dokku}/.ssh/authorized_keys"'
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "dokku ssh-keys:list | grep name1"
   echo "output: $output"
   echo "status: $status"


### PR DESCRIPTION
Previously, an empty line would result in a failing ssh-keys:list call, or a failure to verify the file. Newlines should be ignored.

