### PR TITLE
Revert "The default branch for ruby-getting-started is 'main', not 'master"

### DIFF
--- a/docs/deployment/application-deployment.md
+++ b/docs/deployment/application-deployment.md
@@ -9,7 +9,7 @@ Once you have configured Dokku with at least one user, you can deploy applicatio
 ```shell
 # from your local machine
 # SSH access to github must be enabled on this host
-git clone https://github.com/heroku/ruby-getting-started --branch master
+git clone https://github.com/heroku/ruby-getting-started
 ```
 
 ### Create the app


### PR DESCRIPTION
Reverts dokku/dokku#4167