### PR TITLE
Drop go sum and mod files from releases

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -32,7 +32,7 @@ subcommands/%:
 	ln -sf subcommands $@
 
 src-clean:
-	rm -rf .gitignore src vendor Makefile *.go glide.*
+	rm -rf .gitignore src vendor Makefile *.go glide.* go.sum go.mod
 
 triggers:
 	go build -ldflags="-s -w" $(GO_ARGS) -o triggers src/triggers/triggers.go


### PR DESCRIPTION
These aren't necessary and only bloat the package.