### PR TITLE
Stop using VHOST when listing app domains and urls 

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -919,7 +919,7 @@ internal_get_app_urls() {
         echo "http://$(<"$DOKKU_ROOT/HOSTNAME"):$p"
       done
     else
-      echo "$SCHEME://$(<"$DOKKU_ROOT/VHOST")"
+      echo "$SCHEME://$(<"$DOKKU_ROOT/HOSTNAME")"
     fi
   fi
 }

--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -215,14 +215,11 @@ get_app_domains() {
   verify_app_name "$1"
   local APP=$1
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
-  local GLOBAL_VHOST_PATH="$DOKKU_ROOT/VHOST"
   local GLOBAL_HOSTNAME_PATH="$DOKKU_ROOT/HOSTNAME"
 
   if [[ "$(is_app_vhost_enabled "$APP")" == "true" ]]; then
     if [[ -f "$APP_VHOST_PATH" ]]; then
       cat "$APP_VHOST_PATH"
-    elif [[ -f "$GLOBAL_VHOST_PATH" ]]; then
-      cat "$GLOBAL_VHOST_PATH"
     elif [[ -f "$GLOBAL_HOSTNAME_PATH" ]]; then
       cat "$GLOBAL_HOSTNAME_PATH"
     fi

--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -57,10 +57,7 @@ domains_add() {
   done
 
   for DOMAIN in "$@"; do
-    if [[ $(
-      grep -w -E "^$DOMAIN$" "$APP_VHOST_PATH" >/dev/null 2>&1
-      echo $?
-    ) -eq 0 ]]; then
+    if grep -x --line-regexp --fixed-strings "$DOMAIN" "$APP_VHOST_PATH" 2> /dev/null; then
       dokku_log_info1 "Skipping: $DOMAIN already added to $APP"
     else
       echo "$DOMAIN" >>"$APP_VHOST_PATH"
@@ -159,13 +156,10 @@ domains_add_global() {
   done
 
   for DOMAIN in "$@"; do
-    if [[ $(
-      grep -w -E "^$DOMAIN$" "$GLOBAL_VHOST_PATH" >/dev/null 2>&1
-      echo $?
-    ) -eq 0 ]]; then
-      dokku_log_info1 "Skipping: $DOMAIN already added"
+    if grep -q --line-regexp --fixed-strings "$DOMAIN" "$GLOBAL_VHOST_PATH" 2> /dev/null; then
+      dokku_log_info1 "Skipping $DOMAIN: already added"
     else
-      grep -qxF "$DOMAIN" "$GLOBAL_VHOST_PATH" || echo "$DOMAIN" >>"$GLOBAL_VHOST_PATH"
+      echo "$DOMAIN" >>"$GLOBAL_VHOST_PATH"
       dokku_log_info1 "Added $DOMAIN"
     fi
   done


### PR DESCRIPTION
As mentioned here in https://github.com/dokku/dokku/issues/1558#issuecomment-659149054, I think that `$DOKKU_ROOT/VHOST` should only be used when building `$DOKKU_ROOT/$APP/VHOST`, as a prefix.

This PR removes the two direct usages of `$DOKKU_ROOT/VHOST`: app domains and app urls.