### PR TITLE
Drop dokku references in logging output

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -607,11 +607,11 @@ release_and_deploy() {
 
     local DOKKU_SKIP_DEPLOY=${DOKKU_APP_SKIP_DEPLOY:="$DOKKU_GLOBAL_SKIP_DEPLOY"}
 
-    dokku_log_info1 "Releasing $APP ($IMAGE)..."
+    dokku_log_info1 "Releasing $APP..."
     dokku_release "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG"
 
     if [[ "$DOKKU_SKIP_DEPLOY" != "true" ]]; then
-      dokku_log_info1 "Deploying $APP ($IMAGE)..."
+      dokku_log_info1 "Deploying $APP..."
       cmd-deploy "$APP" "$IMAGE_TAG"
       dokku_log_info2 "Application deployed:"
       get_app_urls urls "$APP" | sed "s/^/       /"

--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -33,7 +33,7 @@ extract_procfile() {
   remove_procfile "$APP"
   copy_from_image "$IMAGE" "Procfile" "$DOKKU_PROCFILE" 2>/dev/null || true
   if [[ -f "$DOKKU_PROCFILE" ]]; then
-    dokku_log_info1_quiet "App Procfile file found ($DOKKU_PROCFILE)"
+    dokku_log_info1_quiet "App Procfile file found"
     # shellcheck disable=SC2069
     PROCFILE_ERRORS="$(procfile-util check --procfile "$DOKKU_PROCFILE" 2>&1 >/dev/null || true)"
     if [[ -n "$PROCFILE_ERRORS" ]]; then


### PR DESCRIPTION
This isn't super useful outside of branding. Users that rely on this information may wish to turn on event logging to trace output that way.