### PR TITLE
Allow keeping the git directory during builds

### DIFF
--- a/docs/deployment/methods/git.md
+++ b/docs/deployment/methods/git.md
@@ -76,3 +76,28 @@ This behavior can be disabled entirely on a per-app basis by setting the `rev-en
 # override for a specific app
 dokku git:set node-js-app rev-env-var ""
 ```
+
+### Keeping the `.git` directory
+
+By default, Dokku will remove the contents of the `.git` before triggering a build for a given app. This is generally a safe default as shipping the entire source code history of your app in the deployed image artifact is unnecessary as it increases bloat and potentially can leak information if there are any security issues with your app code.
+
+To enable the `.git` directory, run the `git:set` command as follows:
+
+```shell
+# on the Dokku host
+
+# keep the .git directory during builds
+dokku git:set node-js-app keep-git-dir true
+```
+
+The default behavior is to delete this directory and it's contents. To revert to the default behavior, the `keep-git-dir` value can be set to either an empty string or `false`.
+
+```shell
+# on the Dokku host
+
+# delete the .git directory during builds (default)
+dokku git:set node-js-app keep-git-dir false
+
+# delete the .git directory during builds (default)
+dokku git:set node-js-app keep-git-dir ""
+```

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -67,7 +67,10 @@ git_build_app_repo() {
   fi
 
   suppress_output env -u GIT_QUARANTINE_PATH git submodule update --init --recursive
-  find . -name .git -prune -exec rm -rf {} \; >/dev/null
+  local DOKKU_KEEP_GIT_DIR="$(fn-plugin-property-get "git" "$APP" "keep-git-dir" "")"
+  if [[ "$DOKKU_KEEP_GIT_DIR" != "true" ]]; then
+    find . -name .git -prune -exec rm -rf {} \; >/dev/null
+  fi
 
   if use_git_worktree; then
     pushd "$DOKKU_ROOT/$APP" >/dev/null

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -35,9 +35,10 @@ cmd-git-report-single() {
   fi
   verify_app_name "$APP"
   local flag_map=(
-    "--git-rev-env-var: $(fn-plugin-property-get "git" "$APP" "rev-env-var" "GIT_REV")"
     "--git-deploy-branch: $(fn-plugin-property-get "git" "$APP" "deploy-branch" "master")"
     "--git-global-deploy-branch: $(fn-plugin-property-get "git" "--global" "deploy-branch" "master")"
+    "--git-keep-git-dir: $(fn-plugin-property-get "git" "$APP" "keep-git-dir" "false")"
+    "--git-rev-env-var: $(fn-plugin-property-get "git" "$APP" "rev-env-var" "GIT_REV")"
   )
 
   if [[ -z "$INFO_FLAG" ]]; then

--- a/plugins/git/subcommands/set
+++ b/plugins/git/subcommands/set
@@ -19,12 +19,12 @@ git-set-cmd() {
   local cmd="git:set" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("deploy-branch" "rev-env-var")
+  local VALID_KEYS=("deploy-branch" "keep-git-dir" "rev-env-var")
   [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then
-    dokku_log_fail "Invalid key specified, valid keys include: deploy-branch, rev-env-var"
+    dokku_log_fail "Invalid key specified, valid keys include: deploy-branch, keep-git-dir, rev-env-var"
   fi
 
   if [[ -n "$VALUE" ]]; then


### PR DESCRIPTION
It may be desirable to keep the contents of the git directory for the build process. Certain build tools can extract extra information from the .git directory, and some workflows may require that the shipped artifact has the entire source code available locally for later usage.
