### PR TITLE
Remove deprecated code

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,3 +1,4 @@
+---
 linters:
   shellcheck:
     shell: bash
@@ -5,6 +6,8 @@ linters:
   golint:
 
 files:
-    ignore:
-      - './debian/*'
-      - '*/vendor/*'
+  ignore:
+    - 'debian/*'
+    - 'docs/*'
+    - 'tests/*'
+    - '*/vendor/*'

--- a/docs/appendices/0.20.0-migration-guide.md
+++ b/docs/appendices/0.20.0-migration-guide.md
@@ -1,0 +1,15 @@
+# 0.20.0 Migration Guide
+
+## Deprecated command removal
+
+The following commands have been deprecated and were removed in this release.
+
+- `apps`: Use `apps:list` instead.
+- `certs`: Use `certs:report` instead.
+- `certs:info`: Use `certs:report` instead.
+- `checks`: Use `checks:report` instead.
+- `docker-options`: Use `docker-options:report` instead.
+- `domains`: Use `domains:report` instead.
+- `plugin`: Use `plugin:list` instead.
+- `proxy`: Use `proxy:report` instead.
+- `trace`: Use `trace:on` or `trace:off` instead.

--- a/docs/deployment/zero-downtime-deploys.md
+++ b/docs/deployment/zero-downtime-deploys.md
@@ -3,7 +3,6 @@
 > New as of 0.5.0
 
 ```
-checks <app>                             Show zero-downtime status
 checks:disable <app> [process-type(s)]   Disable zero-downtime deployment for all processes (or comma-separated process-type list) ***WARNING: this will cause downtime during deployments***
 checks:enable <app> [process-type(s)]    Enable zero-downtime deployment for all processes (or comma-separated process-type list)
 checks:report [<app>] [<flag>]           Displays a checks report for one or more apps

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -51,6 +51,10 @@ Before upgrading, check the migration guides to get comfortable with new feature
 
 - [0.10 Migration Guide](/docs/appendices/0.10.0-migration-guide.md)
 
+### 0.20 Migration Guide
+
+- [0.20 Migration Guide](/docs/appendices/0.20.0-migration-guide.md)
+
 ## Upgrade Instructions
 
 If Dokku was installed via `apt-get install dokku` or `bootstrap.sh` (most common), upgrade with:

--- a/plugins/apps/help-functions
+++ b/plugins/apps/help-functions
@@ -27,7 +27,6 @@ help_desc
 fn-help-content() {
   declare desc="return help content"
   cat <<help_content
-    apps, [DEPRECATED] Alias for apps:list
     apps:clone <old-app> <new-app>, Clones an app
     apps:create <app>, Create a new app
     apps:destroy <app>, Permanently destroy an app

--- a/plugins/apps/subcommands/default
+++ b/plugins/apps/subcommands/default
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_AVAILABLE_PATH/apps/internal-functions"
+source "$PLUGIN_AVAILABLE_PATH/apps/help-functions"
 
-dokku_log_warn "Deprecated: Please use apps:list"
-cmd-apps-list "$@"
+cmd-apps-help "apps:help"

--- a/plugins/certs/help-functions
+++ b/plugins/certs/help-functions
@@ -27,11 +27,9 @@ help_desc
 fn-help-content() {
   declare desc="return help content"
   cat <<help_content
-    certs <app>, [DEPRECATED] Alternative for certs:report
     certs:add <app> CRT KEY, Add an ssl endpoint to an app. Can also import from a tarball on stdin
     certs:chain CRT [CRT ...], [NOT IMPLEMENTED] Print the ordered and complete chain for the given certificate
     certs:generate <app> DOMAIN, Generate a key and certificate signing request (and self-signed certificate)
-    certs:info <app>, [DEPRECATED] Alternative for certs:report
     certs:key <app> CRT KEY [KEY ...], [NOT IMPLEMENTED] Print the correct key for the given certificate
     certs:remove <app>, Remove an SSL Endpoint from an app
     certs:report [<app>] [<flag>], Displays an ssl report for one or more apps

--- a/plugins/certs/internal-functions
+++ b/plugins/certs/internal-functions
@@ -72,42 +72,6 @@ cmd-certs-report-single() {
   fi
 }
 
-cmd-certs-info() {
-  # This is here because it's used in both the info and the default
-  declare desc="prints SSL certificate info for app"
-  declare cmd="certs:info"
-  [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1"
-
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
-  verify_app_name "$APP"
-  local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
-
-  if is_ssl_enabled "$APP"; then
-    dokku_log_info1 "Fetching SSL Endpoint info for $APP..."
-    dokku_log_info1 "Certificate details:"
-    dokku_log_info2 "Common Name(s): "
-
-    for domain in $(get_ssl_hostnames "$APP" | xargs); do
-      dokku_log_info2 "   $domain"
-    done
-
-    dokku_log_info2 "Expires At: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not After :" | awk -F " : " '{ print $2 }')"
-    dokku_log_info2 "Issuer: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Issuer:" | xargs | sed -e "s/Issuer: //g")"
-    dokku_log_info2 "Starts At: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -text | grep "Not Before:" | awk -F ": " '{ print $2 }')"
-    dokku_log_info2 "Subject: $(openssl x509 -in "$APP_SSL_PATH/server.crt" -noout -subject | sed -e "s:subject= ::g" | sed -e "s:^/::g" | sed -e "s:/:; :g")"
-    local SSL_VERIFY_OUTPUT="$(openssl verify -verbose -purpose sslserver "$APP_SSL_PATH/server.crt" | awk -F ':' '{ print $2 }' | tail -1 | xargs || true)"
-    if [[ "$SSL_VERIFY_OUTPUT" == "OK" ]]; then
-      local SSL_SELF_SIGNED="verified by a certificate authority."
-    else
-      local SSL_SELF_SIGNED="self signed."
-    fi
-    dokku_log_info2 "SSL certificate is $SSL_SELF_SIGNED"
-  else
-    dokku_log_info1 "$APP does not have an SSL endpoint"
-  fi
-}
-
 fn-ssl-enabled() {
   declare APP="$1"
   local SSL_ENABLED=false

--- a/plugins/certs/subcommands/default
+++ b/plugins/certs/subcommands/default
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_AVAILABLE_PATH/certs/internal-functions"
+source "$PLUGIN_AVAILABLE_PATH/certs/help-functions"
 
-dokku_log_warn "Deprecated: Please use certs:report"
-cmd-certs-info "$@"
+cmd-certs-help "certs:help"

--- a/plugins/certs/subcommands/info
+++ b/plugins/certs/subcommands/info
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -eo pipefail
-[[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_AVAILABLE_PATH/certs/internal-functions"
-
-dokku_log_warn "Deprecated: Please use certs:report"
-cmd-certs-info "$@"

--- a/plugins/checks/help-functions
+++ b/plugins/checks/help-functions
@@ -27,7 +27,6 @@ help_desc
 fn-help-content() {
   declare desc="return help content"
   cat <<help_content
-    checks <app>, [DEPRECATED] Alternative for checks:report
     checks:disable <app> [process-type(s)], Disable zero-downtime deployment for all processes (or comma-separated process-type list) ***WARNING: this will cause downtime during deployments***
     checks:enable <app> [process-type(s)], Enable zero-downtime deployment for all processes (or comma-separated process-type list)
     checks:report [<app>] [<flag>], Displays a checks report for one or more apps

--- a/plugins/checks/subcommands/default
+++ b/plugins/checks/subcommands/default
@@ -1,31 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_AVAILABLE_PATH/checks/functions"
+source "$PLUGIN_AVAILABLE_PATH/checks/help-functions"
 
-cmd-checks-default() {
-  declare desc="displays app zero-downtime checks status"
-  declare cmd="checks"
-  [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1"
-
-  local APPS=$(dokku_apps)
-  if [[ -n "$APP" ]]; then
-    local APPS="$APP"
-  fi
-
-  dokku_log_warn "Deprecated: Please use checks:report"
-  dokku_col_log_info1_quiet "App Name" "Proctypes Disabled" "Proctypes Skipped"
-  local app
-  for app in $APPS; do
-    verify_app_name "$app"
-    local DOKKU_CHECKS_DISABLED=$(config_get "$app" DOKKU_CHECKS_DISABLED)
-    local DOKKU_CHECKS_SKIPPED=$(config_get "$app" DOKKU_CHECKS_SKIPPED)
-    local checks_disabled="${DOKKU_CHECKS_DISABLED:-none}"
-    local checks_skipped="${DOKKU_CHECKS_SKIPPED:-none}"
-    dokku_col_log_msg "$app" "$checks_disabled" "$checks_skipped"
-  done
-}
-
-cmd-checks-default "$@"
+cmd-checks-help "checks:help"

--- a/plugins/docker-options/help-functions
+++ b/plugins/docker-options/help-functions
@@ -27,7 +27,6 @@ help_desc
 fn-help-content() {
   declare desc="return help content"
   cat <<help_content
-    docker-options <app> [phase(s)], [DEPRECATED] Alternative for docker-options:report
     docker-options:add <app> <phase(s)> OPTION, Add Docker option to app for phase (comma separated phase list)
     docker-options:clear <app> [phase(s)], Clear a docker options from application with an optional phase (comma separated phase list)
     docker-options:remove <app> <phase(s)> OPTION, Remove Docker option from app for phase (comma separated phase list)

--- a/plugins/docker-options/internal-functions
+++ b/plugins/docker-options/internal-functions
@@ -63,7 +63,7 @@ cmd-docker-options-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
+    echo ""
   fi
 }
 

--- a/plugins/docker-options/subcommands/default
+++ b/plugins/docker-options/subcommands/default
@@ -1,23 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_AVAILABLE_PATH/docker-options/functions"
+source "$PLUGIN_AVAILABLE_PATH/docker-options/help-functions"
 
-cmd-docker-options-default() {
-  declare desc="Display applications docker options"
-  declare cmd="docker-options"
-  [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1"
-
-  dokku_log_warn "Deprecated: Please use docker-options:report"
-  verify_app_name "$APP"
-  read -ra passed_phases <<<"$(get_phases "$2")"
-  if [[ ! "${passed_phases[@]}" ]]; then
-    display_all_phases_options
-  else
-    display_passed_phases_options passed_phases[@]
-  fi
-}
-
-cmd-docker-options-default "$@"
+cmd-docker-options-help "docker-options:help"

--- a/plugins/domains/help-functions
+++ b/plugins/domains/help-functions
@@ -27,7 +27,6 @@ help_desc
 fn-help-content() {
   declare desc="return help content"
   cat <<help_content
-    domains [<app>], [DEPRECATED] Alternative for domains:report
     domains:add <app> <domain> [<domain> ...], Add domains to app
     domains:add-global <domain> [<domain> ...], Add global domain names
     domains:clear <app>, Clear all domains for app

--- a/plugins/domains/subcommands/default
+++ b/plugins/domains/subcommands/default
@@ -1,34 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_AVAILABLE_PATH/domains/functions"
+source "$PLUGIN_AVAILABLE_PATH/domains/help-functions"
 
-cmd-domains-default() {
-  declare desc="print app domains"
-  declare cmd="domains"
-  [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1"
-
-  dokku_log_warn "Deprecated: Please use domains:report"
-  if [[ "$(is_global_vhost_enabled)" == "true" ]]; then
-    dokku_log_info2_quiet "Global Domain Name"
-    get_global_vhosts
-  fi
-
-  if [[ "$APP" == "--global" ]]; then
-    return
-  fi
-
-  if [[ -n "$APP" ]]; then
-    verify_app_name "$APP"
-    if [[ -f "$DOKKU_ROOT/$APP/VHOST" ]]; then
-      dokku_log_info2_quiet "$APP Domain Names"
-      get_app_domains "$APP"
-    else
-      dokku_log_fail "No domain names set for $APP"
-    fi
-  fi
-}
-
-cmd-domains-default "$@"
+cmd-domains-help "domains:help"

--- a/plugins/plugin/subcommands/default
+++ b/plugins/plugin/subcommands/default
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_AVAILABLE_PATH/plugin/internal-functions"
+source "$PLUGIN_AVAILABLE_PATH/plugin/help-functions"
 
-dokku_log_warn "Deprecated: Please use plugin:list"
-cmd-plugin-list "$@"
+cmd-plugin-help "plugin:help"

--- a/plugins/proxy/help-functions
+++ b/plugins/proxy/help-functions
@@ -27,7 +27,6 @@ help_desc
 fn-help-content() {
   declare desc="return help content"
   cat <<help_content
-    proxy <app>, [DEPRECATED] Show proxy settings for app
     proxy:disable <app>, Disable proxy for app
     proxy:enable <app>, Enable proxy for app
     proxy:ports <app>, List proxy port mappings for app

--- a/plugins/proxy/subcommands/default
+++ b/plugins/proxy/subcommands/default
@@ -1,27 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/help-functions"
 
-cmd-proxy-default() {
-  declare desc="displays app proxy implementation via command line"
-  declare cmd="proxy"
-  [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1"
-
-  local APPS=$(dokku_apps)
-  if [[ -n "$APP" ]]; then
-    local APPS="$APP"
-  fi
-
-  dokku_log_warn "Deprecated: Please use proxy:report"
-  dokku_col_log_info1_quiet "App Name" "Proxy Type"
-  local app
-  for app in $APPS; do
-    verify_app_name "$app"
-    dokku_col_log_msg "$app" "$(get_app_proxy_type "$app")"
-  done
-}
-
-cmd-proxy-default "$@"
+cmd-proxy-help "proxy:help"

--- a/plugins/trace/help-functions
+++ b/plugins/trace/help-functions
@@ -27,7 +27,6 @@ help_desc
 fn-help-content() {
   declare desc="return help content"
   cat <<help_content
-    trace, [DEPRECATED] Enables/Disables trace mode
     trace:on, Enable trace mode
     trace:off, Disable trace mode
 help_content

--- a/plugins/trace/subcommands/default
+++ b/plugins/trace/subcommands/default
@@ -1,30 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/trace/help-functions"
 
-cmd-trace-default() {
-  declare desc="enables/disables trace mode"
-  declare cmd="trace"
-  [[ "$1" == "$cmd" ]] && shift 1
-  declare ARGUMENT="$1"
-
-  [[ -d $DOKKU_ROOT/.dokkurc ]] || mkdir -p "$DOKKU_ROOT/.dokkurc"
-  [[ "$ARGUMENT" == "on" ]] || [[ "$ARGUMENT" == "off" ]] || {
-    dokku_log_fail "Valid trace options are [on/off]"
-  }
-
-  dokku_log_warn "Deprecated: Please use trace:on or trace:off"
-
-  if [[ "$ARGUMENT" == "on" ]]; then
-    dokku_log_info1 "Enabling trace mode"
-    echo "export DOKKU_TRACE=1" >"$DOKKU_ROOT/.dokkurc/DOKKU_TRACE"
-  fi
-
-  if [[ "$ARGUMENT" == "off" ]]; then
-    dokku_log_info1 "Disabling trace mode"
-    rm -f "$DOKKU_ROOT/.dokkurc/DOKKU_TRACE"
-  fi
-}
-
-cmd-trace-default "$@"
+cmd-trace-help "trace:help"

--- a/tests.mk
+++ b/tests.mk
@@ -107,7 +107,7 @@ prime-ssh-known-hosts:
 
 lint-setup:
 	@mkdir -p test-results/shellcheck tmp/shellcheck
-	@find . -not -path '*/\.*' -not -path './debian/*' -type f | xargs file | grep text | awk -F ':' '{ print $$1 }' | xargs head -n1 | egrep -B1 "bash" | grep "==>" | awk '{ print $$2 }' > tmp/shellcheck/test-files
+	@find . -not -path '*/\.*' -not -path './debian/*' -not -path './docs/*' -not -path './tests/*' -not -path './vendor/*' -type f | xargs file | grep text | awk -F ':' '{ print $$1 }' | xargs head -n1 | egrep -B1 "bash" | grep "==>" | awk '{ print $$2 }' > tmp/shellcheck/test-files
 	@cat tests/shellcheck-exclude | sed -n -e '/^# SC/p' | cut -d' ' -f2 | paste -d, -s > tmp/shellcheck/exclude
 
 lint-ci: lint-setup

--- a/tests/unit/10_apps.bats
+++ b/tests/unit/10_apps.bats
@@ -11,10 +11,17 @@ teardown() {
 }
 
 @test "(apps) apps:help" {
+  run /bin/bash -c "dokku apps"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "Manage apps"
+  help_output="$output"
+
   run /bin/bash -c "dokku apps:help"
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "Manage apps"
+  assert_output "$help_output"
 }
 
 @test "(apps) apps:create" {

--- a/tests/unit/10_certs.bats
+++ b/tests/unit/10_certs.bats
@@ -28,10 +28,17 @@ teardown() {
 }
 
 @test "(certs) certs:help" {
+  run /bin/bash -c "dokku certs"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "Manage SSL (TLS) certs"
+  help_output="$output"
+
   run /bin/bash -c "dokku certs:help"
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "Manage SSL (TLS) certs"
+  assert_output "$help_output"
 }
 
 @test "(certs) certs:add" {
@@ -57,13 +64,6 @@ teardown() {
 
 @test "(certs) certs:add tar:in should ignore OSX hidden files" {
   run /bin/bash -c "dokku certs:add $TEST_APP < $BATS_TEST_DIRNAME/osx_ssl_tarred.tar"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-}
-
-@test "(certs) certs:info" {
-  run /bin/bash -c "dokku certs:add $TEST_APP < $BATS_TEST_DIRNAME/server_ssl.tar && dokku certs:info $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/10_checks.bats
+++ b/tests/unit/10_checks.bats
@@ -17,17 +17,17 @@ teardown() {
 }
 
 @test "(checks) checks:help" {
+  run /bin/bash -c "dokku checks"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "Manage zero-downtime settings"
+  help_output="$output"
+
   run /bin/bash -c "dokku checks:help"
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "Manage zero-downtime settings"
-}
-
-@test "(checks) checks" {
-  run /bin/bash -c "dokku checks $TEST_APP 2>/dev/null | grep $TEST_APP | xargs"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output "$TEST_APP none none"
+  assert_output "$help_output"
 }
 
 @test "(checks) checks:disable" {

--- a/tests/unit/20_docker-options.bats
+++ b/tests/unit/20_docker-options.bats
@@ -13,10 +13,17 @@ teardown() {
 }
 
 @test "(docker-options) docker-options:help" {
+  run /bin/bash -c "dokku docker-options"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "Manage docker options for an app"
+  help_output="$output"
+
   run /bin/bash -c "dokku docker-options:help"
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "Manage docker options for an app"
+  assert_output "$help_output"
 }
 
 @test "(docker-options) docker-options:add (all phases)" {
@@ -24,12 +31,22 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 3"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-build"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-deploy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "-v /tmp"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-run"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "-v /tmp"
 }
-
 
 @test "(docker-options) docker-options:clear" {
   run /bin/bash -c "dokku docker-options:add $TEST_APP build,deploy,run \"-v /tmp\""
@@ -40,10 +57,21 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 0"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-build"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp" 0
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-deploy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "-v /tmp" 0
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-run"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "-v /tmp" 0
 
   run /bin/bash -c "dokku docker-options:add $TEST_APP build,deploy,run \"-v /tmp\""
   echo "output: $output"
@@ -53,26 +81,61 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 2"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-build"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp" 0
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-deploy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "-v /tmp"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-run"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "-v /tmp"
+
   run /bin/bash -c "dokku docker-options:clear $TEST_APP deploy"
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 1"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-build"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp" 0
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-deploy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "-v /tmp" 0
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-run"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "-v /tmp"
+
   run /bin/bash -c "dokku docker-options:clear $TEST_APP run"
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 0"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-build"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp" 0
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-deploy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "-v /tmp" 0
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-run"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "-v /tmp" 0
 }
 
 @test "(docker-options) docker-options:add (build phase)" {
@@ -80,10 +143,11 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP build | egrep '\-v /tmp' | wc -l | grep -q 1"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP --docker-options-build"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp"
 }
 
 @test "(docker-options) docker-options:add (deploy phase)" {
@@ -91,10 +155,11 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP deploy | egrep '\-v /tmp' | wc -l | grep -q 1"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP  --docker-options-deploy"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp"
 }
 
 @test "(docker-options) docker-options:add (run phase)" {
@@ -102,10 +167,11 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP run | egrep '\-v /tmp' | wc -l | grep -q 1"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP  --docker-options-run"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp"
 }
 
 @test "(docker-options) docker-options:remove (all phases)" {
@@ -113,18 +179,21 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 3"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp" 3
   run /bin/bash -c "dokku docker-options:remove $TEST_APP build,deploy,run \"-v /tmp\""
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP 2>/dev/null | xargs"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP"
   echo "output: $output"
   echo "status: $status"
-  assert_output "Deploy options: --restart=on-failure:10"
+  assert_success
+  assert_output_contains "-v /tmp" 0
+  assert_output_contains "Docker options deploy:         --restart=on-failure:10"
 }
 
 @test "(docker-options) docker-options:remove (build phase)" {
@@ -132,18 +201,20 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 3"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp" 3
   run /bin/bash -c "dokku docker-options:remove $TEST_APP build \"-v /tmp\""
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP build 2>/dev/null"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP"
   echo "output: $output"
   echo "status: $status"
-  assert_output "Build options: none"
+  assert_success
+  assert_output_contains "-v /tmp" 2
 }
 
 @test "(docker-options) docker-options:remove (deploy phase)" {
@@ -151,18 +222,20 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP deploy | egrep '\-v /tmp' | wc -l | grep -q 1"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp" 3
   run /bin/bash -c "dokku docker-options:remove $TEST_APP deploy \"-v /tmp\""
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP deploy 2>/dev/null | xargs"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP"
   echo "output: $output"
   echo "status: $status"
-  assert_output "Deploy options: --restart=on-failure:10"
+  assert_success
+  assert_output_contains "-v /tmp" 2
 }
 
 @test "(docker-options) docker-options:remove (run phase)" {
@@ -170,18 +243,20 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP run | egrep '\-v /tmp' | wc -l | grep -q 1"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp" 3
   run /bin/bash -c "dokku docker-options:remove $TEST_APP run \"-v /tmp\""
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP run 2>/dev/null"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP"
   echo "output: $output"
   echo "status: $status"
-  assert_output "Run options: none"
+  assert_success
+  assert_output_contains "-v /tmp" 2
 }
 
 @test "(docker-options) deploy with options" {
@@ -197,10 +272,11 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP deploy | egrep '\-v /tmp' | wc -l | grep -q 1"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp" 1
   deploy_app
 
   CID=$(< $DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
@@ -215,10 +291,11 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "dokku docker-options $TEST_APP | egrep '\-v /tmp' | wc -l | grep -q 3"
+  run /bin/bash -c "dokku docker-options:report $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "-v /tmp" 3
 }
 
 @test "(docker-options) dockerfile deploy with link" {

--- a/tests/unit/20_network.bats
+++ b/tests/unit/20_network.bats
@@ -18,31 +18,6 @@ teardown() {
   global_teardown
 }
 
-assert_nonssl_domain() {
-  local domain=$1
-  assert_app_domain "${domain}"
-  assert_http_success "http://${domain}"
-}
-
-assert_app_domain() {
-  local domain=$1
-  run /bin/bash -c "dokku domains $TEST_APP 2>/dev/null | grep -xF ${domain}"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output "${domain}"
-}
-
-assert_external_port() {
-  local CID="$1"; local exit_status="$2"
-  local EXTERNAL_PORT_COUNT=$(docker port $CID | wc -l)
-  run /bin/bash -c "[[ $EXTERNAL_PORT_COUNT -gt 0 ]]"
-  if [[ "$exit_status" == "success" ]]; then
-    assert_success
-  else
-    assert_failure
-  fi
-}
-
 @test "(network) network:help" {
   run /bin/bash -c "dokku network"
   echo "output: $output"
@@ -73,7 +48,7 @@ assert_external_port() {
   assert_http_success "${TEST_APP}.dokku.me"
 
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.web.*; do
-    assert_external_port $(< $CID_FILE) success
+    assert_external_port $(< $CID_FILE)
   done
 
   run /bin/bash -c "dokku network:set $TEST_APP bind-all-interfaces false"
@@ -88,7 +63,7 @@ assert_external_port() {
   assert_http_success "${TEST_APP}.dokku.me"
 
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.web.*; do
-    assert_external_port $(< $CID_FILE) failure
+    assert_not_external_port $(< $CID_FILE)
   done
 }
 

--- a/tests/unit/30_client.bats
+++ b/tests/unit/30_client.bats
@@ -87,17 +87,6 @@ teardown() {
   assert_failure
 }
 
-@test "(client) domains" {
-  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:setup $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains $TEST_APP | grep -q ${TEST_APP}.dokku.me"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-}
-
 @test "(client) domains:add" {
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:add $TEST_APP www.test.app.dokku.me"
   echo "output: $output"

--- a/tests/unit/30_core_1.bats
+++ b/tests/unit/30_core_1.bats
@@ -16,14 +16,6 @@ teardown() {
   global_teardown
 }
 
-assert_urls() {
-  urls=$@
-  run /bin/bash -c "dokku urls $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output < <(tr ' ' '\n' <<< "${urls}")
-}
-
 @test "(core) remove exited containers" {
   deploy_app
 

--- a/tests/unit/40_core_2.bats
+++ b/tests/unit/40_core_2.bats
@@ -13,24 +13,6 @@ teardown() {
   global_teardown
 }
 
-assert_urls() {
-  urls=$@
-  run /bin/bash -c "dokku urls $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  echo "urls:" $(tr ' ' '\n' <<< "${urls}" | sort)
-  assert_output < <(tr ' ' '\n' <<< "${urls}" | sort)
-}
-
-assert_url() {
-  url=$1
-  run /bin/bash -c "dokku url $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  echo "url: ${url}"
-  assert_output "${url}"
-}
-
 @test "(core) cleanup:help" {
   run /bin/bash -c "dokku cleanup:help"
   echo "output: $output"

--- a/tests/unit/40_nginx-vhosts_2.bats
+++ b/tests/unit/40_nginx-vhosts_2.bats
@@ -17,18 +17,6 @@ teardown() {
   global_teardown
 }
 
-assert_access_log() {
-  local prefix=$1
-  run [ -a /var/log/nginx/$prefix-access.log ]
-  assert_success
-}
-
-assert_error_log() {
-  local prefix=$1
-  run [ -a /var/log/nginx/$prefix-error.log ]
-  assert_success
-}
-
 @test "(nginx-vhosts) nginx (no server tokens)" {
   deploy_app
   run /bin/bash -c "curl -s -D - $(dokku url $TEST_APP) -o /dev/null | egrep '^Server' | egrep '[0-9]+'"

--- a/tests/unit/40_nginx-vhosts_2.bats
+++ b/tests/unit/40_nginx-vhosts_2.bats
@@ -44,7 +44,7 @@ teardown() {
   add_domain "wildcard1.dokku.me"
   add_domain "wildcard2.dokku.me"
   deploy_app
-  cat /home/dokku/${TEST_APP}/nginx.conf
+  dokku nginx:show-conf $TEST_APP
   assert_ssl_domain "wildcard1.dokku.me"
   assert_ssl_domain "wildcard2.dokku.me"
 }
@@ -54,7 +54,7 @@ teardown() {
   TEST_APP="${TEST_APP}.example.com"
   setup_test_tls wildcard
   deploy_app nodejs-express dokku@dokku.me:$TEST_APP
-  run /bin/bash -c "egrep '*.dokku.me' $DOKKU_ROOT/${TEST_APP}/nginx.conf | wc -l"
+  run /bin/bash -c "dokku nginx:show-conf $TEST_APP | grep -e '*.dokku.me' | wc -l"
   assert_output "0"
 }
 

--- a/tests/unit/40_nginx-vhosts_2.bats
+++ b/tests/unit/40_nginx-vhosts_2.bats
@@ -55,6 +55,7 @@ teardown() {
   setup_test_tls wildcard
   deploy_app nodejs-express dokku@dokku.me:$TEST_APP
   run /bin/bash -c "dokku nginx:show-conf $TEST_APP | grep -e '*.dokku.me' | wc -l"
+  dokku nginx:show-conf $TEST_APP
   assert_output "0"
 }
 

--- a/tests/unit/40_nginx-vhosts_2.bats
+++ b/tests/unit/40_nginx-vhosts_2.bats
@@ -1,7 +1,6 @@
 #!/usr/bin/env bats
 
 load test_helper
-source "$PLUGIN_CORE_AVAILABLE_PATH/config/functions"
 
 setup() {
   global_setup

--- a/tests/unit/40_nginx-vhosts_2.bats
+++ b/tests/unit/40_nginx-vhosts_2.bats
@@ -35,6 +35,7 @@ teardown() {
   add_domain "node-js-app.dokku.me"
   add_domain "test.dokku.me"
   deploy_app
+  dokku nginx:show-conf $TEST_APP
   assert_ssl_domain "node-js-app.dokku.me"
   assert_http_redirect "http://test.dokku.me" "https://test.dokku.me:443/"
 }

--- a/tests/unit/40_plugin.bats
+++ b/tests/unit/40_plugin.bats
@@ -25,10 +25,17 @@ teardown() {
 }
 
 @test "(plugin) plugin:help" {
+  run /bin/bash -c "dokku plugin"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "Manage installed plugins"
+  help_output="$output"
+
   run /bin/bash -c "dokku plugin:help"
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "Manage installed plugins"
+  assert_output "$help_output"
 }
 
 @test "(plugin) plugin:install, plugin:disable, plugin:update plugin:uninstall" {
@@ -42,7 +49,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME"
+  run /bin/bash -c "dokku plugin:list | grep enabled | grep $TEST_PLUGIN_NAME"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -57,7 +64,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku plugin | grep disabled | grep $TEST_PLUGIN_NAME"
+  run /bin/bash -c "dokku plugin:list | grep disabled | grep $TEST_PLUGIN_NAME"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -67,7 +74,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku plugin | grep $TEST_PLUGIN_NAME"
+  run /bin/bash -c "dokku plugin:list | grep $TEST_PLUGIN_NAME"
   echo "output: $output"
   echo "status: $status"
   assert_failure
@@ -84,7 +91,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME"
+  run /bin/bash -c "dokku plugin:list | grep enabled | grep $TEST_PLUGIN_NAME"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -99,7 +106,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku plugin | grep disabled | grep $TEST_PLUGIN_NAME"
+  run /bin/bash -c "dokku plugin:list | grep disabled | grep $TEST_PLUGIN_NAME"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -109,7 +116,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku plugin | grep $TEST_PLUGIN_NAME"
+  run /bin/bash -c "dokku plugin:list | grep $TEST_PLUGIN_NAME"
   echo "output: $output"
   echo "status: $status"
   assert_failure
@@ -121,7 +128,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME | grep 0.2.0"
+  run /bin/bash -c "dokku plugin:list | grep enabled | grep $TEST_PLUGIN_NAME | grep 0.2.0"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -131,12 +138,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME | grep 0.2.0"
+  run /bin/bash -c "dokku plugin:list | grep enabled | grep $TEST_PLUGIN_NAME | grep 0.2.0"
   echo "output: $output"
   echo "status: $status"
   assert_failure
 
-  run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME | grep 0.3.0"
+  run /bin/bash -c "dokku plugin:list | grep enabled | grep $TEST_PLUGIN_NAME | grep 0.3.0"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -153,7 +160,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku plugin | grep enabled | grep $TEST_PLUGIN_NAME"
+  run /bin/bash -c "dokku plugin:list | grep enabled | grep $TEST_PLUGIN_NAME"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/40_trace.bats
+++ b/tests/unit/40_trace.bats
@@ -13,26 +13,21 @@ teardown() {
 }
 
 @test "(trace) trace:help" {
+  run /bin/bash -c "dokku trace"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "Manage trace mode"
+  help_output="$output"
+
   run /bin/bash -c "dokku trace:help"
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "Manage trace mode"
+  assert_output "$help_output"
 }
 
 @test "(trace) trace:on" {
   run /bin/bash -c "dokku trace:on"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "test -f $DOKKU_ROOT/.dokkurc/DOKKU_TRACE"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-}
-
-@test "(trace) trace on" {
-  run /bin/bash -c "dokku trace on"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -49,18 +44,6 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-
-  run /bin/bash -c "test -f $DOKKU_ROOT/.dokkurc/DOKKU_TRACE"
-  echo "output: $output"
-  echo "status: $status"
-  assert_failure
-
-  touch "$DOKKU_ROOT/.dokkurc/DOKKU_TRACE"
-  run /bin/bash -c "dokku trace off"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
 
   run /bin/bash -c "test -f $DOKKU_ROOT/.dokkurc/DOKKU_TRACE"
   echo "output: $output"

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -248,7 +248,7 @@ assert_url() {
 }
 
 assert_urls() {
-  urls=( $@ )
+  urls=$@
   run /bin/bash -c "dokku urls $TEST_APP"
   echo "output: $output"
   echo "status: $status"

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -206,7 +206,8 @@ assert_nonssl_domain() {
 
 assert_app_domain() {
   local domain=$1
-  run /bin/bash -c "dokku domains:report $TEST_APP --domains-app-vhosts | grep -xF ${domain}"
+  run /bin/bash -c "dokku domains:report $TEST_APP --domains-app-vhosts | tr \" \" \"\n\" | grep -xF ${domain}"
+  echo "app domains: $(dokku domains:report $TEST_APP --domains-app-vhosts | tr \" \" \"\n\" )"
   echo "output: $output"
   echo "status: $status"
   assert_output "${domain}"


### PR DESCRIPTION
This change removes deprecated commands. In many cases, users have been warned for a number of releases before the commands have been removed. All commands that were removed have existing alternatives.
