### PR TITLE
Omit DWARF symbol table and debug information from go binaries

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -21,10 +21,10 @@ clean:
 	find . -xtype l -delete
 
 commands: **/**/commands.go
-	go build $(GO_ARGS) -o commands src/commands/commands.go
+	go build -ldflags="-s -w" $(GO_ARGS) -o commands src/commands/commands.go
 
 subcommands:
-	go build $(GO_ARGS) -o subcommands/subcommands src/subcommands/subcommands.go
+	go build -ldflags="-s -w" $(GO_ARGS) -o subcommands/subcommands src/subcommands/subcommands.go
 	$(MAKE) $(SUBCOMMANDS)
 
 subcommands/%:
@@ -34,7 +34,7 @@ src-clean:
 	rm -rf .gitignore src vendor Makefile *.go glide.*
 
 triggers:
-	go build $(GO_ARGS) -o triggers src/triggers/triggers.go
+	go build -ldflags="-s -w" $(GO_ARGS) -o triggers src/triggers/triggers.go
 	$(MAKE) $(TRIGGERS)
 
 triggers/%:

--- a/plugins/common/Makefile
+++ b/plugins/common/Makefile
@@ -5,6 +5,6 @@ clean-prop:
 	rm -rf prop
 
 prop: clean-prop **/**/prop.go
-	go build $(GO_ARGS) -o prop src/prop/prop.go
+	go build -ldflags="-s -w" $(GO_ARGS) -o prop src/prop/prop.go
 
 include ../../common.mk


### PR DESCRIPTION
This will reduce the size of binaries in exchange for worse debugging output. This is acceptable for our users and worth it to save money on packagecloud package hosting - which is currently free under a given repository size.
