### PR TITLE
Install sudo when installing from source

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -100,7 +100,7 @@ install-dokku-from-source() {
     log-fail "This installation script requires apt-get. For manual installation instructions, consult http://dokku.viewdocs.io/dokku/advanced-installation/"
   fi
 
-  apt-get -qq -y install git make software-properties-common
+  apt-get -qq -y install sudo git make software-properties-common
   cd /root
   if [[ ! -d /root/dokku ]]; then
     git clone "$DOKKU_REPO" /root/dokku


### PR DESCRIPTION
When installing from source on a brand new debian system, I got an error running `help2man`. It was calling `dokku --help`, which needed `sudo` to change to the `dokku` user. `sudo` was not installed by default, so I added it to the dependencies list in `bootstrap.sh`.