### PR TITLE
Fix plugin typo (plugn) in migration guide

### DIFF
--- a/docs/appendices/0.20.0-migration-guide.md
+++ b/docs/appendices/0.20.0-migration-guide.md
@@ -77,12 +77,12 @@ The following changes on the `network:report` command were made in this release:
 ## Deprecations
 
 - `nginx:show-conf` has been deprecated in favor of `nginx:show-config`.
-- `proxy#is_app_proxy_enabled()` is deprecated in favor of `plugn trigger proxy-is-enabled`.
-- `proxy#get_app_proxy_type()` is deprecated in favor of `plugn trigger proxy-type`.
-- `apps#apps_create()` is deprecated in favor of `plugn trigger app-create`.
-- `apps#apps_destroy()` is deprecated in favor of `plugn trigger app-destroy`.
-- `apps#apps_exists()` is deprecated in favor of `plugn trigger app-exists`.
-- `apps#apps_maybe_create()` is deprecated in favor of `plugn trigger app-maybe-create`.
+- `proxy#is_app_proxy_enabled()` is deprecated in favor of `plugin trigger proxy-is-enabled`.
+- `proxy#get_app_proxy_type()` is deprecated in favor of `plugin trigger proxy-type`.
+- `apps#apps_create()` is deprecated in favor of `plugin trigger app-create`.
+- `apps#apps_destroy()` is deprecated in favor of `plugin trigger app-destroy`.
+- `apps#apps_exists()` is deprecated in favor of `plugin trigger app-exists`.
+- `apps#apps_maybe_create()` is deprecated in favor of `plugin trigger app-maybe-create`.
 - `plugin trigger network-get-listeners` usage without a second `processType` argument is deprecated.
 - `.NGINX_PORT` variable usage within `nginx.conf.sigil` templates is deprecated in favor of `.PROXY_PORT`.
 - `.NGINX_SSL_PORT` variable usage within `nginx.conf.sigil` templates is deprecated in favor of `.PROXY_SSL_PORT`.


### PR DESCRIPTION
[ci skip]

Fix a minor typo in the deprecation list. `plugn` -> `plugin`
