### PR TITLE
Warn if key_file is missing on install but do not exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ A fresh VM running any of the following operating systems:
 - CentOS 7 x64 *(experimental)*
 - Arch Linux x64 *(experimental)*
 
+An SSH keypair that can be used for application deployment. If this exists before installation, it will be automatically imported into dokku.
+Otherwise, you will need to import the keypair manually after installation using `dokku ssh-keys:add`.
+
 ## Installation
 
 To install the latest stable release, run the following commands as a user who has access to `sudo`:

--- a/debian/preinst
+++ b/debian/preinst
@@ -60,10 +60,9 @@ case "$1" in
     if [ -z "${DEBCONF_RECONFIGURE}" ] && [ "$RET" != "true" ]; then
       db_get "dokku/key_file"
       if [ ! -f "$RET" ]; then
-        echo "Error: keyfile '$RET' not found."
-        echo "       you can enter a new keyfile path when you restart the installation."
+        echo "Error: keyfile '$RET' not found." >&2
+        echo "       To deploy, you will need to generate a keypair and add with 'dokku ssh-keys:add'."
         db_reset "dokku/key_file"
-        exit 1
       fi
     fi
     ;;


### PR DESCRIPTION
* Adjusts documentation
* Changes error messages when ssh key is not present
* Moves error messages to stderr
* Removes erroneous exit line

Closes #3717