### PR TITLE
fix: scope init tests to container processes only

### DIFF
--- a/tests/unit/50_init_1.bats
+++ b/tests/unit/50_init_1.bats
@@ -13,8 +13,12 @@ teardown() {
 }
 
 @test "(init) buildpack" {
-  deploy_app zombies-buildpack
-  run ps ax
+  source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+  local APP="zombies-buildpack"
+  deploy_app "$APP"
+  local CIDS=$(get_app_container_ids "$APP")
+
+  run "$DOCKER_BIN" container top "$CIDS"
   echo "output: $output"
   assert_output_contains "<defunct>" "0"
 }

--- a/tests/unit/50_init_2.bats
+++ b/tests/unit/50_init_2.bats
@@ -13,8 +13,12 @@ teardown() {
 }
 
 @test "(init) dockerfile no tini" {
-  deploy_app zombies-dockerfile-no-tini
-  run ps auxf
+  source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+  local APP="zombies-dockerfile-no-tini"
+  deploy_app "$APP"
+  local CIDS=$(get_app_container_ids "$APP")
+  
+  run "$DOCKER_BIN" container top "$CIDS"
   echo "output: $output"
   assert_output_contains "<defunct>" "0"
 }

--- a/tests/unit/50_init_3.bats
+++ b/tests/unit/50_init_3.bats
@@ -13,8 +13,12 @@ teardown() {
 }
 
 @test "(init) dockerfile with tini" {
-  deploy_app zombies-dockerfile-tini
-  run ps ax
+  source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+  local APP="zombies-dockerfile-tini"
+  deploy_app "$APP"
+  local CIDS=$(get_app_container_ids "$APP")
+
+  run "$DOCKER_BIN" container top "$CIDS"
   echo "output: $output"
   assert_output_contains "<defunct>" "0"
 }


### PR DESCRIPTION
Fixes flaky tests https://github.com/dokku/dokku/pull/3609#issuecomment-613800349.

`ps ax` list all processes, which causes tests to fail if a `<defunct>` process just so happens to be somewhere else on the system.

Use `docker container top` to list the test app’s processes only.