### PR TITLE
Remove ps command

### DIFF
--- a/docs/appendices/0.20.0-migration-guide.md
+++ b/docs/appendices/0.20.0-migration-guide.md
@@ -13,6 +13,7 @@ The following commands were previously deprecated and were removed in this relea
 - `plugin`: Use `plugin:list` instead.
 - `proxy`: Use `proxy:report` instead.
 - `trace`: Use `trace:on` or `trace:off` instead.
+- `ps`: Use `enter` with a container ID instead to run `ps auxww` within a container.
 
 ## Deprecations
 

--- a/docs/deployment/process-management.md
+++ b/docs/deployment/process-management.md
@@ -3,7 +3,6 @@
 > New as of 0.3.14, Enhanced in 0.7.0
 
 ```
-ps <app>                                       # List processes running in app container(s)
 ps:inspect <app>                               # Displays a sanitized version of docker inspect for an app
 ps:rebuild <app>                               # Rebuild an app from source
 ps:rebuildall                                  # Rebuild all apps from source
@@ -24,14 +23,6 @@ By default, Dokku will only start a single `web` process - if defined - though p
 > The `web` proctype is the only proctype that will invoke custom checks as defined by a `CHECKS` file. It is also the only process type that will be launched in a container that is either proxied via nginx or bound to an external port.
 
 ## Usage
-
-### Listing processes running in an app container
-
-To find out if your application's containers are running the commands you expect, simply run the `ps` command against that application.
-
-```shell
-dokku ps node-js-app
-```
 
 ### Inspecting app containers
 

--- a/plugins/ps/subcommands/default
+++ b/plugins/ps/subcommands/default
@@ -1,29 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/ps/help-functions"
 
-cmd-ps-default() {
-  declare desc="shows running processes in all running app containers"
-  declare cmd="ps"
-  [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1"
-
-  dokku_log_warn "Deprecated: Please use ps:report"
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
-
-  verify_app_name "$APP"
-  ! (is_deployed "$APP") && dokku_log_warn "App $APP has not been deployed" && exit 0
-
-  local DOKKU_APP_RUNNING_CONTAINER_IDS=$(get_app_running_container_ids "$APP" 2>/dev/null)
-
-  local CID
-  for CID in $DOKKU_APP_RUNNING_CONTAINER_IDS; do
-    has_tty && local DOKKU_RUN_OPTS="-i -t"
-    dokku_log_info1_quiet "running processes in container: $CID"
-    # shellcheck disable=SC2086
-    "$DOCKER_BIN" container exec $DOKKU_RUN_OPTS $CID /bin/sh -c "ps auxwww"
-  done
-}
-
-cmd-ps-default "$@"
+cmd-ps-help "ps:help"

--- a/tests/unit/10_ps-dockerfile.bats
+++ b/tests/unit/10_ps-dockerfile.bats
@@ -12,17 +12,6 @@ teardown() {
   global_teardown
 }
 
-# @test "(ps) dockerfile base" {
-#   # CI support: 'Ah. I just spoke with our Docker expert --
-#   # looks like docker exec is built to work with docker-under-libcontainer,
-#   # but we're using docker-under-lxc. I don't have an estimated time for the fix, sorry
-#   skip "circleci does not support docker exec at the moment."
-#   run /bin/bash -c "dokku ps $TEST_APP | grep -q \"node web.js\""
-#   echo "output: $output"
-#   echo "status: $status"
-#   assert_success
-# }
-
 @test "(ps) dockerfile" {
   deploy_app dockerfile
   run /bin/bash -c "dokku ps:stop $TEST_APP"

--- a/tests/unit/10_ps-general.bats
+++ b/tests/unit/10_ps-general.bats
@@ -13,10 +13,17 @@ teardown() {
 }
 
 @test "(ps) ps:help" {
+  run /bin/bash -c "dokku ps"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "Manage container processes"
+  help_output="$output"
+
   run /bin/bash -c "dokku ps:help"
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "Manage container processes"
+  assert_output "$help_output"
 }
 
 @test "(ps) ps:inspect" {

--- a/tests/unit/10_ps-herokuish.bats
+++ b/tests/unit/10_ps-herokuish.bats
@@ -13,18 +13,6 @@ teardown() {
   global_teardown
 }
 
-# @test "(ps) herokuish base" {
-#   # CI support: 'Ah. I just spoke with our Docker expert --
-#   # looks like docker exec is built to work with docker-under-libcontainer,
-#   # but we're using docker-under-lxc. I don't have an estimated time for the fix, sorry
-#   skip "circleci does not support docker exec at the moment."
-#   deploy_app
-#   run /bin/bash -c "dokku ps $TEST_APP | grep -q \"node web.js\""
-#   echo "output: $output"
-#   echo "status: $status"
-#   assert_success
-# }
-
 @test "(ps) herokuish" {
   deploy_app
   run /bin/bash -c "dokku ps:stop $TEST_APP"


### PR DESCRIPTION
`ps` should be replaced by `enter` with a specified container id.