### PR TITLE
Added the container index to the network-compute-ports trigger

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -738,7 +738,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 - Description: Computes the ports for a given app container
 - Invoked by: `internally triggered by proxy-build-config within proxy implementations`
-- Arguments: `$APP`
+- Arguments: `$APP $PROC_TYPE $IS_HEROKUISH_CONTAINER $CONTAINER_INDEX`
 - Example:
 
 ```shell

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -86,7 +86,7 @@ trigger-scheduler-docker-local-scheduler-deploy() {
       [[ -n "$DOKKU_START_CMD" ]] && START_CMD="$DOKKU_START_CMD"
 
       if [[ "$PROC_TYPE" == "web" ]]; then
-        ports=($(plugn trigger network-compute-ports "$APP" "$PROC_TYPE" "$DOKKU_HEROKUISH"))
+        ports=($(plugn trigger network-compute-ports "$APP" "$PROC_TYPE" "$DOKKU_HEROKUISH" "$CONTAINER_INDEX"))
         local DOKKU_DOCKER_PORT_ARGS=""
         local DOKKU_PORT=""
         for p in "${ports[@]}"; do


### PR DESCRIPTION
Useful for alternative proxy implementations. Updated the documentation for the network-compute-ports trigger to clarify the arguments

For alternate proxy implementations, the network-compute-ports trigger in the local docker scheduler allows for individual port mappings for each container instance. This PR adds the container index to the trigger (so an independent index of port mappings to container index can easily be maintained) and updates the documentation of the trigger to match (also, the documentation was missing a couple of arguments).

