### PR TITLE
Added new plugin

### DIFF
--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -242,6 +242,7 @@ The following plugins are available and provided by Dokku maintainers. Where not
 | [Wkhtmltopdf](https://github.com/mbriskar/dokku-wkhtmltopdf)                                      | [mbriskar][]          | 0.4.0+                |
 | [Dokku Wordpress](https://github.com/dokku-community/dokku-wordpress)                             | [dokku-community][]      | 0.4.0+                |
 | [Access](https://github.com/mainto/dokku-access)                                                  | [mainto](https://github.com/mainto)            | 0.4.0+                |
+| [Dokku Nginx Trust Proxy](https://github.com/kingsquare/dokku-nginx-vhost-trustproxy)             | [kingsquare](https://github.com/kingsquare)  | 0.4.0+ |
 
 ### Deprecated Plugins
 


### PR DESCRIPTION
This adds the Nginx Trust Proxy plugin

This plugin allows dokku to be run behind (multiple) proxies in and gives developers the opportunity to support reverse proxy layers

[ci skip]
