### PR TITLE
Clear proxy configs on boot

### DIFF
--- a/plugins/nginx-vhosts/internal-functions
+++ b/plugins/nginx-vhosts/internal-functions
@@ -162,4 +162,5 @@ nginx_clear_config() {
   declare desc="Remove the nginx conf file"
   declare APP="$1"
   rm -f "$DOKKU_ROOT/$APP/nginx.conf"
+  fn-nginx-vhosts-nginx-init-cmd "reload"
 }

--- a/plugins/ps/subcommands/restore
+++ b/plugins/ps/subcommands/restore
@@ -17,6 +17,8 @@ cmd-ps-restore() {
   plugn trigger pre-restore "$DOKKU_SCHEDULER" "$APP"
 
   if [[ -n "$APP" ]]; then
+    plugn trigger proxy-clear-config "$APP"
+
     if ! (is_deployed "$APP"); then
       dokku_log_warn "App $APP has not been deployed"
       return
@@ -27,6 +29,10 @@ cmd-ps-restore() {
       ps_restore "$APP" || dokku_log_warn "dokku ps:restore ${APP} failed"
     fi
   else
+    for APP in $(dokku_apps); do
+      plugn trigger proxy-clear-config "$APP"
+    done
+
     fn-ps-parallel-cmd "restore"
   fi
 }


### PR DESCRIPTION
Unfortunately, Docker does not persist container IPs on boot, so containers may come up with the wrong IP, resulting in proxying to the incorrect app after a server restart. Instead, we should delete the configs and let ps:restore rebuild the proxy config correctly.

Closes #3932

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
