### PR TITLE
Force tty check to run with the default language

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -4,7 +4,7 @@ set -eo pipefail
 
 has_tty() {
   declare desc="return 0 if we have a tty"
-  if [[ "$(/usr/bin/tty || true)" == "not a tty" ]]; then
+  if [[ "$(LC_ALL=C /usr/bin/tty || true)" == "not a tty" ]]; then
     return 1
   else
     return 0


### PR DESCRIPTION
This fixes the case where the system language is non-english. See this stackexchange answer for more details: https://unix.stackexchange.com/q/87745

Closes #3588

