### PR TITLE
Clarify --cpu mapping for docker-local scheduler

### DIFF
--- a/docs/advanced-usage/deployment-tasks.md
+++ b/docs/advanced-usage/deployment-tasks.md
@@ -34,7 +34,7 @@ Each "phase" has different expectations and limitations:
 
 Please keep the above in mind when utilizing deployment tasks.
 
-> To execute commands on the host during a release phase, see the [plugin creation documentation](/docs/development/plugin-creation) docs for more information on building your own custom plugin.
+> To execute commands on the host during a release phase, see the [plugin creation documentation](/docs/development/plugin-creation.md) docs for more information on building your own custom plugin.
 
 ## `app.json` deployment tasks
 

--- a/docs/advanced-usage/resource-management.md
+++ b/docs/advanced-usage/resource-management.md
@@ -27,11 +27,7 @@ Valid resource options include:
 - `--network-ingress`
 - `--network-egress`
 
-For example, when using the docker-local scheduler the `--cpu` resource limit maps to the `--cpus` Docker run flag. From the Docker docs on the `--cpus` flag:
-
-> Specify how much of the available CPU resources a container can use. For instance, if the host machine has two CPUs and you set `--cpus="1.5"`, the container is guaranteed at most one and a half of the CPUs. This is the equivalent of setting `--cpu-period="100000"` and `--cpu-quota="150000"`.
-
-So setting `resource:limit` for cpu to 100 when using the docker-local scheduler means your app can access at most 100 CPUs. If you have fewer than 100 CPUs on your server, then your app will be able to access all of them.
+See the [Supported Resource Management Properties](/docs/advanced-usage/schedulers/docker-local.md#supported-resource-management-properties) section of the docker local scheduler documentation for more information on how each resource limit maps to Docker.
 
 Resource limits and reservations are applied only during the `run` and `deploy` phases of an application, and will not impact the `build` phase of an application.
 

--- a/docs/advanced-usage/resource-management.md
+++ b/docs/advanced-usage/resource-management.md
@@ -27,6 +27,12 @@ Valid resource options include:
 - `--network-ingress`
 - `--network-egress`
 
+For example, when using the docker-local scheduler the `--cpu` resource limit maps to the `--cpus` Docker run flag. From the Docker docs on the `--cpus` flag:
+
+> Specify how much of the available CPU resources a container can use. For instance, if the host machine has two CPUs and you set `--cpus="1.5"`, the container is guaranteed at most one and a half of the CPUs. This is the equivalent of setting `--cpu-period="100000"` and `--cpu-quota="150000"`.
+
+So setting `resource:limit` for cpu to 100 when using the docker-local scheduler means your app can access at most 100 CPUs. If you have fewer than 100 CPUs on your server, then your app will be able to access all of them.
+
 Resource limits and reservations are applied only during the `run` and `deploy` phases of an application, and will not impact the `build` phase of an application.
 
 ### Resource Limits

--- a/docs/advanced-usage/schedulers/docker-local.md
+++ b/docs/advanced-usage/schedulers/docker-local.md
@@ -66,9 +66,13 @@ The `docker-local` scheduler supports a minimal list of resource _limits_ and _r
 ### Resource Limits
 
 - cpu: (docker option: `--cpus`), and is specified in number of CPUs a process can access.
-- memory: (docker option: `--memory`) and should be specified with a suffix of `b` (bytes), `k` (kilobytes), `m` (megabytes), `g` (gigabytes)
+  - See the ["CPU" section](https://docs.docker.com/config/containers/resource_constraints/#cpu) of the Docker Runtime Options documentation for more information.
+- memory: (docker option: `--memory`) and should be specified with a suffix of `b` (bytes), `k` (kilobytes), `m` (megabytes), `g` (gigabytes).
+  - See the ["Memory" section](https://docs.docker.com/config/containers/resource_constraints/#memory) of the Docker Runtime Options documentation for more information.
 - memory-swap: (docker option: `--memory-swap`) and should be specified with a suffix of `b` (bytes), `k` (kilobytes), `m` (megabytes), `g` (gigabytes)
+  - See the ["Memory" section](https://docs.docker.com/config/containers/resource_constraints/#memory) of the Docker Runtime Options documentation for more information.
 
 ### Resource Reservations
 
 - memory: (docker option: `--memory-reservation`) and should be specified with a suffix of `b` (bytes), `k` (kilobytes), `m` (megabytes), `g` (gigabytes)
+  - See the ["Memory" section](https://docs.docker.com/config/containers/resource_constraints/#memory) of the Docker Runtime Options documentation for more information.


### PR DESCRIPTION
[ci skip]

Clarifies a bit the default mapping of `resource:limit` for `cpu` to the underlying docker-local scheduler `--cpus` flag. 
Should make it clearer what the examples actually do when using `resource:limit --cpu 100`.