### PR TITLE
Scheduler plugins are no longer beta

### DIFF
--- a/docs/advanced-usage/schedulers/alternate-schedulers.md
+++ b/docs/advanced-usage/schedulers/alternate-schedulers.md
@@ -1,6 +1,6 @@
 # Alternative Schedulers
 
-Aside from the built-in [docker-local scheduler](/docs/advanced-usage/schedulers/docker-local.md), Dokku also supports two beta scheduler plugins:
+In addition to the built-in [docker-local scheduler](/docs/advanced-usage/schedulers/docker-local.md), Dokku also supports two scheduler plugins:
 
 - [Kubernetes](https://github.com/dokku/dokku-scheduler-kubernetes)
 - [Nomad](https://github.com/dokku/dokku-scheduler-nomad)


### PR DESCRIPTION
[ci skip]
