### PR TITLE
Do not allow slashes in app names

### DIFF
--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -582,7 +582,7 @@ func IsValidAppName(appName string) error {
 		return fmt.Errorf("APP must not be null")
 	}
 
-	r, _ := regexp.Compile("^[a-z0-9][^:A-Z]*$")
+	r, _ := regexp.Compile("^[a-z0-9][^/:A-Z]*$")
 	if r.MatchString(appName) {
 		return nil
 	}

--- a/tests/unit/10_apps.bats
+++ b/tests/unit/10_apps.bats
@@ -81,6 +81,11 @@ teardown() {
   echo "status: $status"
   assert_failure
 
+  run /bin/bash -c "dokku apps:create test/app"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+
   run /bin/bash -c "dokku --app $TEST_APP apps:create"
   echo "output: $output"
   echo "status: $status"


### PR DESCRIPTION
There is likely a better regex for the actually allowed names, but this will suffice for ensuring folks don't do weird things with their folder structures...

Closes #4013

