### PR TITLE
Add support for host-mode networking

### DIFF
--- a/plugins/network/network.go
+++ b/plugins/network/network.go
@@ -95,6 +95,12 @@ func GetContainerIpaddress(appName, processType, containerID string) (ipAddr str
 		return
 	}
 
+	if b, err := common.DockerInspect(containerID, "'{{ .HostConfig.NetworkMode }}'"); err == nil {
+		if string(b[:]) == "host" {
+			return "127.0.0.1"
+		}
+	}
+
 	b, err := common.DockerInspect(containerID, "'{{.NetworkSettings.Networks.bridge.IPAddress}}'")
 	if err != nil || len(b) == 0 {
 		// docker < 1.9 compatibility

--- a/tests/unit/20_network.bats
+++ b/tests/unit/20_network.bats
@@ -67,3 +67,20 @@ assert_external_port() {
     assert_external_port $(< $CID_FILE) failure
   done
 }
+
+@test "(proxy) network host-mode" {
+  run /bin/bash -c "dokku docker-options:add $TEST_APP deploy \"--network=host\""
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "curl --silent --write-out '%{http_code}\n' `dokku url $TEST_APP` | grep 200"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}


### PR DESCRIPTION
In host-mode, there is no 'bridge' network by default, so we return an invalid IP address of 'no value'. Instead, return '127.0.0.1' for those containers.
