### PR TITLE
Detect correct python binary to use

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -92,6 +92,12 @@ setup-dokku-installer() {
   NGINX_ROOT="/etc/nginx"
   [[ -x /usr/bin/openresty ]] && NGINX_ROOT="/usr/local/openresty/nginx/conf"
 
+  if command -v "python3" &>/dev/null; then
+    sed -i '1 s/^.*$/#!\/usr\/bin\/env python3/' /usr/share/dokku/contrib/dokku-installer.py
+  elif command -v "python2.7" &>/dev/null; then
+    sed -i '1 s/^.*$/#!\/usr\/bin\/env python2.7/' /usr/share/dokku/contrib/dokku-installer.py
+  fi
+
   if [[ -f "$NGINX_ROOT/conf.d/dokku-installer.conf" ]]; then
     echo "Setting up dokku-installer"
     /usr/share/dokku/contrib/dokku-installer.py onboot

--- a/plugins/scheduler-docker-local/scheduler-inspect
+++ b/plugins/scheduler-docker-local/scheduler-inspect
@@ -48,7 +48,15 @@ EOF
   for CONTAINER_FILE in $CONTAINER_FILES; do
     CIDS+="$(<"$DOKKU_ROOT/$APP/$CONTAINER_FILE")"
   done
-  "$DOCKER_BIN" container inspect "${CIDS[@]}" | python2.7 "$TMP_INSPECT_CMD"
+
+  local PYTHON_BIN=python
+  if command -v "python3" &>/dev/null; then
+    PYTHON_BIN=python3
+  elif command -v "python2.7" &>/dev/null; then
+    PYTHON_BIN=python2.7
+  fi
+
+  "$DOCKER_BIN" container inspect "${CIDS[@]}" | "$PYTHON_BIN" "$TMP_INSPECT_CMD"
 
 }
 


### PR DESCRIPTION
Ideally python usage goes away - the dokku-installer should become a mandatory cli command, and the plugin is rewritten in golang - but for now, we need to use the correct binary when running dokku.

Closes #3714