### PR TITLE
Depend on python3 binary for CentOS 8 support

### DIFF
--- a/rpm.mk
+++ b/rpm.mk
@@ -72,7 +72,7 @@ endif
 		--depends 'nginx >= 1.8.0' \
 		--depends 'plugn' \
 		--depends 'procfile-util' \
-		--depends 'python' \
+		--depends '/usr/bin/python3' \
 		--depends 'sshcommand >= 0.10.0' \
 		--depends 'sudo' \
 		--after-install rpm/dokku.postinst \


### PR DESCRIPTION
This will fix compatibility with CentOS 8 by requiring a binary path that can be fulfilled by the python3 package.
