### PR TITLE
Make image removal synchronous

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -649,9 +649,6 @@ docker_cleanup() {
     # delete danging images
     # shellcheck disable=SC2046
     "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -q) &>/dev/null || true
-
-    # delete unused images
-    "$DOCKER_BIN" image prune --all &>/dev/null || true
   fi
 }
 

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -636,7 +636,7 @@ docker_cleanup() {
     "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -f "label=com.dokku.app-name=$APP" -q) &>/dev/null || true
 
     # delete unused images
-    "$DOCKER_BIN" image prune --all --filter "label=com.dokku.app-name=$APP" &>/dev/null || true
+    "$DOCKER_BIN" image prune --all --filter "label=com.dokku.app-name=$APP" --force &>/dev/null || true
   else
     # delete all non-running containers
     # shellcheck disable=SC2046

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -633,10 +633,10 @@ docker_cleanup() {
 
     # delete danging images
     # shellcheck disable=SC2046
-    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -f "label=com.dokku.app-name=$APP" -q) &>/dev/null &
+    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -f "label=com.dokku.app-name=$APP" -q) &>/dev/null || true
 
     # delete unused images
-    docker image prune --all --filter "label=com.dokku.app-name=$APP" &>/dev/null &
+    "$DOCKER_BIN" image prune --all --filter "label=com.dokku.app-name=$APP" &>/dev/null || true
   else
     # delete all non-running containers
     # shellcheck disable=SC2046
@@ -648,10 +648,10 @@ docker_cleanup() {
 
     # delete danging images
     # shellcheck disable=SC2046
-    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -q) &>/dev/null &
+    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -q) &>/dev/null || true
 
     # delete unused images
-    docker image prune --all &>/dev/null &
+    "$DOCKER_BIN" image prune --all &>/dev/null || true
   fi
 }
 

--- a/plugins/scheduler-docker-local/scheduler-docker-cleanup
+++ b/plugins/scheduler-docker-local/scheduler-docker-cleanup
@@ -23,10 +23,10 @@ scheduler-docker-local-scheduler-docker-cleanup() {
 
     # delete danging images
     # shellcheck disable=SC2046
-    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -f "label=com.dokku.app-name=$APP" -q) &>/dev/null &
+    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -f "label=com.dokku.app-name=$APP" -q) &>/dev/null || true
 
     # delete unused images
-    docker image prune --all --filter "label=com.dokku.app-name=$APP" &>/dev/null &
+    "$DOCKER_BIN" image prune --all --filter "label=com.dokku.app-name=$APP" &>/dev/null || true
   else
     # delete all non-running containers
     # shellcheck disable=SC2046
@@ -38,10 +38,10 @@ scheduler-docker-local-scheduler-docker-cleanup() {
 
     # delete danging images
     # shellcheck disable=SC2046
-    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -q) &>/dev/null &
+    "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -q) &>/dev/null || true
 
     # delete unused images
-    docker image prune --all &>/dev/null &
+    "$DOCKER_BIN" image prune --all &>/dev/null || true
   fi
 }
 

--- a/plugins/scheduler-docker-local/scheduler-docker-cleanup
+++ b/plugins/scheduler-docker-local/scheduler-docker-cleanup
@@ -26,7 +26,7 @@ scheduler-docker-local-scheduler-docker-cleanup() {
     "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -f "label=com.dokku.app-name=$APP" -q) &>/dev/null || true
 
     # delete unused images
-    "$DOCKER_BIN" image prune --all --filter "label=com.dokku.app-name=$APP" &>/dev/null || true
+    "$DOCKER_BIN" image prune --all --filter "label=com.dokku.app-name=$APP" --force &>/dev/null || true
   else
     # delete all non-running containers
     # shellcheck disable=SC2046

--- a/plugins/scheduler-docker-local/scheduler-docker-cleanup
+++ b/plugins/scheduler-docker-local/scheduler-docker-cleanup
@@ -39,9 +39,6 @@ scheduler-docker-local-scheduler-docker-cleanup() {
     # delete danging images
     # shellcheck disable=SC2046
     "$DOCKER_BIN" rmi $("$DOCKER_BIN" images -f 'dangling=true' -q) &>/dev/null || true
-
-    # delete unused images
-    "$DOCKER_BIN" image prune --all &>/dev/null || true
   fi
 }
 


### PR DESCRIPTION
Asynchronous image removal would remove intermediate build images during the build process, causing intermittent build failures for users of multi-stage dockerfiles. While we still remove intermediate docker images that may be used in the current build, we now do so during the deploy, ensuring that there are no intermediate build failures in the future.

Closes #3474
