### PR TITLE
Add build-essential to Vagrant provision

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant::configure("2") do |config|
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
 
-    vm.vm.provision :shell, :inline => "export DEBIAN_FRONTEND=noninteractive && apt-get update >/dev/null && apt-get -qq -y install git >/dev/null && cd /root/dokku && #{make_cmd}"
+    vm.vm.provision :shell, :inline => "export DEBIAN_FRONTEND=noninteractive && apt-get update >/dev/null && apt-get -qq -y install git build-essential >/dev/null && cd /root/dokku && #{make_cmd}"
     vm.vm.provision :shell, :inline => "cd /root/dokku && make dokku-installer"
     vm.vm.provision :shell do |s|
       s.inline = <<-EOT


### PR DESCRIPTION
When I follow the documentation for [Vagrant installation](http://dokku.viewdocs.io/dokku/getting-started/install/vagrant/), after running `vagrant up` during the provision step I get the error: 
```
dokku: Running provisioner: shell...
dokku: Running: inline script
dokku: /tmp/vagrant-shell: line 1: make: command not found
```

If I install `build-essential` package on the target VM, everything works flawlessly. 

I found an existing issue with a detailed report https://github.com/dokku/dokku/issues/4166 and this PR aims to fix it. 