### PR TITLE
feat: allow remotes named other than dokku for CLI

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -61,10 +61,29 @@ fn-dokku-host() {
   echo "$DOKKU_HOST"
 }
 
+fn-dokku-remotes() {
+  git remote -v 2>/dev/null | grep -Ei "dokku@" | cut -f1 | uniq
+}
+
+fn-alternative-dokku-remote() {
+  declare remote_name="$1"
+
+  dokku_remotes=$(fn-dokku-remotes)
+  match=$(echo "$dokku_remotes" | grep -Ei "^${remote_name}$")
+
+  echo "$match"
+}
+
 main() {
   declare CMD="$1" APP_ARG="$2"
   local APP="" DOKKU_GIT_REMOTE="dokku" DOKKU_REMOTE_HOST=""
   local cmd_set=false next_index=1 skip=false args=("$@")
+
+  alternative_dokku_remote="$(fn-alternative-dokku-remote "$CMD")"
+  if [[ "$alternative_dokku_remote" ]]; then
+    DOKKU_GIT_REMOTE="$alternative_dokku_remote"
+    shift
+  fi
 
   for arg in "$@"; do
     if [[ "$skip" == "true" ]]; then

--- a/docs/community/clients.md
+++ b/docs/community/clients.md
@@ -53,6 +53,15 @@ Configure the `DOKKU_HOST` environment variable or run `dokku` from a repository
 
 You can also configure a `DOKKU_PORT` environment variable if you are running ssh on a non-standard port. This defaults to `22`.
 
+### Multi-environment use
+
+Instead of defining a git remote named `dokku`, you can also have multiple remotes with different names, e.g. one named `test` and one named `production`. To run a command on any of the defined remotes, prefix the command with the remote name:
+
+```shell
+dokku production apps:list
+dokku test ps:restart
+```
+
 ## (nodejs) dokku-toolbelt
 
 Dokku-toolbelt is a node-based cli wrapper that proxies requests to the Dokku command running on remote hosts. You can install it via the following shell command (assuming you have nodejs and npm installed):


### PR DESCRIPTION
This change allows CLI users to use remotes named other than `dokku`. Users can prefix the dokku commands with the remote name to run a command on a specified remote.

This allows users to run commands on multiple environments or servers from the same git repo.

Example:

Given that the user has the following git remotes:
```bash
origin git@github.com:dokku/dokku.git
test dokku@test.example.com:myapp
production dokku@example.com:myapp
```
It is possible to run the commands on the specified remote like this:

```bash
dokku test ps:rebuild
dokku production logs -t
```

The change is backwards compatible with the existing CLI.