### PR TITLE
Add missing labels to built images

### DIFF
--- a/plugins/builder-dockerfile/builder-release
+++ b/plugins/builder-dockerfile/builder-release
@@ -16,7 +16,7 @@ trigger-builder-dockerfile-builder-release() {
   plugn trigger pre-release-dockerfile "$APP" "$IMAGE_TAG"
 
   local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
-  echo "FROM $IMAGE" | suppress_output "$DOCKER_BIN" image build --label=com.dokku.image-stage=release -t "$IMAGE" -
+  echo "FROM $IMAGE" | suppress_output "$DOCKER_BIN" image build --label=com.dokku.image-stage=release --label=com.dokku.app-name=$APP --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=dokku -t "$IMAGE" -
   plugn trigger post-release-dockerfile "$APP" "$IMAGE_TAG"
 }
 

--- a/plugins/builder-herokuish/builder-release
+++ b/plugins/builder-herokuish/builder-release
@@ -38,7 +38,7 @@ trigger-builder-herokuish-builder-release() {
     "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
   fi
 
-  echo "FROM $IMAGE" | suppress_output "$DOCKER_BIN" image build --label=com.dokku.image-stage=release -t "$IMAGE" -
+  echo "FROM $IMAGE" | suppress_output "$DOCKER_BIN" image build --label=com.dokku.image-stage=release --label=com.dokku.app-name=$APP --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=dokku -t "$IMAGE" -
   plugn trigger post-release-buildpack "$APP" "$IMAGE_TAG"
 }
 


### PR DESCRIPTION
This fixes an issue where disk space is not recouped after deploys unless 'dokku cleanup' without arguments is called.

Also injects the label-schema labels as necessary.

Refs #4099
