### PR TITLE
Update DOKKU_SCALE from Procfile during ps:scale

### DIFF
--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -194,7 +194,17 @@ ps_scale() {
   local DOKKU_PROCFILE="$DOKKU_ROOT/$APP/DOKKU_PROCFILE"
   shift 1
 
-  [[ ! -e $DOKKU_SCALE_FILE ]] && generate_scale_file "$APP" "$IMAGE_TAG" >/dev/null 2>&1
+  # shellcheck disable=SC2015
+  [[ ! -e $DOKKU_PROCFILE ]] && extract_procfile "$APP" "$IMAGE_TAG" >/dev/null 2>&1 || true
+  if [[ ! -e $DOKKU_SCALE_FILE ]] ; then
+    generate_scale_file "$APP" "$IMAGE_TAG" >/dev/null 2>&1
+  elif [[ -e $DOKKU_PROCFILE ]] ; then
+    for PROC_NAME in $(procfile-util list --procfile "$DOKKU_PROCFILE"); do
+      if ! grep -qE "^${PROC_NAME}=" "$DOKKU_SCALE_FILE"; then
+        echo "$PROC_NAME=0" >> "$DOKKU_SCALE_FILE"
+      fi
+    done
+  fi
   if [[ -z "$@" ]]; then
     dokku_log_info1_quiet "Scaling for $APP"
     dokku_col_log_msg_quiet "proctype" "qty"

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -222,7 +222,7 @@ deploy_app() {
   local APP_TYPE=${APP_TYPE:="nodejs-express"}
   local GIT_REMOTE=${GIT_REMOTE:="dokku@dokku.me:$TEST_APP"}
   local GIT_REMOTE_BRANCH=${GIT_REMOTE_BRANCH:="master"}
-  local TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local TMP=${CUSTOM_TMP:=$(mktemp -d "/tmp/dokku.me.XXXXX")}
 
   rmdir "$TMP" && cp -r "${BATS_TEST_DIRNAME}/../../tests/apps/$APP_TYPE" "$TMP"
 
@@ -230,7 +230,7 @@ deploy_app() {
   [[ -n "$CUSTOM_TEMPLATE" ]] && $CUSTOM_TEMPLATE $TEST_APP $TMP/$CUSTOM_PATH
 
   pushd "$TMP" &>/dev/null || exit 1
-  trap 'popd &>/dev/null || true; rm -rf "$TMP"' RETURN INT TERM
+  [[ -z "$CUSTOM_TMP" ]] && trap 'popd &>/dev/null || true; rm -rf "$TMP"' RETURN INT TERM
 
   git init
   git config user.email "robot@example.com"


### PR DESCRIPTION
Part of https://github.com/plotly/streambed/issues/13523

This is intended to make the minimal change needed to fix the problem we're seeing. I've logged internal issues for:
* Consider how to handle processes removed from the `Procfile` that are already in `DOKKU_SCALE`: https://github.com/plotly/streambed/issues/13593
* `ps:scale` cleanups (avoid creating `DOKKU_SCALE` during the "can-scale" check, and consider some refactoring in `generate_scale_file`): https://github.com/plotly/streambed/issues/13594

I'm happy to log these in this repo as well if you think that's useful.