### PR TITLE
Support for expected CHECKS text with special characters

### DIFF
--- a/plugins/scheduler-docker-local/check-deploy
+++ b/plugins/scheduler-docker-local/check-deploy
@@ -211,7 +211,7 @@ trigger-scheduler-docker-local-check-deploy() {
       # shellcheck disable=SC2086
       if OUTPUT=$(curl -# $CURL_ARGS 2>&1); then
         # OUTPUT contains the HTTP response
-        if [[ "$OUTPUT" =~ $EXPECTED ]]; then
+        if [[ "$OUTPUT" =~ "$EXPECTED" ]]; then
           SUCCESS=1
           break
         fi


### PR DESCRIPTION
Fixes #4122 

Added a quote around the "$EXPECTED" to deal with text with restricted characters. While deploying a Spring Boot application, the content of the built-in health check is {"status":"UP"}. Unfortunately all my checks failed, because for some reason the comparison didn't like this content.

remote:  !     http://localhost/actuator/health: expected to but did not find: "{"status":"UP"}"
remote:  !     Check attempt 7/10 failed.

After making this change, it works: I'm assuming the difference is that the presence of the quote or curly braces characters in the content.


