### PR TITLE
Fix deprecation warning in config_all but actually don't break it

### DIFF
--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -32,7 +32,7 @@ config_all() {
     return 0
   fi
 
-  "$PLUGIN_AVAILABLE_PATH/config/commands" config:show "$@"
+  "$PLUGIN_AVAILABLE_PATH/config/subcommands/show" config:show "$@"
 }
 
 config_keys() {


### PR DESCRIPTION
My last "fix" just failed silently instead. Apologies.
