### PR TITLE
feat: always initialize git repository

### DIFF
--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -172,9 +172,14 @@ git_build() {
     local REF="$REV"
   else
     DOKKU_DEPLOY_BRANCH="$(fn-git-deploy-branch "$APP")"
-    REF=$(<"$DOKKU_ROOT/$APP/refs/heads/$DOKKU_DEPLOY_BRANCH")
+    if [[ -f "$DOKKU_ROOT/$APP/refs/heads/$DOKKU_DEPLOY_BRANCH" ]]; then
+      REF=$(<"$DOKKU_ROOT/$APP/refs/heads/$DOKKU_DEPLOY_BRANCH")
+    fi
   fi
 
+  if [[ -z "$REF" ]]; then
+    return
+  fi
   # shellcheck disable=SC2086
   git_build_app_repo $APP $REF
 }

--- a/plugins/git/post-create
+++ b/plugins/git/post-create
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/git/functions"
+
+trigger-git-post-create() {
+  declare desc="initializes an app with the correct git repository structure"
+  declare trigger="post-create"
+  declare APP="$1"
+
+  fn-git-create-hook "$APP"
+}
+
+trigger-git-post-create "$@"

--- a/tests/unit/git_2.bats
+++ b/tests/unit/git_2.bats
@@ -52,7 +52,7 @@ teardown() {
   run /bin/bash -c "test -d $DOKKU_ROOT/$TEST_APP/refs"
   echo "output: $output"
   echo "status: $status"
-  assert_failure
+  assert_success
 
   run /bin/bash -c "dokku git:initialize $TEST_APP"
   echo "output: $output"
@@ -69,7 +69,7 @@ teardown() {
   run /bin/bash -c "test -d $DOKKU_ROOT/$TEST_APP/refs"
   echo "output: $output"
   echo "status: $status"
-  assert_failure
+  assert_success
 
   deploy_app
 


### PR DESCRIPTION
This fixes issues where alternative tools that don't trigger the init via sshcommand - such as git-http-backend - are not able to setup applications correctly.

Note that those apps could always manually trigger git:initialize if desired, but if the app already exists, then this should already _just work_ without that extra initialization.
