### PR TITLE
Prohibit non-dns names for apps and process types

### DIFF
--- a/docs/appendices/0.22.0-migration-guide.md
+++ b/docs/appendices/0.22.0-migration-guide.md
@@ -1,0 +1,6 @@
+# 0.22.0 Migration Guide
+
+## Changes
+
+- Underscores are no longer valid characters in app names. Please rename applications before upgrading.
+- Process type names specified in Procfile may no longer use characters not valid in DNS records.

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -19,6 +19,7 @@ Docker releases updates periodically to their engine. We recommend reading their
 
 Before upgrading, check the migration guides to get comfortable with new features and prepare your deployment to be upgraded.
 
+- [Upgrading to 0.22](/docs/appendices/0.22.0-migration-guide.md)
 - [Upgrading to 0.21](/docs/appendices/0.21.0-migration-guide.md)
 - [Upgrading to 0.20](/docs/appendices/0.20.0-migration-guide.md)
 - [Upgrading to 0.10](/docs/appendices/0.10.0-migration-guide.md)

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -739,7 +739,7 @@ func IsValidAppName(appName string) error {
 		return fmt.Errorf("APP must not be null")
 	}
 
-	r, _ := regexp.Compile("^[a-z0-9][^/:A-Z]*$")
+	r, _ := regexp.Compile("^[a-z0-9][^/:_A-Z]*$")
 	if r.MatchString(appName) {
 		return nil
 	}
@@ -749,7 +749,7 @@ func IsValidAppName(appName string) error {
 		os.RemoveAll(appRoot)
 	}
 
-	return errors.New("App name must begin with lowercase alphanumeric character, and cannot include uppercase characters or colons")
+	return errors.New("App name must begin with lowercase alphanumeric character, and cannot include uppercase characters, colons, or underscores")
 }
 
 // VerifyAppName verifies app name format and app existence"

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -185,13 +185,13 @@ is_valid_app_name() {
   local APP="$1"
   [[ -z "$APP" ]] && dokku_log_fail "APP must not be null"
   if [[ "$APP" =~ ^[a-z].* ]] || [[ "$APP" =~ ^[0-9].* ]]; then
-    if [[ ! $APP =~ [A-Z] ]] && [[ ! $APP =~ [:] ]]; then
+    if [[ ! $APP =~ [A-Z] ]] && [[ ! $APP =~ [:] ]] && [[ ! $APP =~ [_] ]]; then
       return 0
     fi
   fi
 
   [[ -d "$DOKKU_ROOT/$APP" ]] && rm -rf "${DOKKU_ROOT:?}/$APP"
-  dokku_log_fail "App name must begin with lowercase alphanumeric character"
+  dokku_log_fail "App name must begin with lowercase alphanumeric character, and cannot include uppercase characters, colons, or underscores"
 }
 
 verify_app_name() {

--- a/plugins/ps/post-extract
+++ b/plugins/ps/post-extract
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+
+trigger-ps-post-extract() {
+  declare desc="ps post-extract plugin trigger"
+  declare trigger="post-extract"
+  declare APP="$1" TMP_WORK_DIR="$2" REV="$3"
+
+  if [[ ! -f "$TMP_WORK_DIR/Procfile" ]]; then
+    return
+  fi
+
+  pushd "$TMP_WORK_DIR" >/dev/null
+  for process_type in $(procfile-util list); do
+    if echo "$process_type" | grep -vqE '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'; then
+      dokku_log_fail "Invalid process type name ($process_type)"
+    fi
+  done
+  popd >/dev/null
+}
+
+trigger-ps-post-extract "$@"

--- a/tests/unit/apps_1.bats
+++ b/tests/unit/apps_1.bats
@@ -86,6 +86,11 @@ teardown() {
   echo "status: $status"
   assert_failure
 
+  run /bin/bash -c "dokku apps:create test_app"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+
   run /bin/bash -c "dokku --app $TEST_APP apps:create"
   echo "output: $output"
   echo "status: $status"


### PR DESCRIPTION
This is necessary for ensuring ssl certificates can be auto-retrieved for apps, and also easing integration into schedulers that use names and process types as part of DNS records.

As well, this fixes an issue where we may potentially have invalid DNS entries when adding apps to custom networks.

Closes #4102
Closes #4114

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
