### PR TITLE
Correctly doc apps:report output

### DIFF
--- a/docs/appendices/0.20.0-migration-guide.md
+++ b/docs/appendices/0.20.0-migration-guide.md
@@ -54,6 +54,10 @@ Dokku will no longer distribute packages for Debian versions that are not `stabl
 
 The `--git-sha` flag was moved from the `apps:report` command to the `git:report` command.
 
+## App report output
+
+When an app is not deployed, the `apps:report` command no longer shows the message `not deployed`. Please use the `--deployed` flag on `ps:report` instead to see if the app has been deployed.
+
 ## Changes
 
 ### App report flags

--- a/docs/deployment/application-management.md
+++ b/docs/deployment/application-management.md
@@ -244,13 +244,15 @@ dokku apps:report
 ```
 
 ```
-=====> node-js-app
+=====> node-js-app app information
        App dir:             /home/dokku/node-js-app
        App deploy source:   git
        App locked:          false
-=====> python-sample
-not deployed
-=====> ruby-sample
+=====> python-sample app information
+       App dir:             /home/dokku/python-sample
+       App deploy source:
+       App locked:          false
+=====> ruby-sample app information
        App dir:             /home/dokku/ruby-sample
        App deploy source:   git
        App locked:          false
@@ -263,7 +265,7 @@ dokku apps:report node-js-app
 ```
 
 ```
-=====> node-js-app
+=====> node-js-app app information
        App dir:             /home/dokku/node-js-app
        App deploy source:   git
        App locked:          false

--- a/docs/deployment/process-management.md
+++ b/docs/deployment/process-management.md
@@ -238,3 +238,60 @@ dokku ps:set node-js-app restart-policy on-failure:20
 ```
 
 Restart policies have no bearing on server reboot, and Dokku will always attempt to restart your apps at that point unless they were manually stopped.
+
+
+### Displaying reports for an app
+
+> New as of 0.12.0
+
+You can get a report about the deployed apps using the `ps:report` command:
+
+```shell
+dokku ps:report
+```
+
+```
+=====> node-js-app ps information
+       Deployed:                      false
+       Processes:                     0
+       Ps can scale:                  true
+       Ps restart policy:             on-failure:10
+       Restore:                       true
+       Running:                       false
+=====> python-sample ps information
+       Deployed:                      false
+       Processes:                     0
+       Ps can scale:                  true
+       Ps restart policy:             on-failure:10
+       Restore:                       true
+       Running:                       false
+=====> ruby-sample ps information
+       Deployed:                      false
+       Processes:                     0
+       Ps can scale:                  true
+       Ps restart policy:             on-failure:10
+       Restore:                       true
+       Running:                       false
+```
+
+You can run the command for a specific app also.
+
+```shell
+dokku ps:report node-js-app
+```
+
+```
+=====> node-js-app ps information
+       Deployed:                      false
+       Processes:                     0
+       Ps can scale:                  true
+       Ps restart policy:             on-failure:10
+       Restore:                       true
+       Running:                       false
+```
+
+You can pass flags which will output only the value of the specific information you want. For example:
+
+```shell
+dokku ps:report node-js-app --deployed
+```


### PR DESCRIPTION
The `not deployed` message was removed in 0.20.0, and that state can be queried via `ps:report` now.

Closes #4134
