### PR TITLE
Fix deprecation warning in config_all

### DIFF
--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -32,7 +32,7 @@ config_all() {
     return 0
   fi
 
-  "$PLUGIN_AVAILABLE_PATH/config/commands" show "$@"
+  "$PLUGIN_AVAILABLE_PATH/config/commands" config:show "$@"
 }
 
 config_keys() {

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -32,7 +32,7 @@ config_all() {
     return 0
   fi
 
-  "$PLUGIN_AVAILABLE_PATH/config/commands" "$@"
+  "$PLUGIN_AVAILABLE_PATH/config/commands" show "$@"
 }
 
 config_keys() {


### PR DESCRIPTION
**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
