### PR TITLE
The default branch for ruby-getting-started is 'main', not 'master

### DIFF
--- a/docs/deployment/application-deployment.md
+++ b/docs/deployment/application-deployment.md
@@ -9,7 +9,7 @@ Once you have configured Dokku with at least one user, you can deploy applicatio
 ```shell
 # from your local machine
 # SSH access to github must be enabled on this host
-git clone https://github.com/heroku/ruby-getting-started
+git clone https://github.com/heroku/ruby-getting-started --branch master
 ```
 
 ### Create the app


### PR DESCRIPTION
- Ensure the user is using the master branch to match later instructions to do a git push master.

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.

[ci skip]