### PR TITLE
Fix nginx proxy-read-timeout not set for HTTPS

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -84,6 +84,7 @@ server {
     proxy_pass  http://{{ $.APP }}-{{ $upstream_port }};
     {{ if eq $.HTTP2_PUSH_SUPPORTED "true" }}http2_push_preload on; {{ end }}
     proxy_http_version 1.1;
+    proxy_read_timeout {{ $.PROXY_READ_TIMEOUT }};
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
     proxy_set_header Host $http_host;

--- a/tests/unit/nginx-vhosts_8.bats
+++ b/tests/unit/nginx-vhosts_8.bats
@@ -138,6 +138,41 @@ teardown() {
   assert_output_contains "45s;" 0
 }
 
+@test "(nginx-vhosts) nginx:set proxy-read-timeout (with SSL)" {
+  setup_test_tls
+  deploy_app
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-read-timeout 45s"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "45s;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-read-timeout"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "45s;" 0
+}
+
 @test "(nginx-vhosts) nginx:build-config (with SSL and unrelated domain)" {
   setup_test_tls
   add_domain "node-js-app.dokku.me"


### PR DESCRIPTION
#4043 implemented Nginx `proxy-read-timeout` however it only sets for HTTP scheme, not HTTPS. 

This pull request fixes it. 