### PR TITLE
Fix lost ability to run an interactive shell

### DIFF
--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -80,6 +80,7 @@ scheduler-docker-local-scheduler-run() {
   declare -a DOCKER_START_ARGS_ARRAY
   if [[ "$DOKKU_DETACH_CONTAINER" != "1" ]]; then
     DOCKER_START_ARGS_ARRAY+=("--attach")
+    has_tty && DOCKER_START_ARGS_ARRAY+=("--interactive") # --tty does not exist for docker container start
   fi
 
   local EARLY_EXIT_CODE=0 EXIT_CODE=0


### PR DESCRIPTION
Bug introduced between 0.18.5 and 0.19.5

A simple `dokku run app /bin/bash` would hang otherwise.
