### PR TITLE
Docs / Getting Started: use HTTPS instead of SSH for clone

### DIFF
--- a/docs/deployment/application-deployment.md
+++ b/docs/deployment/application-deployment.md
@@ -9,7 +9,7 @@ Once you have configured Dokku with at least one user, you can deploy applicatio
 ```shell
 # from your local machine
 # SSH access to github must be enabled on this host
-git clone git@github.com:heroku/ruby-getting-started.git
+git clone https://github.com/heroku/ruby-getting-started
 ```
 
 ### Create the app


### PR DESCRIPTION
If the user has not yet added their public key to GitHub, using SSH for clone results in an error message due to permission denied. This is frequently the case for e.g. virtual machines used to trying out something.

Let me know if you want me to make any changes to this PR and thank you for all the work you put into dokku!

[ci skip]