### PR TITLE
Allow controlling Nginx proxy-buffer-size, proxy-buffering, proxy-buffers, proxy-busy-buffers-size

### DIFF
--- a/plugins/nginx-vhosts/.gitignore
+++ b/plugins/nginx-vhosts/.gitignore
@@ -1,0 +1,1 @@
+/pagesize

--- a/plugins/nginx-vhosts/Makefile
+++ b/plugins/nginx-vhosts/Makefile
@@ -1,0 +1,10 @@
+BUILD = pagesize
+PLUGIN_NAME = nginx-vhosts
+
+clean-pagesize:
+	rm -rf pagesize
+
+pagesize: clean-pagesize **/**/pagesize.go
+	go build -ldflags="-s -w" $(GO_ARGS) -o pagesize src/pagesize/pagesize.go
+
+include ../../common.mk

--- a/plugins/nginx-vhosts/command-functions
+++ b/plugins/nginx-vhosts/command-functions
@@ -47,6 +47,10 @@ cmd-nginx-report-single() {
     "--nginx-hsts-include-subdomains: $(fn-plugin-property-get-default "nginx" "$APP" "hsts-include-subdomains" "true")"
     "--nginx-hsts-max-age: $(fn-plugin-property-get-default "nginx" "$APP" "hsts-max-age" "15724800")"
     "--nginx-hsts-preload: $(fn-plugin-property-get-default "nginx" "$APP" "hsts-preload" "false")"
+    "--nginx-proxy-buffer-size: $(fn-nginx-proxy-buffer-size "$APP")"
+    "--nginx-proxy-buffering: $(fn-nginx-proxy-buffering "$APP")"
+    "--nginx-proxy-buffers: $(fn-nginx-proxy-buffers "$APP")"
+    "--nginx-proxy-busy-buffers-size: $(fn-nginx-proxy-busy-buffers-size "$APP")"
     "--nginx-proxy-read-timeout: $(fn-nginx-proxy-read-timeout "$APP")"
     "--nginx-last-visited-at: $(fn-nginx-vhosts-last-visited-at "$APP")"
   )

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -22,6 +22,34 @@ fn-nginx-access-log-path() {
   fn-plugin-property-get-default "nginx" "$APP" "access-log-path" "${NGINX_LOG_ROOT}/${APP}-access.log"
 }
 
+fn-nginx-proxy-buffer-size() {
+  declare desc="get the configured proxy buffer size"
+  declare APP="$1"
+
+  fn-plugin-property-get-default "nginx" "$APP" "proxy-buffer-size" "$(fn-get-pagesize)"
+}
+
+fn-nginx-proxy-buffering() {
+  declare desc="get the configured proxy buffering"
+  declare APP="$1"
+
+  fn-plugin-property-get-default "nginx" "$APP" "proxy-buffering" "on"
+}
+
+fn-nginx-proxy-buffers() {
+  declare desc="get the configured proxy buffers"
+  declare APP="$1"
+
+  fn-plugin-property-get-default "nginx" "$APP" "proxy-buffers" "8 $(fn-get-pagesize)"
+}
+
+fn-nginx-proxy-busy-buffers-size() {
+  declare desc="get the configured proxy busy buffers size"
+  declare APP="$1"
+
+  fn-plugin-property-get-default "nginx" "$APP" "proxy-busy-buffers-size" "$(($(fn-get-pagesize) * 2))"
+}
+
 fn-nginx-proxy-read-timeout() {
   declare desc="get the configured proxy read timeout"
   declare APP="$1"
@@ -400,6 +428,10 @@ nginx_build_config() {
     local NGINX_ACCESS_LOG_PATH="$(fn-nginx-access-log-path "$APP")"
     local NGINX_ERROR_LOG_PATH="$(fn-nginx-error-log-path "$APP")"
     local PROXY_READ_TIMEOUT="$(fn-nginx-proxy-read-timeout "$APP")"
+    local PROXY_BUFFER_SIZE="$(fn-nginx-proxy-buffer-size "$APP")"
+    local PROXY_BUFFERING="$(fn-nginx-proxy-buffering "$APP")"
+    local PROXY_BUFFERS="$(fn-nginx-proxy-buffers "$APP")"
+    local PROXY_BUSY_BUFFERS_SIZE="$(fn-nginx-proxy-busy-buffers-size "$APP")"
 
     if [[ -z "$DOKKU_APP_LISTENERS" ]]; then
       dokku_log_warn_quiet "No web listeners specified for $APP"
@@ -447,6 +479,10 @@ nginx_build_config() {
         DOKKU_APP_LISTEN_PORT="$DOKKU_APP_LISTEN_PORT" DOKKU_APP_LISTEN_IP="$DOKKU_APP_LISTEN_IP"
         APP_SSL_PATH="$APP_SSL_PATH" SSL_INUSE="$SSL_INUSE" SSL_SERVER_NAME="$SSL_SERVER_NAME"
         PROXY_READ_TIMEOUT="$PROXY_READ_TIMEOUT"
+        PROXY_BUFFER_SIZE="$PROXY_BUFFER_SIZE"
+        PROXY_BUFFERING="$PROXY_BUFFERING"
+        PROXY_BUFFERS="$PROXY_BUFFERS"
+        PROXY_BUSY_BUFFERS_SIZE="$PROXY_BUSY_BUFFERS_SIZE"
         # Deprecated: Remove this after a few versions
         NGINX_PORT="$PROXY_PORT" NGINX_SSL_PORT="$PROXY_SSL_PORT"
         PROXY_PORT="$PROXY_PORT" PROXY_SSL_PORT="$PROXY_SSL_PORT" RAW_TCP_PORTS="$RAW_TCP_PORTS"

--- a/plugins/nginx-vhosts/go.mod
+++ b/plugins/nginx-vhosts/go.mod
@@ -1,0 +1,3 @@
+module github.com/dokku/dokku/plugins/nginx-vhosts
+
+go 1.14

--- a/plugins/nginx-vhosts/internal-functions
+++ b/plugins/nginx-vhosts/internal-functions
@@ -114,6 +114,12 @@ fn-nginx-vhosts-nginx-init-cmd() {
   esac
 }
 
+fn-get-pagesize() {
+  declare desc="return the underlying system's memory page size"
+
+  "$PLUGIN_CORE_AVAILABLE_PATH/nginx-vhosts/pagesize"
+}
+
 nginx_vhosts_validate_single_func() {
   declare APP="$1" FLAG="$2"
   local NGINX_CONF="$DOKKU_ROOT/$APP/nginx.conf"

--- a/plugins/nginx-vhosts/src/pagesize/pagesize.go
+++ b/plugins/nginx-vhosts/src/pagesize/pagesize.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println(os.Getpagesize())
+}

--- a/plugins/nginx-vhosts/subcommands/set
+++ b/plugins/nginx-vhosts/subcommands/set
@@ -9,13 +9,13 @@ cmd-nginx-set() {
   declare cmd="nginx:set"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("access-log-path" "bind-address-ipv4" "bind-address-ipv6" "disable-custom-config" "error-log-path" "hsts" "hsts-include-subdomains" "hsts-preload" "hsts-max-age" "proxy-read-timeout")
+  local VALID_KEYS=("access-log-path" "bind-address-ipv4" "bind-address-ipv6" "disable-custom-config" "error-log-path" "hsts" "hsts-include-subdomains" "hsts-preload" "hsts-max-age" "proxy-read-timeout" "proxy-buffer-size" "proxy-buffering" "proxy-buffers" "proxy-busy-buffers-size")
 
   [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then
-    dokku_log_fail "Invalid key specified, valid keys include: access-log-path, bind-address-ipv4, bind-address-ipv6, disable-custom-config, error-log-path, hsts, hsts-include-subdomains, hsts-preload, hsts-max-age, proxy-read-timeout"
+    dokku_log_fail "Invalid key specified, valid keys include: access-log-path, bind-address-ipv4, bind-address-ipv6, disable-custom-config, error-log-path, hsts, hsts-include-subdomains, hsts-preload, hsts-max-age, proxy-read-timeout, proxy-buffer-size, proxy-buffering, proxy-buffers, proxy-busy-buffers-size"
   fi
 
   if [[ -n "$VALUE" ]]; then

--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -26,6 +26,10 @@ server {
     proxy_pass  http://{{ $.APP }}-{{ $upstream_port }};
     proxy_http_version 1.1;
     proxy_read_timeout {{ $.PROXY_READ_TIMEOUT }};
+    proxy_buffer_size {{ $.PROXY_BUFFER_SIZE }};
+    proxy_buffering {{ $.PROXY_BUFFERING }};
+    proxy_buffers {{ $.PROXY_BUFFERS }};
+    proxy_busy_buffers_size {{ $.PROXY_BUSY_BUFFERS_SIZE }};
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
     proxy_set_header Host $http_host;
@@ -85,6 +89,10 @@ server {
     {{ if eq $.HTTP2_PUSH_SUPPORTED "true" }}http2_push_preload on; {{ end }}
     proxy_http_version 1.1;
     proxy_read_timeout {{ $.PROXY_READ_TIMEOUT }};
+    proxy_buffer_size {{ $.PROXY_BUFFER_SIZE }};
+    proxy_buffering {{ $.PROXY_BUFFERING }};
+    proxy_buffers {{ $.PROXY_BUFFERS }};
+    proxy_busy_buffers_size {{ $.PROXY_BUSY_BUFFERS_SIZE }};
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
     proxy_set_header Host $http_host;

--- a/tests/unit/nginx-vhosts_8.bats
+++ b/tests/unit/nginx-vhosts_8.bats
@@ -173,6 +173,142 @@ teardown() {
   assert_output_contains "45s;" 0
 }
 
+@test "(nginx-vhosts) nginx:set proxy-buffer-size" {
+  deploy_app
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffer-size 2k"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "proxy_buffer_size 2k;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffer-size"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "proxy_buffer_size 2k;" 0
+}
+
+@test "(nginx-vhosts) nginx:set proxy-buffering" {
+  deploy_app
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffering off"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "proxy_buffering off;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffering"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "proxy_buffering off;" 0
+}
+
+@test "(nginx-vhosts) nginx:set proxy-buffers" {
+  deploy_app
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffers \"64 4k\""
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "proxy_buffers 64 4k;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffers"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "proxy_buffers 64 4k;" 0
+}
+
+@test "(nginx-vhosts) nginx:set proxy-busy-buffers-size" {
+  deploy_app
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-busy-buffers-size 10k"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "proxy_busy_buffers_size 10k;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-busy-buffers-size"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "proxy_busy_buffers_size 10k;" 0
+}
+
 @test "(nginx-vhosts) nginx:build-config (with SSL and unrelated domain)" {
   setup_test_tls
   add_domain "node-js-app.dokku.me"


### PR DESCRIPTION
# Purpose
This PR enables user to set [`proxy_buffer_size`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size), [`proxy_buffering`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering), [`proxy_buffers`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) and [`proxy_busy_buffers_size`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_busy_buffers_size) Nginx properties through `dokku nginx:set`.

# Background
A redone of #4138.

The approach is back to the first commit in that PR, which didn't hide these property values if they are not set. `PAGESIZE` value is from Golang's [`os.Getpagesize()`](https://golang.org/pkg/os/#Getpagesize) so no extra dependencies introduced and guarantee to get an integer.

# Motivation
From https://github.com/dokku/dokku/pull/4138#issuecomment-694302239:
> My use case was because one of my apps sometimes sends a huge header, and Nginx cannot handle it, responding with `502` with the error of `upstream sent too big header while reading response header from upstream`. 
>
> A [solution](https://stackoverflow.com/a/27551259/9578295) is to increase the Nginx buffer size like so:
> ```
> proxy_buffer_size 128k;
> proxy_buffers 4 256k;
> proxy_busy_buffers_size 256k;
> ```
> Or, disable proxy buffering by:
> ```
> proxy_buffering off;
> ```
> 
> Although we can supply a custom Nginx template to overcome this, I thought it would be better if Dokku provides such options so that users can directly manipulate these values without playing around the templates.