### PR TITLE
dokku run do not supports interactive mode.

### DIFF
--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -80,8 +80,9 @@ scheduler-docker-local-scheduler-run() {
   declare -a DOCKER_START_ARGS_ARRAY
   if [[ "$DOKKU_DETACH_CONTAINER" != "1" ]]; then
     DOCKER_START_ARGS_ARRAY+=("--attach")
+
+    has_tty && DOCKER_START_ARGS_ARRAY+=" --interactive"
   fi
-  has_tty && DOCKER_START_ARGS_ARRAY+=" --interactive"
 
   local EARLY_EXIT_CODE=0 EXIT_CODE=0
   if [[ "$DOKKU_DETACH_CONTAINER" == "1" ]]; then

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -81,13 +81,14 @@ scheduler-docker-local-scheduler-run() {
   if [[ "$DOKKU_DETACH_CONTAINER" != "1" ]]; then
     DOCKER_START_ARGS_ARRAY+=("--attach")
   fi
+  has_tty && DOCKER_START_ARGS_ARRAY+=" --interactive"
 
   local EARLY_EXIT_CODE=0 EXIT_CODE=0
   if [[ "$DOKKU_DETACH_CONTAINER" == "1" ]]; then
-    "$DOCKER_BIN" container start "${DOCKER_START_ARGS_ARRAY[@]}" "$CONTAINER_ID" >/dev/null || CONTAINER_EXIT_CODE=$?
+    "$DOCKER_BIN" container start ${DOCKER_START_ARGS_ARRAY[@]} "$CONTAINER_ID" >/dev/null || CONTAINER_EXIT_CODE=$?
     echo "$CONTAINER_ID"
   else
-    "$DOCKER_BIN" container start "${DOCKER_START_ARGS_ARRAY[@]}" "$CONTAINER_ID" || CONTAINER_EXIT_CODE=$?
+    "$DOCKER_BIN" container start ${DOCKER_START_ARGS_ARRAY[@]} "$CONTAINER_ID" || CONTAINER_EXIT_CODE=$?
     EXIT_CODE="$("$DOCKER_BIN" container wait "$CONTAINER_ID" 2>/dev/null || echo "$CONTAINER_EXIT_CODE")"
     [[ -z "$EXIT_CODE" ]] && EXIT_CODE=0
   fi


### PR DESCRIPTION
After [!3687](https://github.com/dokku/dokku/pull/3687) I discovered is not possible anymore to use command `dokku run` in the interactive mode. e.g. using `bash`

The error seems to be related with the docker command. The command `docker run` accepts the flags `--interactive` which permits to keep STDIN/STDOUT opened. Instead `--interactive` param in the `docker create` command seems to have a different behaviour, indeed `docker start` accepts `--interactive` param as well.

The PR appends the param `--interactive` to `docker start` command.


```bash
vagrant@dokku:~$ dokku --version
dokku version 0.19.2
vagrant@dokku:~$ dokku apps:create test-app
-----> Creating test-app... done
vagrant@dokku:~$ docker pull alpine:latest
latest: Pulling from library/alpine
9d48c3bd43c5: Pull complete
Digest: sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb
Status: Downloaded newer image for alpine:latest
docker.io/library/alpine:latest
vagrant@dokku:~$ docker tag alpine:latest dokku/test-app:latest
vagrant@dokku:~$ dokku run test-app sh
/ # ls -la
```

```
vagrant@dokku:~$ dokku --version
dokku version 0.18.5
vagrant@dokku:~$ dokku apps:create test-app
-----> Creating test-app... done
vagrant@dokku:~$ docker pull alpine:latest
latest: Pulling from library/alpine
9d48c3bd43c5: Pull complete
Digest: sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb
Status: Downloaded newer image for alpine:latest
docker.io/library/alpine:latest
vagrant@dokku:~$ docker tag alpine:latest dokku/test-app:latest
vagrant@dokku:~$ dokku run test-app sh
/ # ls -la
total 64
drwxr-xr-x    1 root     root          4096 Oct 19 09:53 .
drwxr-xr-x    1 root     root          4096 Oct 19 09:53 ..
-rwxr-xr-x    1 root     root             0 Oct 19 09:53 .dockerenv
drwxr-xr-x    2 root     root          4096 Aug 20 10:30 bin
drwxr-xr-x    5 root     root           360 Oct 19 09:54 dev
drwxr-xr-x    1 root     root          4096 Oct 19 09:53 etc
drwxr-xr-x    2 root     root          4096 Aug 20 10:30 home
drwxr-xr-x    5 root     root          4096 Aug 20 10:30 lib
drwxr-xr-x    5 root     root          4096 Aug 20 10:30 media
drwxr-xr-x    2 root     root          4096 Aug 20 10:30 mnt
drwxr-xr-x    2 root     root          4096 Aug 20 10:30 opt
dr-xr-xr-x  112 root     root             0 Oct 19 09:54 proc
drwx------    1 root     root          4096 Oct 19 09:54 root
drwxr-xr-x    2 root     root          4096 Aug 20 10:30 run
drwxr-xr-x    2 root     root          4096 Aug 20 10:30 sbin
drwxr-xr-x    2 root     root          4096 Aug 20 10:30 srv
dr-xr-xr-x   13 root     root             0 Oct 19 09:54 sys
drwxrwxrwt    2 root     root          4096 Aug 20 10:30 tmp
drwxr-xr-x    7 root     root          4096 Aug 20 10:30 usr
drwxr-xr-x   11 root     root          4096 Aug 20 10:30 var
/ #
```
