### PR TITLE
Isolated ps:scale

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -561,6 +561,7 @@ release_and_deploy() {
 
   local APP="$1"
   local IMAGE_TAG="$2"
+  local CUSTOM_SCALE="$3"
   local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
   local DOKKU_DOCKERFILE_PORTS
 
@@ -588,7 +589,7 @@ release_and_deploy() {
 
     if [[ "$DOKKU_SKIP_DEPLOY" != "true" ]]; then
       dokku_log_info1 "Deploying $APP ($IMAGE)..."
-      dokku_deploy_cmd "$APP" "$IMAGE_TAG"
+      dokku_deploy_cmd "$APP" "$IMAGE_TAG" "$CUSTOM_SCALE"
       dokku_log_info2 "Application deployed:"
       get_app_urls urls "$APP" | sed "s/^/       /"
     else

--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -218,7 +218,12 @@ ps_scale() {
   else
     if [[ "$(fn-ps-can-scale "$APP")" == "true" ]]; then
       set_scale "$APP" "$@"
-      release_and_deploy "$APP" "$IMAGE_TAG"
+      if [[ -z "$(config_get "$APP" DOKKU_ISOLATED_SCALE)" ]]; then
+        release_and_deploy "$APP" "$IMAGE_TAG"
+      else
+        local CUSTOM_SCALE=$(echo "$@" | awk '{ gsub(/ +/, "\n"); print }')
+        release_and_deploy "$APP" "$IMAGE_TAG" "$CUSTOM_SCALE"
+      fi
     else
       dokku_log_fail "App contains DOKKU_SCALE file and cannot be manually scaled"
     fi

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -10,7 +10,7 @@ source "$PLUGIN_AVAILABLE_PATH/scheduler-docker-local/internal-functions"
 scheduler-docker-local-scheduler-deploy() {
   declare desc="deploys an image tag for a given application"
   declare trigger="scheduler-docker-local scheduler-deploy"
-  declare DOKKU_SCHEDULER="$1" APP="$2" IMAGE_TAG="$3"
+  declare DOKKU_SCHEDULER="$1" APP="$2" IMAGE_TAG="$3" CUSTOM_SCALE="$4"
 
   if [[ "$DOKKU_SCHEDULER" != "docker-local" ]]; then
     return
@@ -29,6 +29,7 @@ scheduler-docker-local-scheduler-deploy() {
   local IMAGE_SOURCE_TYPE="dockerfile"
   [[ "$DOKKU_HEROKUISH" == "true" ]] && IMAGE_SOURCE_TYPE="herokuish"
   local DOKKU_SCALE_FILE="$DOKKU_ROOT/$APP/DOKKU_SCALE"
+  [[ ! -z "$CUSTOM_SCALE" ]] && DOKKU_SCALE_FILE=$CUSTOM_SCALE
   local oldids=$(get_app_container_ids "$APP")
 
   DOKKU_NETWORK_BIND_ALL="$(plugn trigger network-get-property "$APP" bind-all-interfaces)"


### PR DESCRIPTION
This is a draft / semi-pseudocode PR for implementing a new feature: **isolated ps:scale**. I'll try to improve the PR more, but wanted to put it out to catch early feature design issues.

Use case: When you call **dokku ps:scale [APP] ...**, you may not want to restart every dyno; instead, you may want to only stop and start the dyno(s) mentioned in the ps:scale command. This PR tries to implement this feature, via a config `DOKKU_ISOLATED_SCALE`.