### PR TITLE
Remove old reference to SPONSORS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Docker powered mini-Heroku. The smallest PaaS implementation you've ever seen.
 
 ## Sponsors
 
-See our list of past sponsors in the [SPONSORS](https://github.com/dokku/dokku/blob/master/SPONSORS.md) file.
-
 Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/dokku#sponsor)]
 
 <a href="https://opencollective.com/dokku/sponsor/0/website" target="_blank"><img src="https://opencollective.com/dokku/sponsor/0/avatar.svg"></a>


### PR DESCRIPTION
Anyone wishing to sponsor should do so on Patreon or OpenCollective.

Closes #3624