### PR TITLE
DRY up reports in golang

### DIFF
--- a/plugins/buildpacks/buildpacks.go
+++ b/plugins/buildpacks/buildpacks.go
@@ -1,9 +1,6 @@
 package buildpacks
 
 import (
-	"fmt"
-	"os"
-	"reflect"
 	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
@@ -24,38 +21,7 @@ func ReportSingleApp(appName, infoFlag string) {
 		"--buildpacks-list": strings.Join(buildpacks, ","),
 	}
 
-	if len(infoFlag) == 0 {
-		common.LogInfo2Quiet(fmt.Sprintf("%s buildpacks information", appName))
-		for k, v := range infoFlags {
-			key := common.UcFirst(strings.Replace(strings.TrimPrefix(k, "--"), "-", " ", -1))
-			common.LogVerbose(fmt.Sprintf("%s%s", Right(fmt.Sprintf("%s:", key), 31, " "), v))
-		}
-		return
-	}
-
-	for k, v := range infoFlags {
-		if infoFlag == k {
-			fmt.Fprintln(os.Stdout, v)
-			return
-		}
-	}
-
-	keys := reflect.ValueOf(infoFlags).MapKeys()
-	strkeys := make([]string, len(keys))
-	for i := 0; i < len(keys); i++ {
-		strkeys[i] = keys[i].String()
-	}
-	common.LogFail(fmt.Sprintf("Invalid flag passed, valid flags: %s", strings.Join(strkeys, ", ")))
-}
-
-func times(str string, n int) (out string) {
-	for i := 0; i < n; i++ {
-		out += str
-	}
-	return
-}
-
-// Right right-pads the string with pad up to len runes
-func Right(str string, length int, pad string) string {
-	return str + times(pad, length-len(str))
+	trimPrefix := false
+	uppercaseFirstCharacter := true
+	common.ReportSingleApp("buildpacks", appName, infoFlag, infoFlags, trimPrefix, uppercaseFirstCharacter)
 }

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -355,7 +355,7 @@ func ReadFirstLine(filename string) (text string) {
 // ReportSingleApp is an internal function that displays a report for an app
 func ReportSingleApp(reportType string, appName string, infoFlag string, infoFlags map[string]string, trimPrefix bool, uppercaseFirstCharacter bool) {
 	flags := []string{}
-	for key, _ := range infoFlags {
+	for key := range infoFlags {
 		flags = append(flags, key)
 	}
 	sort.Strings(flags)

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -350,6 +352,55 @@ func ReadFirstLine(filename string) (text string) {
 	return
 }
 
+// ReportSingleApp is an internal function that displays a report for an app
+func ReportSingleApp(reportType string, appName string, infoFlag string, infoFlags map[string]string, trimPrefix bool, uppercaseFirstCharacter bool) {
+	flags := []string{}
+	for key, _ := range infoFlags {
+		flags = append(flags, key)
+	}
+	sort.Strings(flags)
+
+	if len(infoFlag) == 0 {
+		LogInfo2Quiet(fmt.Sprintf("%s %v information", appName, reportType))
+		for _, k := range flags {
+			v := infoFlags[k]
+			prefix := "--"
+			if trimPrefix {
+				prefix = fmt.Sprintf("--%v-", reportType)
+			}
+
+			key := strings.Replace(strings.Replace(strings.TrimPrefix(k, prefix), "-", " ", -1), ".", " ", -1)
+
+			if uppercaseFirstCharacter {
+				key = UcFirst(key)
+			}
+
+			LogVerbose(fmt.Sprintf("%s%s", RightPad(fmt.Sprintf("%s:", key), 31, " "), v))
+		}
+		return
+	}
+
+	for _, k := range flags {
+		if infoFlag == k {
+			v := infoFlags[k]
+			fmt.Fprintln(os.Stdout, v)
+			return
+		}
+	}
+
+	keys := reflect.ValueOf(infoFlags).MapKeys()
+	strkeys := make([]string, len(keys))
+	for i := 0; i < len(keys); i++ {
+		strkeys[i] = keys[i].String()
+	}
+	LogFail(fmt.Sprintf("Invalid flag passed, valid flags: %s", strings.Join(strkeys, ", ")))
+}
+
+// RightPad right-pads the string with pad up to len runes
+func RightPad(str string, length int, pad string) string {
+	return str + times(pad, length-len(str))
+}
+
 // StripInlineComments removes bash-style comment from input line
 func StripInlineComments(text string) string {
 	bytes := []byte(text)
@@ -414,4 +465,11 @@ func PlugnTrigger(triggerName string, args ...string) error {
 		shellArgs[i+2] = arg
 	}
 	return sh.Command("plugn", shellArgs...).Run()
+}
+
+func times(str string, n int) (out string) {
+	for i := 0; i < n; i++ {
+		out += str
+	}
+	return
 }

--- a/plugins/network/network.go
+++ b/plugins/network/network.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -225,38 +224,7 @@ func ReportSingleApp(appName, infoFlag string) {
 		"--network-listeners":           strings.Join(GetListeners(appName), " "),
 	}
 
-	if len(infoFlag) == 0 {
-		common.LogInfo2Quiet(fmt.Sprintf("%s network information", appName))
-		for k, v := range infoFlags {
-			key := common.UcFirst(strings.Replace(strings.TrimPrefix(k, "--"), "-", " ", -1))
-			common.LogVerbose(fmt.Sprintf("%s%s", Right(fmt.Sprintf("%s:", key), 31, " "), v))
-		}
-		return
-	}
-
-	for k, v := range infoFlags {
-		if infoFlag == k {
-			fmt.Fprintln(os.Stdout, v)
-			return
-		}
-	}
-
-	keys := reflect.ValueOf(infoFlags).MapKeys()
-	strkeys := make([]string, len(keys))
-	for i := 0; i < len(keys); i++ {
-		strkeys[i] = keys[i].String()
-	}
-	common.LogFail(fmt.Sprintf("Invalid flag passed, valid flags: %s", strings.Join(strkeys, ", ")))
-}
-
-func times(str string, n int) (out string) {
-	for i := 0; i < n; i++ {
-		out += str
-	}
-	return
-}
-
-// Right right-pads the string with pad up to len runes
-func Right(str string, length int, pad string) string {
-	return str + times(pad, length-len(str))
+	trimPrefix := false
+	uppercaseFirstCharacter := true
+	common.ReportSingleApp("network", appName, infoFlag, infoFlags, trimPrefix, uppercaseFirstCharacter)
 }

--- a/plugins/resource/resource.go
+++ b/plugins/resource/resource.go
@@ -3,10 +3,6 @@ package resource
 import (
 	"errors"
 	"fmt"
-	"os"
-	"reflect"
-	"sort"
-	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 )
@@ -32,39 +28,15 @@ func ReportSingleApp(appName, infoFlag string) {
 		return
 	}
 
-	flags := []string{}
 	infoFlags := map[string]string{}
 	for key, value := range resources {
 		flag := fmt.Sprintf("--resource-%v", key)
-		flags = append(flags, flag)
 		infoFlags[flag] = value
 	}
-	sort.Strings(flags)
 
-	if len(infoFlag) == 0 {
-		common.LogInfo2Quiet(fmt.Sprintf("%s resource information", appName))
-		for _, k := range flags {
-			v := infoFlags[k]
-			key := strings.Replace(strings.Replace(strings.TrimPrefix(k, "--resource-"), "-", " ", -1), ".", " ", -1)
-			common.LogVerbose(fmt.Sprintf("%s%s", Right(fmt.Sprintf("%s:", key), 31, " "), v))
-		}
-		return
-	}
-
-	for _, k := range flags {
-		v := infoFlags[k]
-		if infoFlag == k {
-			fmt.Fprintln(os.Stdout, v)
-			return
-		}
-	}
-
-	keys := reflect.ValueOf(infoFlags).MapKeys()
-	strkeys := make([]string, len(keys))
-	for i := 0; i < len(keys); i++ {
-		strkeys[i] = keys[i].String()
-	}
-	common.LogFail(fmt.Sprintf("Invalid flag passed, valid flags: %s", strings.Join(strkeys, ", ")))
+	trimPrefix := true
+	uppercaseFirstCharacter := false
+	common.ReportSingleApp("resource", appName, infoFlag, infoFlags, trimPrefix, uppercaseFirstCharacter)
 }
 
 // GetResourceValue fetches a single value for a given app/process/request/key combination
@@ -85,18 +57,6 @@ func GetResourceValue(appName string, processType string, resourceType string, k
 	}
 
 	return defaultValue, nil
-}
-
-func times(str string, n int) (out string) {
-	for i := 0; i < n; i++ {
-		out += str
-	}
-	return
-}
-
-// Right right-pads the string with pad up to len runes
-func Right(str string, length int, pad string) string {
-	return str + times(pad, length-len(str))
 }
 
 func propertyKey(processType string, resourceType string, key string) string {


### PR DESCRIPTION
This unifies all the report-handling code so that plugins only need to worry about the data they wish to represent, and not the logic of actually returning it.
