### PR TITLE
Show error message when docker-related build commands fail

### DIFF
--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -29,7 +29,10 @@ trigger-builder-build-builder-herokuish() {
   [[ -n "$NEW_DOKKU_IMAGE" ]] && DOKKU_IMAGE="$NEW_DOKKU_IMAGE"
 
   CID=$(tar -c . | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /app && tar -xC /app")
-  test "$("$DOCKER_BIN" wait "$CID")" -eq 0
+  if test "$("$DOCKER_BIN" wait "$CID")" -ne 0; then
+    dokku_log_warn "Failure extracting app code"
+    return 1
+  fi
 
   "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
   [[ -d $DOKKU_APP_CACHE_DIR ]] || mkdir -p "$DOKKU_APP_CACHE_DIR"
@@ -44,7 +47,10 @@ trigger-builder-build-builder-herokuish() {
   # shellcheck disable=SC2086
   CID=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -d -v $DOKKU_APP_HOST_CACHE_DIR:/cache -e CACHE_PATH=/cache "${ARG_ARRAY[@]}" $IMAGE /build)
   "$DOCKER_BIN" attach "$CID"
-  test "$("$DOCKER_BIN" wait "$CID")" -eq 0
+  if test "$("$DOCKER_BIN" wait "$CID")" -ne 0; then
+    dokku_log_warn "Failure during app build"
+    return 1
+  fi
 
   "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
 

--- a/plugins/builder-herokuish/builder-release
+++ b/plugins/builder-herokuish/builder-release
@@ -20,13 +20,19 @@ trigger-builder-release-builder-herokuish() {
   plugn trigger pre-release-buildpack "$APP" "$IMAGE_TAG"
   if [[ -n $(config_export global) ]]; then
     CID=$(config_export global | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh")
-    test "$("$DOCKER_BIN" wait "$CID")" -eq 0
+    if test "$("$DOCKER_BIN" wait "$CID")" -ne 0; then
+      dokku_log_warn "Failure injecting global environment variables"
+      return 1
+    fi
 
     "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
   fi
   if [[ -n $(config_export app "$APP") ]]; then
     CID=$(config_export app "$APP" | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh")
-    test "$("$DOCKER_BIN" wait "$CID")" -eq 0
+    if test "$("$DOCKER_BIN" wait "$CID")" -ne 0; then
+      dokku_log_warn "Failure injecting app environment variables"
+      return 1
+    fi
 
     "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
   fi

--- a/plugins/builder-herokuish/pre-build-buildpack
+++ b/plugins/builder-herokuish/pre-build-buildpack
@@ -23,13 +23,19 @@ trigger-pre-build-buildpack-builder-herokuish() {
   # create build env files for use in buildpacks like this:
   # https://github.com/niteoweb/heroku-buildpack-buildout/blob/5879fa3418f7d8e079f1aa5816ba1adde73f4948/bin/compile#L34
   CID=$(config_bundle --merged "$APP" | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /tmp/env; cat | tar -x -C /tmp/env")
-  test "$("$DOCKER_BIN" wait "$CID")" -eq 0
+  if test "$("$DOCKER_BIN" wait "$CID")" -ne 0; then
+    dokku_log_warn "Failure injecting BUILD_ENV into build environment"
+    return 1
+  fi
 
   "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
 
   # create build env for 'old style' buildpacks and dokku plugins
   CID=$(config_export app "$APP" --format envfile --merged | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "cat >> /app/.env")
-  test "$("$DOCKER_BIN" wait "$CID")" -eq 0
+  if test "$("$DOCKER_BIN" wait "$CID")" -ne 0; then
+    dokku_log_warn "Failure injecting old-style BUILD_ENV"
+    return 1
+  fi
 
   "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
 }


### PR DESCRIPTION
This makes it more apparent that a deploy has failed than the silent error exit that might otherwise happen.
