### PR TITLE
rework docker-args-process trigger arguments

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -370,7 +370,7 @@ verify_app_name "$APP"
 
 - Description: `$PROC_TYPE` may be set to magic `_all_` process type to signify global docker deploy options.
 - Invoked by: `dokku ps:rebuild`
-- Arguments: `$APP $IMAGE_TAG $IMAGE_SOURCE_TYPE`
+- Arguments: `$APP $IMAGE_SOURCE_TYPE`
 - Example:
 
 ```shell
@@ -378,7 +378,8 @@ verify_app_name "$APP"
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
+
+APP="$1"; IMAGE_SOURCE_TYPE="$2"
 verify_app_name "$APP"
 
 # TODO
@@ -388,7 +389,7 @@ verify_app_name "$APP"
 
 - Description: `$PROC_TYPE` may be set to magic `_all_` process type to signify global docker deploy options.
 - Invoked by: `dokku deploy`
-- Arguments: `$APP $IMAGE_TAG $IMAGE_SOURCE_TYPE [$PROC_TYPE $CONTAINER_INDEX]`
+- Arguments: `$APP $IMAGE_SOURCE_TYPE $IMAGE_TAG [$PROC_TYPE $CONTAINER_INDEX]`
 - Example:
 
 ```shell
@@ -396,7 +397,7 @@ verify_app_name "$APP"
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
+APP="$1"; $IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3"; PROC_TYPE="$4"; CONTAINER_INDEX="$5"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
 verify_app_name "$APP"
 
 # TODO
@@ -406,7 +407,7 @@ verify_app_name "$APP"
 
 - Description: `$PROC_TYPE` may be set to magic `_all_` process type to signify global docker run options.
 - Invoked by: `dokku run`
-- Arguments: `$APP $IMAGE_TAG $IMAGE_SOURCE_TYPE`
+- Arguments: `$APP $IMAGE_SOURCE_TYPE $IMAGE_TAG`
 - Example:
 
 ```shell
@@ -414,7 +415,7 @@ verify_app_name "$APP"
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
+APP="$1"; IMAGE_SOURCE_TYPE="$3"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
 verify_app_name "$APP"
 
 # TODO

--- a/plugins/app-json/internal-functions
+++ b/plugins/app-json/internal-functions
@@ -87,7 +87,7 @@ execute_script() {
 
   local IMAGE_SOURCE_TYPE="dockerfile"
   is_image_herokuish_based "$IMAGE" "$APP" && IMAGE_SOURCE_TYPE="herokuish"
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_TAG" "$IMAGE_SOURCE_TYPE")
+  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG")
 
   # eval args as array to respect escapes
   declare -a ARG_ARRAY

--- a/plugins/builder-dockerfile/builder-build
+++ b/plugins/builder-dockerfile/builder-build
@@ -30,7 +30,7 @@ trigger-builder-build-builder-dockerfile() {
 
   [[ "$DOKKU_DOCKERFILE_CACHE_BUILD" == "false" ]] && DOKKU_DOCKER_BUILD_OPTS="$DOKKU_DOCKER_BUILD_OPTS --no-cache"
   local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$BUILDER_TYPE")
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-build "$APP" "$IMAGE_TAG" "$BUILDER_TYPE")
+  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")
 
   # strip --volume and -v args from DOCKER_ARGS
   local DOCKER_ARGS=$(sed -e "s/--volume=[[:graph:]]\+[[:blank:]]\?//g" -e "s/-v[[:blank:]]\?[[:graph:]]\+[[:blank:]]\?//g" <<<"$DOCKER_ARGS")

--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -40,7 +40,7 @@ trigger-builder-build-builder-herokuish() {
 
   local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$BUILDER_TYPE")
   [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" -e TRACE=true "
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-build "$APP" "$IMAGE_TAG" "$BUILDER_TYPE")
+  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")
 
   declare -a ARG_ARRAY
   eval "ARG_ARRAY=($DOCKER_ARGS)"

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -74,7 +74,7 @@ scheduler-docker-local-scheduler-deploy() {
       local DOCKER_ARGS
       DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")
       DOCKER_ARGS+=" -e DYNO=$PROC_TYPE.$CONTAINER_INDEX "
-      DOCKER_ARGS+=$(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_TAG" "$IMAGE_SOURCE_TYPE" "$PROC_TYPE" "$CONTAINER_INDEX")
+      DOCKER_ARGS+=$(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")
       [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" -e TRACE=true "
 
       declare -a ARG_ARRAY

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -35,7 +35,7 @@ scheduler-docker-local-scheduler-run() {
   local DYNO_NUMBER="$RANDOM"
   local IMAGE_SOURCE_TYPE="dockerfile"
   is_image_herokuish_based "$IMAGE" "$APP" && IMAGE_SOURCE_TYPE="herokuish"
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-run "$APP" "$IMAGE_TAG" "$IMAGE_SOURCE_TYPE")
+  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-run "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG")
   DOCKER_ARGS+=" -e DYNO=run.$DYNO_NUMBER --name $APP.run.$DYNO_NUMBER"
 
   declare -a ARG_ARRAY


### PR DESCRIPTION
The IMAGE_TAG is not always available, while the IMAGE_SOURCE_TYPE is. Since the point of these triggers was to unify the argument passed and make it easier to interact with them, this version makes more sense.

Closes #3780