### PR TITLE
feat: Add download option to the certs plugin

### DIFF
--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -9,6 +9,7 @@ certs:add <app> CRT KEY                  # Add an ssl endpoint to an app. Can al
 certs:generate <app> DOMAIN              # Generate a key and certificate signing request (and self-signed certificate)
 certs:remove <app>                       # Remove an SSL Endpoint from an app.
 certs:report [<app>] [<flag>]            # Displays an ssl report for one or more apps
+certs:show <app> <crt|key>               # Show the server.crt or server.key on stdout
 certs:update <app> CRT KEY               # Update an SSL Endpoint on an app. Can also import from a tarball on stdin
 ```
 
@@ -55,6 +56,16 @@ If you decide to obtain a CA signed certificate, you can import that certificate
 ### Certificate removal
 
 The `certs:remove` command only works on app-specific certificates. It will `rm` the app-specific tls directory, rebuild the nginx configuration, and reload nginx.
+
+### Showing the certificate
+
+The `certs:show` command can be used to show your configured certs for an app. The show command can be used for example to export Let's Encrypt certificates
+after they've been generated. You can export it as follows:
+
+```shell
+dokku certs:show node-js-app crt > server.crt
+dokku certs:show node-js-app key > server.key
+```
 
 ### Displaying certificate reports for an app
 

--- a/plugins/certs/help-functions
+++ b/plugins/certs/help-functions
@@ -34,6 +34,7 @@ fn-help-content() {
     certs:remove <app>, Remove an SSL Endpoint from an app
     certs:report [<app>] [<flag>], Displays an ssl report for one or more apps
     certs:rollback <app>, [NOT IMPLEMENTED] Rollback an SSL Endpoint for an app
+    certs:show <app> <crt|key>, Show the server.crt or server.key on stdout
     certs:update <app> CRT KEY, Update an SSL Endpoint on an app. Can also import from a tarball on stdin
 help_content
 }

--- a/plugins/certs/subcommands/show
+++ b/plugins/certs/subcommands/show
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/certs/functions"
+
+cmd-certs-show() {
+  declare desc="Show the server.crt or server.key on stdout"
+  declare cmd="certs:show"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1" KEY_TYPE="$2"
+
+  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$APP"
+  local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
+
+  if [[ "$KEY_TYPE" != "key" ]] && [[ "$KEY_TYPE" != "crt" ]]; then
+    dokku_log_fail "specify either 'key' or 'crt'"
+  fi
+
+  if ! is_ssl_enabled "$APP"; then
+    dokku_log_fail "$APP doesn't have an SSL endpoint defined"
+  fi
+
+  cat "$APP_SSL_PATH/server.$KEY_TYPE"
+}
+
+cmd-certs-show "$@"

--- a/tests/unit/certs.bats
+++ b/tests/unit/certs.bats
@@ -75,3 +75,29 @@ teardown() {
   echo "status: $status"
   assert_success
 }
+
+@test "(certs) certs:show" {
+  run /bin/bash -c "dokku certs:show fake-app-name 2>&1"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "App fake-app-name does not exist"
+  assert_failure
+
+  run /bin/bash -c "dokku certs:show $TEST_APP fake-var-name"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "specify either 'key' or 'crt'"
+  assert_failure
+
+  run /bin/bash -c "dokku certs:add $TEST_APP < $BATS_TEST_DIRNAME/server_ssl.tar && dokku certs:show $TEST_APP crt"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "-----END CERTIFICATE-----"
+  assert_success
+
+  run /bin/bash -c "dokku certs:add $TEST_APP < $BATS_TEST_DIRNAME/server_ssl.tar && dokku certs:show $TEST_APP key"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "-----END RSA PRIVATE KEY-----"
+  assert_success
+}


### PR DESCRIPTION
The 'server.key' and 'server.crt' can downloaded.
The command will print the certificates to stdin.

Is this something dokku is interested in to get mainlined?

This helped my use case where I spin up a new dokku when I'm testing and developing my app
and remove it when I'm done. This made me hit a domain request limit on let's encrypt.

With the changes in this PR I can download the certificates, so that I can upload them
with the certs plugin when I spin up a new dokku vm.
