### PR TITLE
Allow apps named tls

### DIFF
--- a/docs/appendices/0.21.0-migration-guide.md
+++ b/docs/appendices/0.21.0-migration-guide.md
@@ -1,5 +1,9 @@
 # 0.21.0 Migration Guide
 
+## Changes
+
+The `tls` name is no longer a reserved app name, and can be used by applications. This was previously a reserved app name due to it's use as a place for global SSL certificate files; Dokku has not supported global SSL certificates for many releases, and thus there is no need to reserve the name.
+
 ## Deprecations
 
 - `git#git_deploy_branch()` is deprecated in favor of `plugn trigger git-deploy-branch`.

--- a/plugins/apps/subcommands.go
+++ b/plugins/apps/subcommands.go
@@ -79,10 +79,6 @@ func CommandDestroy(args []string) error {
 		return err
 	}
 
-	if appName == "tls" {
-		return errors.New("Unable to destroy tls directory")
-	}
-
 	if len(args) >= 2 {
 		force := args[1]
 		if force == "force" {

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -346,7 +346,7 @@ func DokkuApps() (apps []string, err error) {
 		if !DirectoryExists(appRoot) {
 			continue
 		}
-		if f.Name() == "tls" || strings.HasPrefix(f.Name(), ".") {
+		if strings.HasPrefix(f.Name(), ".") {
 			continue
 		}
 		apps = append(apps, f.Name())

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -13,7 +13,7 @@ has_tty() {
 
 dokku_apps() {
   declare desc="prints list of all local apps"
-  local INSTALLED_APPS=$(find "$DOKKU_ROOT" -follow -maxdepth 1 -mindepth 1 -type d ! -name 'tls' ! -name '.*' -printf "%f\n" 2>/dev/null | sort) || (dokku_log_fail "You haven't deployed any applications yet")
+  local INSTALLED_APPS=$(find "$DOKKU_ROOT" -follow -maxdepth 1 -mindepth 1 -type d ! -name '.*' -printf "%f\n" 2>/dev/null | sort) || (dokku_log_fail "You haven't deployed any applications yet")
   [[ $INSTALLED_APPS ]] && echo "$INSTALLED_APPS"
 }
 


### PR DESCRIPTION
The `tls` name is no longer a reserved app name, and can be used by applications. This was previously a reserved app name due to it's use as a place for global SSL certificate files; Dokku has not supported global SSL certificates for many releases, and thus there is no need to reserve the name.

