### PR TITLE
Remove all --force-yes usage throughout the codebase

### DIFF
--- a/contrib/dokku-update
+++ b/contrib/dokku-update
@@ -81,7 +81,7 @@ main() {
       ;;
     debian | ubuntu)
       apt-get update -qq >/dev/null
-      apt-get -qq -y --force-yes dist-upgrade
+      apt-get -qq -y dist-upgrade
       ;;
     centos | opensuse | rhel)
       dokku-log-warn "Updating this operating system is not supported"

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -327,7 +327,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 case "$DOKKU_DISTRO" in
   debian|ubuntu)
-    apt-get install --force-yes -qq -y nginx
+    apt-get install -qq -y nginx
     ;;
 
   opensuse)

--- a/docs/getting-started/uninstalling.md
+++ b/docs/getting-started/uninstalling.md
@@ -2,31 +2,31 @@
 
 While we hate to see you go, if you need to uninstall Dokku, the following may help you out:
 
-## Arch Installation
+## Arch Uninstallation
 
 ```shell
 # purge dokku from your system
 yaourt -Rsn dokku
 ```
 
-## CentOS Installation
+## CentOS Uninstallation
 
 ```shell
 # uninstall dokku
 yum remove dokku herokuish
 ```
 
-## Debian Installation
+## Debian Uninstallation
 
 ```shell
 # purge dokku from your system
-apt-get purge -y --force-yes dokku herokuish
+apt-get purge dokku herokuish
 
 # remove any dependencies that are no longer necessary
-apt-get -y --force-yes autoremove
+apt-get autoremove
 ```
 
-## Makefile Installation
+## Makefile Uninstallation
 
 This is a manual deletion process, and as it is not a recommended installation method, there is currently no automated uninstallation.
 

--- a/plugins/nginx-vhosts/dependencies
+++ b/plugins/nginx-vhosts/dependencies
@@ -26,7 +26,7 @@ nginx_needs_upgrade() {
 nginx_install() {
   declare desc="install nginx and dnsutils"
   export DEBIAN_FRONTEND=noninteractive
-  apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes -qq -y nginx dnsutils
+  apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qq -y nginx dnsutils
 }
 
 trigger-nginx-vhosts-dependencies() {


### PR DESCRIPTION
It was deprecated in a recent apt release and shouldn't be necessary for anything any longer.

Closes #3949
