### PR TITLE
Avoid calling the user-auth trigger where possible

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -672,6 +672,12 @@ dokku_auth() {
   declare desc="calls user-auth plugin trigger"
   export SSH_USER=${SSH_USER:=$USER}
   export SSH_NAME=${NAME:="default"}
+
+  # this plugin trigger exists in the core `20_events` plugin
+  if [[ $(find "$PLUGIN_PATH"/enabled/*/user-auth 2>/dev/null | wc -l) == 1 ]]; then
+    return 0
+  fi
+
   if ! plugn trigger user-auth "$SSH_USER" "$SSH_NAME" "$@"; then
     return 1
   fi


### PR DESCRIPTION
As this trigger is always in the execution path, `plugn` starts and expensively checks to see if it can execute the trigger. Rather than call this on every invocation, skip the trigger if no non-core implementation exists.

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
