### PR TITLE
Switch AUR helper to yay

### DIFF
--- a/contrib/dokku-update
+++ b/contrib/dokku-update
@@ -77,7 +77,7 @@ main() {
   dokku-log-info "Running system updates"
   case "$DOKKU_DISTRO" in
     arch)
-      yaourt -Syyua
+      yay -Syyua
       ;;
     debian | ubuntu)
       apt-get update -qq >/dev/null

--- a/docs/getting-started/uninstalling.md
+++ b/docs/getting-started/uninstalling.md
@@ -6,7 +6,7 @@ While we hate to see you go, if you need to uninstall Dokku, the following may h
 
 ```shell
 # purge dokku from your system
-yaourt -Rsn dokku
+yay -Rsn dokku
 ```
 
 ## CentOS Uninstallation

--- a/docs/home.html
+++ b/docs/home.html
@@ -201,12 +201,12 @@
 
         <div class="shell shell-arch">
           <p class="line">
-            <span class="output">&nbsp;# install dokku via yaourt</span>
+            <span class="output">&nbsp;# install dokku via yay</span>
           </p>
           <p class="line">
             <span class="path"></span>
             <span class="prompt">$</span>
-            <span class="command">yaourt -S dokku</span>
+            <span class="command">yay -S dokku</span>
           </p>
         </div>
       </div>


### PR DESCRIPTION
[ci skip]

Yaourt has long been considered not a good choice of AUR helper. This PR is to suggest the use of an alternative, yay, which is a lot more robust. Whilst the Arch Linux team never recommends an AUR helper the [wiki](https://wiki.archlinux.org/index.php/AUR_helpers) shows yay is a suitable candidate. 