### PR TITLE
Fix config_all bug introduced in 0.21.2

### DIFF
--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -32,7 +32,7 @@ config_all() {
     return 0
   fi
 
-  "$PLUGIN_AVAILABLE_PATH/config/commands" config:show "$@"
+  "$PLUGIN_AVAILABLE_PATH/config/subcommands/show" "$@"
 }
 
 config_keys() {


### PR DESCRIPTION
Making it silently fail also removed the warning I guess, but it also removed the feature