### PR TITLE
Correct Bats path in single tests

### DIFF
--- a/tests/bats-exec-test-single
+++ b/tests/bats-exec-test-single
@@ -46,7 +46,8 @@ main() {
   TMP_OUTPUT=$(mktemp "/tmp/${FUNCNAME[0]}.XXXX")
   trap 'rm -rf "$TMP_OUTPUT" >/dev/null' RETURN INT TERM EXIT
 
-  /usr/local/libexec/bats-preprocess <"$TEST_FILE" >"$TMP_OUTPUT"
+  eval "$(grep "export BATS_TEST_PATTERN" </usr/local/libexec/bats-core/bats)"
+  /usr/local/libexec/bats-core/bats-preprocess <"$TEST_FILE" >"$TMP_OUTPUT"
   AVAILABLE_TESTS="$(fn-available-tests "$TMP_OUTPUT")"
   MATCHED_TEST=$(fn-matched-test "$TEST_NAME" "$AVAILABLE_TESTS")
 
@@ -62,7 +63,7 @@ main() {
 
   echo "Running test: ${MATCHED_TEST}"
   export BATS_TEST_SOURCE="$TMP_OUTPUT"
-  /usr/local/libexec/bats-exec-test "$TEST_FILE" "$(fn-real-test-name "$MATCHED_TEST")"
+  /usr/local/libexec/bats-core/bats-exec-test "$TEST_FILE" "$(fn-real-test-name "$MATCHED_TEST")"
 }
 
 main "$@"


### PR DESCRIPTION
**Fixed paths to Bats script**
Bats-core moved scripts to `libexec/bats-core/` (see https://github.com/bats-core/bats-core/commit/e8a2774534c070990b4b13818ac8ddacae6009c5).

**Set `BATS_TEST_PATTERN` for `bats-preprocess`**
Regex pattern for tests moved out of `bats-preprocess` into `bats` (see https://github.com/bats-core/bats-core/commit/f5acd286129e3b68945a33da7d74ece82564ac57).

Now the pattern must be exported as `BATS_TEST_PATTERN` before executing `bat-preprocess`, so that line is grepped and executed.

`eval` is used because otherwise `"` and `\$` are read literally.