### PR TITLE
Bump minimum docker version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.21.4
 Section: web
 Priority: optional
 Architecture: amd64
-Depends: locales, git, cpio, curl, man-db, netcat, sshcommand (>= 0.10.0), docker-engine-cs (>= 1.13.0) | docker-engine (>= 1.13.0) | docker-io (>= 1.13.0) | docker.io (>= 1.13.0) | docker-ce (>= 1.13.0) | docker-ee (>= 1.13.0) | moby-engine, net-tools, software-properties-common, procfile-util, python-software-properties | python3-software-properties, rsyslog, dos2unix, jq
+Depends: locales, git, cpio, curl, man-db, netcat, sshcommand (>= 0.10.0), docker-engine-cs (>= 17.05.0) | docker-engine (>= 17.05.0) | docker-io (>= 17.05.0) | docker.io (>= 17.05.0) | docker-ce (>= 17.05.0) | docker-ee (>= 17.05.0) | moby-engine, net-tools, software-properties-common, procfile-util, python-software-properties | python3-software-properties, rsyslog, dos2unix, jq
 Recommends: herokuish (>= 0.3.4), parallel, dokku-update, dokku-event-listener
 Pre-Depends: gliderlabs-sigil, nginx (>= 1.8.0) | openresty, dnsutils, cgroupfs-mount | cgroup-lite, plugn (>= 0.3.0), sudo, python3, debconf
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>

--- a/docs/appendices/0.22.0-migration-guide.md
+++ b/docs/appendices/0.22.0-migration-guide.md
@@ -4,3 +4,4 @@
 
 - Underscores are no longer valid characters in app names. Please rename applications before upgrading.
 - Process type names specified in Procfile may no longer use characters not valid in DNS records.
+- The minimum Docker version is now 17.05.0.


### PR DESCRIPTION
This is necessary in order to properly support image filtering during 'dokku cleanup' calls.

Closes #4088
