### PR TITLE
[config] validate args for config:set and config:unset

### DIFF
--- a/plugins/config/subcommands.go
+++ b/plugins/config/subcommands.go
@@ -62,6 +62,9 @@ func CommandClear(args []string, global bool, noRestart bool) {
 //CommandUnset implements config:unset
 func CommandUnset(args []string, global bool, noRestart bool) {
 	appName, keys := getCommonArgs(global, args)
+	if len(keys) == 0 {
+		common.LogFail("At least one key must be given")
+	}
 	err := UnsetMany(appName, keys, !noRestart)
 	if err != nil {
 		common.LogFail(err.Error())
@@ -71,6 +74,9 @@ func CommandUnset(args []string, global bool, noRestart bool) {
 //CommandSet implements config:set
 func CommandSet(args []string, global bool, noRestart bool, encoded bool) {
 	appName, pairs := getCommonArgs(global, args)
+	if len(pairs) == 0 {
+		common.LogFail("At least one env pair must be given")
+	}
 	updated := make(map[string]string)
 	for _, e := range pairs {
 		parts := strings.SplitN(e, "=", 2)

--- a/tests/unit/20_config.bats
+++ b/tests/unit/20_config.bats
@@ -69,6 +69,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
+  run /bin/bash -c "dokku config:set $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "FAILED: At least one env pair must be given"
+  [ "$status" -eq 1 ]
+
   run /bin/bash -c "dokku config:get $TEST_APP test_var1 | grep true"
   echo "output: $output"
   echo "status: $status"
@@ -88,6 +94,11 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+  run /bin/bash -c "dokku --app $TEST_APP config:set"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "FAILED: At least one env pair must be given"
+  [ "$status" -eq 1 ]
 
   run /bin/bash -c "dokku --app $TEST_APP config:get test_var1 | grep true"
   echo "output: $output"
@@ -128,6 +139,11 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_output ""
+  run /bin/bash -c "dokku config:unset $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "FAILED: At least one key must be given"
+  [ "$status" -eq 1 ]
 }
 
 @test "(config) global config (herokuish)" {


### PR DESCRIPTION
Fixes dokku/dokku#3606

```
$ dokku config:unset envtest
FAILED: At least one key must be given
$ dokku config:set envtest
FAILED: At least one env pair must be given
```

Related: at the moment it's a warning to `config:unset` a key that doesn't exist but the app is still restarted. Likewise, setting a key to the same value will restart the app. Heroku seems to restart the app unconditionally in those cases like dokku does, so that is all OK right?

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.