### PR TITLE
Fix missing 502 error page

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -93,6 +93,7 @@ EOF
   cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/400-error.html" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors/400-error.html"
   cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/404-error.html" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors/404-error.html"
   cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/500-error.html" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors/500-error.html"
+  cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/502-error.html" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors/502-error.html"
 
   # patch broken nginx 1.8.0 logrotate
   [[ -f /etc/logrotate.d/nginx ]] && sed -i -e 's/invoke-rc.d/service/g' /etc/logrotate.d/nginx


### PR DESCRIPTION
In dokku/dokku#3602 a new error page for the 502 status code was
introduced.

However, this error page is not currently being used, and results in a
404 error being served instead, because nginx is trying to load a
non-existent file:

```
open() "/var/lib/dokku/data/nginx-vhosts/dokku-errors/502-error.html" failed (2: No such file or directory)
```

Fix this by copying the `502-error.html` file into the `dokku-errors`
directory upon installation.
