### PR TITLE
When `cert:add` remove previous cert before copying the new cert 

### DIFF
--- a/plugins/certs/subcommands/add
+++ b/plugins/certs/subcommands/add
@@ -71,6 +71,7 @@ cmd-certs-set() {
   fi
 
   mkdir -p "$APP_SSL_PATH"
+  rm -f "$APP_SSL_PATH/server.crt" "$APP_SSL_PATH/server.key"
   cp "$CRT_FILE" "$APP_SSL_PATH/server.crt"
   cp "$KEY_FILE" "$APP_SSL_PATH/server.key"
   chmod 750 "$APP_SSL_PATH"


### PR DESCRIPTION
When the certificate of an app is a symlink (to the global cert) rather than a copy of it, using `cert:add` would currently overwrite the global certificate.
This PR makes sure that `dokku cert:add` first removes the app cert (and thus the symlink) before copying over the new certificate.

See also:
 * [josegonzalez/dokku-global-cert#3](https://github.com/josegonzalez/dokku-global-cert/issues/3) (issue)
 * [josegonzalez/dokku-global-cert#4](https://github.com/josegonzalez/dokku-global-cert/pull/4) (pr)
