### PR TITLE
Fix type-errors in dokku-installer.py

### DIFF
--- a/contrib/dokku-installer.py
+++ b/contrib/dokku-installer.py
@@ -207,11 +207,11 @@ class GetHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         max_num = 0
         exists = False
         for line in proc.stdout:
-            m = pattern.search(line)
+            m = pattern.search(bytes_to_string(line))
             if m:
                 # User of the form `user` or `user#` exists
                 exists = True
-                max_num = max(max_num, m.group(1))
+                max_num = max(max_num, int(m.group(1)))
         if exists:
             return max_num
         else:


### PR DESCRIPTION
Ran the installer on a clean Ubuntu 18.04.3 LTS node and got a 502 Bad Gateway on the initial setup page.

After debugging, identified there were two problems with the `dokku-installer.py` script (Python 3.6.8).

```
TypeError: cannot use a string pattern on a bytes-like object

TypeError: '>' not supported between instances of 'str' and 'int'
```

The two changes to the script fix these two type-errors (if I understood the intent of the code correctly).