### PR TITLE
Pass SOURCECODE_WORK_DIR to build-buildpack triggers

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -745,7 +745,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 - Description: Allows you to run commands after the build image is create for a given app. Only applies to apps using buildpacks.
 - Invoked by: `internal function dokku_build() (build phase)`
-- Arguments: `$APP`
+- Arguments: `$APP` `$SOURCECODE_WORK_DIR`
 - Example:
 
 ```shell
@@ -1005,7 +1005,7 @@ dokku config:set --no-restart $APP MANUALLY_STOPPED=1
 
 - Description: Allows you to run commands before the build image is created for a given app. For instance, this can be useful to add env vars to your container. Only applies to apps using buildpacks.
 - Invoked by: `internal function dokku_build() (build phase)`
-- Arguments: `$APP`
+- Arguments: `$APP` `$SOURCECODE_WORK_DIR`
 - Example:
 
 ```shell

--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -33,7 +33,7 @@ trigger-builder-build-builder-herokuish() {
 
   "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
   [[ -d $DOKKU_APP_CACHE_DIR ]] || mkdir -p "$DOKKU_APP_CACHE_DIR"
-  plugn trigger pre-build-buildpack "$APP"
+  plugn trigger pre-build-buildpack "$APP" "$SOURCECODE_WORK_DIR"
 
   local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$BUILDER_TYPE")
   [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" -e TRACE=true "
@@ -48,7 +48,7 @@ trigger-builder-build-builder-herokuish() {
 
   "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
 
-  plugn trigger post-build-buildpack "$APP"
+  plugn trigger post-build-buildpack "$APP" "$SOURCECODE_WORK_DIR"
 }
 
 trigger-builder-build-builder-herokuish "$@"


### PR DESCRIPTION
This will allow those triggers to insert and extract files from the sourcecode work directory. Note that changes are not committed to this directory, nor will they be reflected in the committed codebase.