### PR TITLE
Use large instances for running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     parallelism: 4
+    resource_class: large
     steps:
       - checkout
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     parallelism: 4
-    resource_class: large
+    resource_class: medium+
     steps:
       - checkout
       - run: |


### PR DESCRIPTION
In theory, tests will run faster, but at the very least they won't run out of memory...
