### PR TITLE
Change error exit to warning when no apps exist

### DIFF
--- a/plugins/apps/subcommands.go
+++ b/plugins/apps/subcommands.go
@@ -108,7 +108,8 @@ func CommandList(args []string) error {
 	common.LogInfo2Quiet("My Apps")
 	apps, err := common.DokkuApps()
 	if err != nil {
-		return err
+		common.LogWarn(err.Error())
+		return nil
 	}
 
 	for _, appName := range apps {

--- a/tests/unit/10_apps.bats
+++ b/tests/unit/10_apps.bats
@@ -24,6 +24,32 @@ teardown() {
   assert_output "$help_output"
 }
 
+@test "(apps) apps:list" {
+  run /bin/bash -c "dokku apps:list 2>&1"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "You haven't deployed any applications yet"
+  assert_output_contains "$TEST_APP" 0
+
+  run /bin/bash -c "dokku apps:create $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku apps:list 2>&1"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "You haven't deployed any applications yet" 0
+  assert_output_contains "$TEST_APP"
+
+  run /bin/bash -c "dokku --force apps:destroy $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
 @test "(apps) apps:create" {
   run /bin/bash -c "dokku apps:create $TEST_APP"
   echo "output: $output"


### PR DESCRIPTION
This was a regression introduced in 0.20.0 when the plugin was converted to golang.