### PR TITLE
Drop support for unsupported Debian and Ubuntu releases …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,8 @@ jobs:
       - run: |
           echo 'export DOKKU_SKIP_CLEANUP=true' | sudo tee /home/dokku/.dokkurc/dokku_skip_cleanup
       - run: |
-          if [[ "$(lsb_release -rs)" == "14.04" ]]; then
-            # dokku.me now resolves to 10.0.0.2. add 10.0.0.2/24 to eth0
-            sudo ip a a 10.0.0.2/24 broadcast 10.0.0.255 dev eth0
-          else
-            # dokku.me now resolves to 10.0.0.2. add 10.0.0.2/24 to ens4
-            sudo ip a a 10.0.0.2/24 broadcast 10.0.0.255 dev ens4
-          fi
+          # dokku.me now resolves to 10.0.0.2. add 10.0.0.2/24 to ens4
+          sudo ip a a 10.0.0.2/24 broadcast 10.0.0.255 dev ens4
       - run: |
           case $CIRCLE_NODE_INDEX in
             0) sudo -E make -e lint-ci go-tests ci-go-coverage ;;

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Support us with a monthly donation and help us continue our activities. [[Become
 
 A fresh VM running any of the following operating systems:
 
-- Ubuntu x64 - Any currently supported release
-- Debian 8.2+ x64
+- Ubuntu 16.04/18.04 x64 - Any currently supported release
+- Debian 9+ x64
 - CentOS 7 x64 *(experimental)*
 - Arch Linux x64 *(experimental)*
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 [[ $TRACE ]] && set -x
 
 # A script to bootstrap dokku.
-# It expects to be run on Ubuntu 14.04 via 'sudo'
+# It expects to be run on Ubuntu 16.04/18.04, or CentOS 7 via 'sudo'
 # If installing a tag higher than 0.3.13, it may install dokku via a package (so long as the package is higher than 0.3.13)
 # It checks out the dokku source code from Github into ~/dokku and then runs 'make install' from dokku source.
 
@@ -156,24 +156,19 @@ install-dokku-from-deb-package() {
     wget -nv -O - https://get.docker.com/ | sh
   fi
 
-  if [[ "$DOKKU_DISTRO_VERSION" == "14.04" ]]; then
-    echo "--> Adding nginx PPA"
-    add-apt-repository -y ppa:nginx/stable
-  fi
-
-  OS_ID="$(lsb_release -cs 2>/dev/null || echo "trusty")"
+  OS_ID="$(lsb_release -cs 2>/dev/null || echo "bionic")"
   if ! in-array "$DOKKU_DISTRO" "debian" "ubuntu"; then
     DOKKU_DISTRO="ubuntu"
-    OS_ID="trusty"
+    OS_ID="bionic"
   fi
 
   if [[ "$DOKKU_DISTRO" == "ubuntu" ]]; then
-    OS_IDS=("trusty" "utopic" "vivid" "wily" "xenial" "yakkety" "zesty" "artful" "bionic")
+    OS_IDS=("xenial" "bionic")
     if ! in-array "$OS_ID" "${OS_IDS[@]}"; then
-      OS_ID="trusty"
+      OS_ID="bionic"
     fi
   elif [[ "$DOKKU_DISTRO" == "debian" ]]; then
-    OS_IDS=("wheezy" "jessie" "stretch" "buster")
+    OS_IDS=("stretch" "buster")
     if ! in-array "$OS_ID" "${OS_IDS[@]}"; then
       OS_ID="stretch"
     fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -179,7 +179,7 @@ install-dokku-from-deb-package() {
   elif [[ "$DOKKU_DISTRO" == "debian" ]]; then
     OS_IDS=("stretch" "buster")
     if ! in-array "$OS_ID" "${OS_IDS[@]}"; then
-      OS_ID="stretch"
+      OS_ID="buster"
     fi
   fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,13 +12,18 @@ set -eo pipefail
 # That's good because it prevents our output overlapping with wget's.
 # It also means that we can't run a partially downloaded script.
 
+log-fail() {
+  declare desc="log fail formatter"
+  echo "$@" 1>&2
+  exit 1
+}
+
 ensure-environment() {
   local FREE_MEMORY
   echo "Preparing to install $DOKKU_TAG from $DOKKU_REPO..."
 
   hostname -f >/dev/null 2>&1 || {
-    echo "This installation script requires that you have a hostname set for the instance. Please set a hostname for 127.0.0.1 in your /etc/hosts"
-    exit 1
+    log-fail "This installation script requires that you have a hostname set for the instance. Please set a hostname for 127.0.0.1 in your /etc/hosts"
   }
 
   FREE_MEMORY=$(grep MemTotal /proc/meminfo | awk '{print $2}')
@@ -90,8 +95,7 @@ install-dokku-from-source() {
   local DOKKU_CHECKOUT="$1"
 
   if ! command -v apt-get &>/dev/null; then
-    echo "This installation script requires apt-get. For manual installation instructions, consult http://dokku.viewdocs.io/dokku/advanced-installation/"
-    exit 1
+    log-fail "This installation script requires apt-get. For manual installation instructions, consult http://dokku.viewdocs.io/dokku/advanced-installation/"
   fi
 
   apt-get -qq -y install git make software-properties-common
@@ -115,8 +119,7 @@ install-dokku-from-package() {
       install-dokku-from-rpm-package "$@"
       ;;
     *)
-      echo "Unsupported Linux distribution. For manual installation instructions, consult http://dokku.viewdocs.io/dokku/advanced-installation/"
-      exit 1
+      log-fail "Unsupported Linux distribution. For manual installation instructions, consult http://dokku.viewdocs.io/dokku/advanced-installation/"
       ;;
   esac
 }
@@ -199,8 +202,7 @@ install-dokku-from-rpm-package() {
   local DOKKU_CHECKOUT="$1"
 
   if [[ "$DOKKU_DISTRO_VERSION" != "7" ]]; then
-    echo "Only CentOS version 7 is supported."
-    exit 1
+    log-fail "Unsupported Linux distribution. Only the following versions are supported: CentOS [7]"
   fi
 
   echo "--> Installing docker"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -201,7 +201,7 @@ install-dokku-from-deb-package() {
 install-dokku-from-rpm-package() {
   local DOKKU_CHECKOUT="$1"
 
-  if [[ "$DOKKU_DISTRO_VERSION" != "7" ]]; then
+  if ! in-array "$DOKKU_DISTRO_VERSION" "7"; then
     log-fail "Unsupported Linux distribution. Only the following versions are supported: CentOS [7]"
   fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,6 +12,8 @@ set -eo pipefail
 # That's good because it prevents our output overlapping with wget's.
 # It also means that we can't run a partially downloaded script.
 
+SUPPORTED_VERSIONS="Debian [9, 10], CentOS [7], Ubuntu [16.04, 18.04]"
+
 log-fail() {
   declare desc="log fail formatter"
   echo "$@" 1>&2
@@ -139,6 +141,10 @@ install-dokku-from-deb-package() {
   local NO_INSTALL_RECOMMENDS=${DOKKU_NO_INSTALL_RECOMMENDS:=""}
   local OS_ID
 
+  if ! in-array "$DOKKU_DISTRO_VERSION" "16.04" "18.04" "9" "10"; then
+    log-fail "Unsupported Linux distribution. Only the following versions are supported: $SUPPORTED_VERSIONS"
+  fi
+
   if [[ -n $DOKKU_DOCKERFILE ]]; then
     NO_INSTALL_RECOMMENDS=" --no-install-recommends "
   fi
@@ -202,7 +208,7 @@ install-dokku-from-rpm-package() {
   local DOKKU_CHECKOUT="$1"
 
   if ! in-array "$DOKKU_DISTRO_VERSION" "7"; then
-    log-fail "Unsupported Linux distribution. Only the following versions are supported: CentOS [7]"
+    log-fail "Unsupported Linux distribution. Only the following versions are supported: $SUPPORTED_VERSIONS"
   fi
 
   echo "--> Installing docker"

--- a/contrib/build-base.Dockerfile
+++ b/contrib/build-base.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/contrib/copy-packages
+++ b/contrib/copy-packages
@@ -16,7 +16,7 @@ def download_file(filename, url):
 
 def upload_file(filename):
     versions = [
-        "bionic",
+        "xenial"
     ]
     cmd_template = "package_cloud push dokku/dokku/ubuntu/{0} {1}"
     for version in versions:
@@ -26,7 +26,7 @@ def upload_file(filename):
 
 def main():
     auth = HTTPBasicAuth(PACKAGECLOUD_TOKEN, '')
-    base = requests.get('https://packagecloud.io/api/v1/repos/dokku/dokku/packages/deb/ubuntu/trusty.json',
+    base = requests.get('https://packagecloud.io/api/v1/repos/dokku/dokku/packages/deb/ubuntu/bionic.json',
                         auth=auth)
     data = base.json()
     urls = []

--- a/contrib/release-dokku
+++ b/contrib/release-dokku
@@ -136,7 +136,7 @@ fn-publish-package() {
   [[ "$RELEASE_TYPE" == "rpm" ]] && DIST=el/7
 
   if [[ "$DIST" == "ubuntu" ]]; then
-    OS_IDS=("trusty" "utopic" "vivid" "wily" "xenial" "yakkety" "zesty" "artful" "bionic")
+    OS_IDS=("xenial" "bionic")
     for OS_ID in "${OS_IDS[@]}"; do
       log-info "(release-dokku) pushing ${RELEASE_TYPE} to packagecloud.com/${REPOSITORY}/${DIST}"
       package_cloud push "${REPOSITORY}/${DIST}/${OS_ID}" "$PACKAGE_NAME"
@@ -147,7 +147,7 @@ fn-publish-package() {
     done
 
     DIST=debian
-    OS_IDS=("wheezy" "jessie" "stretch" "buster")
+    OS_IDS=("stretch" "buster")
     for OS_ID in "${OS_IDS[@]}"; do
       log-info "(release-dokku) pushing ${RELEASE_TYPE} to packagecloud.com/${REPOSITORY}/${DIST}"
       package_cloud push "${REPOSITORY}/${DIST}/${OS_ID}" "$PACKAGE_NAME"

--- a/contrib/release-dokku-update
+++ b/contrib/release-dokku-update
@@ -61,7 +61,7 @@ fn-publish-package() {
   [[ "$RELEASE_TYPE" == "rpm" ]] && DIST=el/7
 
   if [[ "$DIST" == "ubuntu" ]]; then
-    OS_IDS=("trusty" "utopic" "vivid" "wily" "xenial" "yakkety" "zesty" "artful" "bionic")
+    OS_IDS=("xenial" "bionic")
     for OS_ID in "${OS_IDS[@]}"; do
       log-info "(release-dokku-update) pushing ${RELEASE_TYPE} to packagecloud.com/${REPOSITORY}/${DIST}"
       package_cloud push "${REPOSITORY}/${DIST}/${OS_ID}" "$PACKAGE_NAME"
@@ -72,7 +72,7 @@ fn-publish-package() {
     done
 
     DIST=debian
-    OS_IDS=("wheezy" "jessie" "stretch" "buster")
+    OS_IDS=("stretch" "buster")
     for OS_ID in "${OS_IDS[@]}"; do
       log-info "(release-dokku-update) pushing ${RELEASE_TYPE} to packagecloud.com/${REPOSITORY}/${DIST}"
       package_cloud push "${REPOSITORY}/${DIST}/${OS_ID}" "$PACKAGE_NAME"

--- a/contrib/release-herokuish
+++ b/contrib/release-herokuish
@@ -61,7 +61,7 @@ fn-publish-package() {
   [[ "$RELEASE_TYPE" == "rpm" ]] && DIST=el/7
 
   if [[ "$DIST" == "ubuntu" ]]; then
-    OS_IDS=("trusty" "utopic" "vivid" "wily" "xenial" "yakkety" "zesty" "artful" "bionic")
+    OS_IDS=("xenial" "bionic")
     for OS_ID in "${OS_IDS[@]}"; do
       log-info "(release-herokuish) pushing ${RELEASE_TYPE} to packagecloud.com/${REPOSITORY}/${DIST}"
       package_cloud push "${REPOSITORY}/${DIST}/${OS_ID}" "$PACKAGE_NAME"
@@ -72,7 +72,7 @@ fn-publish-package() {
     done
 
     DIST=debian
-    OS_IDS=("wheezy" "jessie" "stretch" "buster")
+    OS_IDS=("stretch" "buster")
     for OS_ID in "${OS_IDS[@]}"; do
       log-info "(release-herokuish) pushing ${RELEASE_TYPE} to packagecloud.com/${REPOSITORY}/${DIST}"
       package_cloud push "${REPOSITORY}/${DIST}/${OS_ID}" "$PACKAGE_NAME"

--- a/deb.mk
+++ b/deb.mk
@@ -47,7 +47,7 @@ install-from-deb:
 
 	@echo "--> Installing dokku"
 	wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -
-	@echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ $(shell lsb_release -cs 2>/dev/null || echo "trusty") main" | sudo tee /etc/apt/sources.list.d/dokku.list
+	@echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ $(shell lsb_release -cs 2>/dev/null || echo "bionic") main" | sudo tee /etc/apt/sources.list.d/dokku.list
 	sudo apt-get update -qq >/dev/null
 	sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -yy dokku
 

--- a/docs/appendices/0.20.0-migration-guide.md
+++ b/docs/appendices/0.20.0-migration-guide.md
@@ -2,6 +2,8 @@
 
 ## Removals
 
+### Command removals
+
 The following commands were previously deprecated and were removed in this release.
 
 - `apps`: Use `apps:list` instead.
@@ -25,6 +27,23 @@ The refactor of the proxy plugin removes the following functions from being sour
 - `proxy#set_proxy_ports()`
 
 The informal policy is to allow removal of functions within a `functions` file if they are not used in OSS plugins. Should you be affected by any such removals, please file an issue to expose the functionality via a plugin trigger.
+
+### Remove support for Unsupported Operating Systems
+
+Dokku will no longer distribute packages for Ubuntu versions that have reached either End of Life or End of Standard Support (for LTS releases). This currently includes the following releases:
+
+- Ubuntu 14.04 (trusty)
+- Ubuntu 14.10 (utopic)
+- Ubuntu 15.04 (vivid)
+- Ubuntu 15.10 (wily)
+- Ubuntu 16.10 (yakkety)
+- Ubuntu 17.04 (zesty)
+- Ubuntu 17.10 (artful)
+
+Dokku will no longer distribute packages for Debian versions that are not `stable` or `oldstable`. This currently includes the following releases:
+
+- Debian 7 (wheezy)
+- Debian 8 (jessie)
 
 ## Deprecations
 

--- a/docs/deployment/methods/dockerfiles.md
+++ b/docs/deployment/methods/dockerfiles.md
@@ -38,7 +38,7 @@ dokku docker-options:add node-js-app build '--file Dockerfile.dokku'
 Once set, the Dockerfile usage would be as follows:
 
 ```Dockerfile
-FROM debian:jessie
+FROM ubuntu:18.04
 
 # set the argument default
 ARG NODE_ENV=production
@@ -50,7 +50,7 @@ RUN echo $NODE_ENV
 You may also set the argument as an environment variable
 
 ```Dockerfile
-FROM debian:jessie
+FROM ubuntu:18.04
 
 # set the argument default
 ARG NODE_ENV=production
@@ -101,7 +101,7 @@ worker: bin/run-worker.sh
 And `Dockerfile`:
 
 ```Dockerfile
-FROM debian:jessie
+FROM ubuntu:18.04
 WORKDIR /app
 COPY . ./
 CMD ["bin/run-dev.sh"]

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -9,11 +9,11 @@ We maintain the Dokku test harness within the `tests` directory:
 
 ## Continuous Integration
 
-All pull requests have tests run against them on [CircleCI](https://circleci.com/), a continuous integration platform that provides Docker support for Ubuntu Trusty 14.04.
+All pull requests have tests run against them on [CircleCI](https://circleci.com/), a continuous integration platform that provides Docker support for Ubuntu Trusty 16.04.
 
 If you wish to skip tests for a particular commit, e.g. documentation changes, you may add the `[ci skip]` designator to your commit message. Commits that _should_ be tested but have the above designator will not be merged.
 
-While we do provide official packages for a variety of platforms, as our test suite currently runs on Ubuntu Trusty 14.04, we only provide official installation support for that platform.
+While we do provide official packages for a variety of platforms, as our test suite currently runs on Ubuntu Trusty 16.04, we only provide official installation support for that platform and the latest LTS release of Ubuntu (currently 18.04).
 
 ## Local Test Execution
 

--- a/docs/getting-started/install/debian.md
+++ b/docs/getting-started/install/debian.md
@@ -12,8 +12,8 @@ wget -nv -O - https://get.docker.com/ | sh
 
 # install dokku
 wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -
-OS_ID="$(lsb_release -cs 2>/dev/null || echo "trusty")"
-echo "trusty utopic vivid wily xenial yakkety zesty artful bionic" | grep -q "$OS_ID" || OS_ID="trusty"
+OS_ID="$(lsb_release -cs 2>/dev/null || echo "bionic")"
+echo "xenial bionic" | grep -q "$OS_ID" || OS_ID="bionic"
 echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ ${OS_ID} main" | sudo tee /etc/apt/sources.list.d/dokku.list
 sudo apt-get update -qq >/dev/null
 sudo apt-get install -qq -y dokku

--- a/docs/getting-started/install/digitalocean.md
+++ b/docs/getting-started/install/digitalocean.md
@@ -6,7 +6,7 @@
 
 1. Login to your [DigitalOcean](https://m.do.co/c/fe06b043a083) account.
 2. Click **Create a Droplet**.
-3. Under **Choose an image > One-click apps**, choose the latest **Dokku** release for 16.04 _(version numbers may vary)_.
+3. Under **Choose an image > One-click apps**, choose the latest **Dokku** release for 18.04 _(version numbers may vary)_.
 4. Under **Choose a size**, select your machine spec.
 5. Under **Choose a datacenter region**, select your region.
 6. Add an SSH Key.

--- a/docs/getting-started/install/dreamhost.md
+++ b/docs/getting-started/install/dreamhost.md
@@ -19,7 +19,7 @@ source openrc.sh # Set the environment variables for DreamHost Cloud
 
 This allows OpenStack client to connect to DreamHost API endpoints.
 The command below creates a new server instance named `my-dokku-instance`
-based on Ubuntu 14.04, with 2 GB RAM and 1 CPU (the flavor called
+based on Ubuntu 18.04, with 2 GB RAM and 1 CPU (the flavor called
 `supersonic`), opening network port access to HTTP and SSH (the
 `default` security group), and the name of the chosen SSH key. This
 key will be automatically added to the new server in the
@@ -28,7 +28,7 @@ be reused by Dokku.
 
 ```sh
 openstack server create \
-  --image Ubuntu-14.04 \
+  --image Ubuntu-18.04 \
   --flavor gp1.supersonic \
   --security-group default \
   --key-name $YOUR_SSH_KEYNAME \
@@ -46,7 +46,7 @@ server:
 apt_upgrade: true
 
 apt_sources:
- - source: "deb https://packagecloud.io/dokku/dokku/ubuntu/ trusty main"
+ - source: "deb https://packagecloud.io/dokku/dokku/ubuntu/ bionic main"
    key: |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
     Version: SKS 1.1.5
@@ -107,7 +107,7 @@ apt_sources:
     =H60S
     -----END PGP PUBLIC KEY BLOCK-----
    filename: dokku.list
- - source: "deb https://apt.dockerproject.org/repo ubuntu-trusty main"
+ - source: "deb https://apt.dockerproject.org/repo ubuntu-bionic main"
    key: |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
     Version: SKS 1.1.5

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ Dokku is an extensible, open source Platform as a Service that runs on a single 
 
 To start using Dokku, you'll need a system that meets the following minimum requirements:
 
-- A fresh installation of [Ubuntu x64 - Any currently supported release](https://www.ubuntu.com/download), [Debian 8.2 x64](https://www.debian.org/distrib/) or [CentOS 7 x64](https://www.centos.org/download/) *(experimental)* with the FQDN set <sup>[1]</sup>
+- A fresh installation of [Ubuntu 16.04/18.04 x64](https://www.ubuntu.com/download), [Debian 9 x64](https://www.debian.org/distrib/) or [CentOS 7 x64](https://www.centos.org/download/) *(experimental)* with the FQDN set <sup>[1]</sup>
 - At least 1 GB of system memory <sup>[2]</sup>
 
 You can *optionally* have a domain name pointed at the host's IP, though this is not necessary.
@@ -27,7 +27,7 @@ sudo DOKKU_TAG=v0.19.13 bash bootstrap.sh
 
 The installation process takes about 5-10 minutes, depending upon internet connection speed.
 
-If you're using Debian 8 or Ubuntu 14.04, make sure your package manager is configured to install a sufficiently recent version of nginx<sup>[3]</sup>, otherwise, the installation may fail due to `unmet dependencies` relating nginx.
+If you're using Debian 9 or Ubuntu 18.04, make sure your package manager is configured to install a sufficiently recent version of nginx<sup>[3]</sup>, otherwise, the installation may fail due to `unmet dependencies` relating nginx.
 
 #### 2. Setup SSH key and Virtualhost Settings
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -198,7 +198,7 @@ __Symptom:__ I successfully deployed my application with no deployment errors bu
 
 __Solution:__
 
-This can occur if Dokku is running on a system with a firewall like UFW enabled (some OS versions like Ubuntu 16.04 have this enabled by default). You can check if this is your case by running the following script:
+This can occur if Dokku is running on a system with a firewall like UFW enabled (some OS versions like Ubuntu have this enabled by default). You can check if this is your case by running the following script:
 
 ```shell
 sudo ufw status

--- a/docs/home.html
+++ b/docs/home.html
@@ -164,12 +164,12 @@
           <p class="line">
             <span class="path"></span>
             <span class="prompt">$</span>
-            <span class="command">export OS_ID="$(lsb_release -cs 2>/dev/null || echo "trusty")"</span>
+            <span class="command">export OS_ID="$(lsb_release -cs 2>/dev/null || echo "bionic")"</span>
           </p>
           <p class="line">
             <span class="path"></span>
             <span class="prompt">$</span>
-            <span class="command">echo "utopicvividwilyxenialyakketyzestyartfulbionic" | grep -q "$OS_ID" || OS_ID="trusty"</span>
+            <span class="command">echo "xenial bionic" | grep -q "$OS_ID" || OS_ID="bionic"</span>
           </p>
           <p class="line">
             <span class="path"></span>

--- a/docs/networking/port-management.md
+++ b/docs/networking/port-management.md
@@ -145,7 +145,7 @@ Dokku will extract all tcp ports exposed using the `EXPOSE` directive (one port 
 For example, if the Dokku installation is configured with the domain `dokku.me` and an application named `node-js-app` is deployed with following Dockerfile:
 
 ```
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 EXPOSE 1234
 RUN python -m SimpleHTTPServer 1234
 ```

--- a/tests.mk
+++ b/tests.mk
@@ -17,8 +17,6 @@ ifneq ($(shell shellcheck --version >/dev/null 2>&1 ; echo $$?),0)
 ifeq ($(SYSTEM),Darwin)
 	brew install shellcheck
 else
-	sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
-	sudo rm -rf /var/lib/apt/lists/* && sudo apt-get clean
 	sudo apt-get update -qq && sudo apt-get install -qq -y shellcheck
 endif
 endif

--- a/tests/ci/setup.sh
+++ b/tests/ci/setup.sh
@@ -9,23 +9,23 @@ install_dependencies() {
   mkdir -p "$ROOT_DIR/build/"
   HEROKUISH_VERSION=$(grep HEROKUISH_VERSION "${ROOT_DIR}/deb.mk" | head -n1 | cut -d' ' -f3)
   HEROKUISH_PACKAGE_NAME="herokuish_${HEROKUISH_VERSION}_amd64.deb"
-  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/herokuish_${HEROKUISH_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${HEROKUISH_PACKAGE_NAME}"
+  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/herokuish_${HEROKUISH_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${HEROKUISH_PACKAGE_NAME}"
 
   PLUGN_VERSION=$(grep PLUGN_VERSION "${ROOT_DIR}/Makefile" | head -n1 | cut -d' ' -f3)
   PLUGN_PACKAGE_NAME="plugn_${PLUGN_VERSION}_amd64.deb"
-  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/plugn_${PLUGN_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PLUGN_PACKAGE_NAME}"
+  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/plugn_${PLUGN_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PLUGN_PACKAGE_NAME}"
 
   SSHCOMMAND_VERSION=$(grep SSHCOMMAND_VERSION "${ROOT_DIR}/Makefile" | head -n1 | cut -d' ' -f3)
   SSHCOMMAND_PACKAGE_NAME="sshcommand_${SSHCOMMAND_VERSION}_amd64.deb"
-  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/sshcommand_${SSHCOMMAND_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${SSHCOMMAND_PACKAGE_NAME}"
+  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/sshcommand_${SSHCOMMAND_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${SSHCOMMAND_PACKAGE_NAME}"
 
   SIGIL_VERSION=$(grep SIGIL_VERSION "${ROOT_DIR}/deb.mk" | head -n1 | cut -d' ' -f3)
   SIGIL_PACKAGE_NAME="gliderlabs-sigil_${SIGIL_VERSION}_amd64.deb"
-  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/gliderlabs-sigil_${SIGIL_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${SIGIL_PACKAGE_NAME}"
+  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/gliderlabs-sigil_${SIGIL_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${SIGIL_PACKAGE_NAME}"
 
   PROCFILE_VERSION=$(grep PROCFILE_VERSION "${ROOT_DIR}/Makefile" | head -n1 | cut -d' ' -f3)
   PROCFILE_UTIL_PACKAGE_NAME="procfile-util_${PROCFILE_VERSION}_amd64.deb"
-  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/trusty/procfile-util_${PROCFILE_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PROCFILE_UTIL_PACKAGE_NAME}"
+  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/procfile-util_${PROCFILE_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PROCFILE_UTIL_PACKAGE_NAME}"
 
   sudo add-apt-repository -y ppa:nginx/stable
   sudo apt-get update


### PR DESCRIPTION
While the latest packages may continue to work on other releases, we will no longer officially support these releases, nor will we distribute packages.
