### PR TITLE
Allow passing labels to one-off dokku containers

### DIFF
--- a/docs/deployment/one-off-processes.md
+++ b/docs/deployment/one-off-processes.md
@@ -46,6 +46,12 @@ dokku --rm-container run node-js-app ls -lah
 dokku --rm run node-js-app ls -lah
 ```
 
+Containers may have specific labels attached. In order to avoid issues with dokku internals, do not use any labels beginning with either `com.dokku` or `org.label-schema`.
+
+```shell
+dokku --label=com.example.test-label=value run node-js-app ls -lah
+```
+
 Finally, you may wish to run a container in "detached" mode via the `--detach` Dokku flag. Running a process in detached mode will immediately return a `CONTAINER_ID`. It is up to the user to then further manage this container in whatever manner they see fit, as Dokku will *not* automatically terminate the container.
 
 ```shell

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -336,6 +336,8 @@ parse_args() {
   local next_index=1
   local skip=false
   local args=("$@")
+  local flags
+
   for arg in "$@"; do
     if [[ "$skip" == "true" ]]; then
       next_index=$((next_index + 1))
@@ -364,8 +366,22 @@ parse_args() {
         skip=true
         ;;
     esac
+
+    if [[ "$skip" == "true" ]]; then
+      flags="${flags} ${arg}"
+    elif [[ "$arg" == "--app" ]]; then
+      flags="${flags} ${arg}=${args[$next_index]}"
+    elif [[ "$arg" =~ ^--.* ]]; then
+      flags="${flags} ${arg}"
+    fi
+
     next_index=$((next_index + 1))
   done
+
+  if [[ -z "$DOKKU_GLOBAL_FLAGS" ]]; then
+    export DOKKU_GLOBAL_FLAGS="$(echo -e "${flags}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  fi
+
   return 0
 }
 

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -31,15 +31,15 @@ scheduler-docker-local-scheduler-run() {
   local DOCKER_ARGS=$(: | plugn trigger docker-args-run "$APP" "$IMAGE_TAG")
   [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" -e TRACE=true "
 
+  local DYNO_NUMBER="$RANDOM"
   local IMAGE_SOURCE_TYPE="dockerfile"
   is_image_herokuish_based "$IMAGE" && IMAGE_SOURCE_TYPE="herokuish"
   DOCKER_ARGS+=$(: | plugn trigger docker-args-process-run "$APP" "$IMAGE_TAG" "$IMAGE_SOURCE_TYPE")
-  DOCKER_ARGS+=" -e DYNO=run.$RANDOM"
+  DOCKER_ARGS+=" -e DYNO=run.$DYNO_NUMBER --name $APP.run.$DYNO_NUMBER"
 
   declare -a ARG_ARRAY
   eval "ARG_ARRAY=($DOCKER_ARGS)"
 
-  local DOKKU_RUN_OPTS=" -e DYNO=run.$RANDOM"
   if [[ "$DOKKU_RM_CONTAINER" ]]; then
     DOCKER_ARGS+=" --rm"
   elif [[ "$DOKKU_DETACH_CONTAINER" ]]; then
@@ -52,6 +52,15 @@ scheduler-docker-local-scheduler-run() {
   for env_pair in "${RUN_ENV[@]}"; do
     DOCKER_ARGS_ARRAY+=("--env=$env_pair")
   done
+
+  if [[ -n "$DOKKU_GLOBAL_FLAGS" ]]; then
+    read -ra flags <<<"$DOKKU_GLOBAL_FLAGS"
+    for flag in "${flags[@]}"; do
+      if [[ "$flag" =~ ^--label.* ]]; then
+        DOCKER_ARGS_ARRAY+=("$flag")
+      fi
+    done
+  fi
 
   [[ "$IMAGE_SOURCE_TYPE" == "herokuish" ]] && local EXEC_CMD="/exec"
 

--- a/tests/unit/30_core_1.bats
+++ b/tests/unit/30_core_1.bats
@@ -111,11 +111,16 @@ assert_urls() {
 @test "(core) run (detached)" {
   deploy_app
 
-  RANDOM_RUN_CID="$(dokku --detach run $TEST_APP sleep 300)"
+  RANDOM_RUN_CID="$(dokku --label=com.dokku.test-label=value --detach run $TEST_APP sleep 300)"
   run /bin/bash -c "docker inspect -f '{{ .State.Status }}' $RANDOM_RUN_CID"
   echo "output: $output"
   echo "status: $status"
   assert_output "running"
+
+  run /bin/bash -c "docker inspect $RANDOM_RUN_CID --format '{{ index .Config.Labels \"com.dokku.test-label\" }}'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "value"
 
   run /bin/bash -c "docker stop $RANDOM_RUN_CID"
   echo "output: $output"


### PR DESCRIPTION
This feature is allows users to add extra label metadata to one-off containers. As this can interfere with Dokku internals if they shadow labels used by plugins, care should be taken to avoid the `com.dokku` or `org.label-schema` namespace.
