### PR TITLE
Add scheduler-post-run trigger

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -143,7 +143,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
-APP="$1"; CONTAINERID="$2"; PROC_TYPE="$3"; PORT="$4" ; IP="$5"
+APP="$1"; CONTAINER_ID="$2"; PROC_TYPE="$3"; PORT="$4" ; IP="$5"
 
 eval "$(config_export app $APP)"
 DOKKU_DISABLE_DEPLOY="${DOKKU_DISABLE_DEPLOY:-false}"
@@ -1508,6 +1508,25 @@ DOKKU_SCHEDULER="$1"; APP="$2";
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 DOKKU_SCHEDULER="$1"; APP="$2"; IMAGE_TAG="$3";
+
+# TODO
+```
+
+### `scheduler-post-run`
+
+> Warning: The scheduler plugin trigger apis are under development and may change
+> between minor releases until the 1.0 release.
+
+- Description: Allows you to run scheduler commands after a `dokku run` invocation is called
+- Invoked by: `dokku run`
+- Arguments: `$DOKKU_SCHEDULER $APP $CONTAINER_ID`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+DOKKU_SCHEDULER="$1"; APP="$2"; CONTAINER_ID="$3";
 
 # TODO
 ```

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -9,6 +9,7 @@ scheduler-docker-local-scheduler-run() {
   declare desc="runs command in container based on app image"
   declare trigger="scheduler-docker-local scheduler-run"
   declare DOKKU_SCHEDULER="$1" APP="$2" ENV_COUNT="$3"
+  local CONTAINER_ID
   shift 3
 
   declare RUN_ENV=("${@:1:ENV_COUNT}")
@@ -42,10 +43,8 @@ scheduler-docker-local-scheduler-run() {
 
   if [[ "$DOKKU_RM_CONTAINER" ]]; then
     DOCKER_ARGS+=" --rm"
-  elif [[ "$DOKKU_DETACH_CONTAINER" ]]; then
-    DOCKER_ARGS+=" --detach"
   fi
-  has_tty && DOCKER_ARGS+=" -i -t"
+  has_tty && DOCKER_ARGS+=" --interactive --tty"
   # the output of docker-args-run is possibly quoted/escaped so eval to normalize
   declare -a DOCKER_ARGS_ARRAY
   eval "DOCKER_ARGS_ARRAY=($DOCKER_ARGS)"
@@ -76,7 +75,24 @@ scheduler-docker-local-scheduler-run() {
   fi
 
   # shellcheck disable=SC2086
-  "$DOCKER_BIN" container run --label=com.dokku.container-type=run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS "${DOCKER_ARGS_ARRAY[@]}" $IMAGE $EXEC_CMD "$@"
+  CONTAINER_ID="$("$DOCKER_BIN" container create --label=com.dokku.container-type=run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS "${DOCKER_ARGS_ARRAY[@]}" $IMAGE $EXEC_CMD "$@")"
+
+  declare -a DOCKER_START_ARGS_ARRAY
+  if [[ "$DOKKU_DETACH_CONTAINER" != "1" ]]; then
+    DOCKER_START_ARGS_ARRAY+=("--attach")
+  fi
+
+  local EARLY_EXIT_CODE=0 EXIT_CODE=0
+  if [[ "$DOKKU_DETACH_CONTAINER" == "1" ]]; then
+    "$DOCKER_BIN" container start "${DOCKER_START_ARGS_ARRAY[@]}" "$CONTAINER_ID" >/dev/null || CONTAINER_EXIT_CODE=$?
+    echo "$CONTAINER_ID"
+  else
+    "$DOCKER_BIN" container start "${DOCKER_START_ARGS_ARRAY[@]}" "$CONTAINER_ID" || CONTAINER_EXIT_CODE=$?
+    EXIT_CODE="$("$DOCKER_BIN" container wait "$CONTAINER_ID" 2>/dev/null || echo "$CONTAINER_EXIT_CODE")"
+    [[ -z "$EXIT_CODE" ]] && EXIT_CODE=0
+  fi
+  plugn trigger scheduler-post-run "$DOKKU_SCHEDULER" "$APP" "$CONTAINER_ID" "$EXIT_CODE"
+  return "$EXIT_CODE"
 }
 
 scheduler-docker-local-scheduler-run "$@"

--- a/tests/unit/30_core_1.bats
+++ b/tests/unit/30_core_1.bats
@@ -55,6 +55,7 @@ assert_urls() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+  docker rm $RANDOM_RUN_CID
 }
 
 @test "(core) run (with DOKKU_RM_CONTAINER/--rm-container)" {


### PR DESCRIPTION
After a `dokku run` container is created and started, this plugin trigger will allow developers to run auxiliary commands in response to that container.
