### PR TITLE
Make default vhost example listen to ipv6

### DIFF
--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -121,7 +121,7 @@ Create the file at `/etc/nginx/conf.d/00-default-vhost.conf`:
 
 ```nginx
 server {
-    listen 80 default_server;
+    listen [::]:80 default_server;
     server_name _;
     access_log off;
     return 410;
@@ -137,7 +137,7 @@ server {
 # be copied into /etc/nginx/ssl/ folder.
 #
 # server {
-#     listen 443 ssl;
+#     listen [::]:443 ssl;
 #     server_name _;
 #     ssl_certificate /etc/nginx/ssl/cert.crt;
 #     ssl_certificate_key /etc/nginx/ssl/cert.key;

--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -121,7 +121,9 @@ Create the file at `/etc/nginx/conf.d/00-default-vhost.conf`:
 
 ```nginx
 server {
+    listen 80 default_server;
     listen [::]:80 default_server;
+
     server_name _;
     access_log off;
     return 410;
@@ -137,6 +139,7 @@ server {
 # be copied into /etc/nginx/ssl/ folder.
 #
 # server {
+#     listen 443 ssl;
 #     listen [::]:443 ssl;
 #     server_name _;
 #     ssl_certificate /etc/nginx/ssl/cert.crt;


### PR DESCRIPTION
[ci skip]

This PR adds listening to IPv6 in the default NGINX vHost of the config example, otherwise the vHost will not be hit for incoming IPv6 connections.