### PR TITLE
Use version in DOKKU_LIB_ROOT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,10 +108,11 @@ addman: help2man man-db
 	mandb
 
 version:
+	mkdir -p ${DOKKU_LIB_ROOT}
 ifeq ($(DOKKU_VERSION),master)
-	git describe --tags > ~dokku/VERSION  2>/dev/null || echo '~${DOKKU_VERSION} ($(shell date -uIminutes))' > ~dokku/VERSION
+	git describe --tags > ${DOKKU_LIB_ROOT}/VERSION  2>/dev/null || echo '~${DOKKU_VERSION} ($(shell date -uIminutes))' > ${DOKKU_LIB_ROOT}/VERSION
 else
-	echo $(DOKKU_VERSION) > ~dokku/VERSION
+	echo $(DOKKU_VERSION) > ${DOKKU_LIB_ROOT}/STABLE_VERSION
 endif
 
 plugin-dependencies: plugn procfile-util

--- a/debian/postinst
+++ b/debian/postinst
@@ -88,11 +88,6 @@ setup-sshcommand() {
   fi
 }
 
-setup-version() {
-  rm -f "${DOKKU_ROOT}/VERSION"
-  cp "${DOKKU_LIB_ROOT}/STABLE_VERSION" "${DOKKU_ROOT}/VERSION"
-}
-
 setup-dokku-installer() {
   if [[ -f /etc/nginx/conf.d/dokku-installer.conf ]]; then
     echo "Setting up dokku-installer"
@@ -155,7 +150,6 @@ case "$1" in
     setup-storage
     setup-plugins
     setup-sshcommand
-    setup-version
     setup-dokku-installer
     dpkg-handling
     ;;

--- a/dokku
+++ b/dokku
@@ -244,8 +244,13 @@ case "$1" in
     ;;
 
   version | -v | --version)
-    test -f "$DOKKU_ROOT/VERSION" || dokku_log_fail "Unable to determine dokku's version"
-    DOKKU_VERSION=$(cat "${DOKKU_ROOT}/VERSION")
+    if [[ -f "$DOKKU_LIB_ROOT/STABLE_VERSION" ]]; then
+      DOKKU_VERSION=$(cat "${DOKKU_LIB_ROOT}/STABLE_VERSION")
+    elif [[ -f "$DOKKU_LIB_ROOT/VERSION" ]]; then
+      DOKKU_VERSION=$(cat "${DOKKU_LIB_ROOT}/VERSION")
+    else
+      dokku_log_fail "Unable to determine dokku's version"
+    fi
     echo "dokku version ${DOKKU_VERSION}"
     ;;
 

--- a/rpm/dokku.postinst
+++ b/rpm/dokku.postinst
@@ -48,11 +48,6 @@ setup-sshcommand() {
   fi
 }
 
-setup-version() {
-  rm -f "${DOKKU_ROOT}/VERSION"
-  cp "${DOKKU_LIB_ROOT}/STABLE_VERSION" "${DOKKU_ROOT}/VERSION"
-}
-
 main() {
   if [[ -r /etc/default/dokku ]]; then
     # shellcheck disable=SC1091
@@ -66,7 +61,6 @@ main() {
   setup-storage
   setup-plugins
   setup-sshcommand
-  setup-version
 }
 
 main


### PR DESCRIPTION
The version in DOKKU_ROOT may be incorrect for docker-based installs if that directory is mounted from an external volume. Instead, pull it from the DOKKU_LIB_ROOT directory, and respect the STABLE_VERSION if specified (VERSION will be the entire version, including commit sha).