### PR TITLE
Retire intermediate containers after use

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1909,6 +1909,26 @@ DOKKU_SCHEDULER="$1"; APP="$2"; CONTAINER_ID="$3";
 # TODO
 ```
 
+### `scheduler-register-retired`
+
+> Warning: The scheduler plugin trigger apis are under development and may change
+> between minor releases until the 1.0 release.
+
+- Description: Allows scheduling retiring a local container
+- Invoked by: `internally`
+- Arguments: `$APP $CONTAINER_ID`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+APP="$1";
+CONTAINER_ID="$2";
+
+# TODO
+```
+
 ### `scheduler-retire`
 
 > Warning: The scheduler plugin trigger apis are under development and may change

--- a/plugins/app-json/appjson.go
+++ b/plugins/app-json/appjson.go
@@ -270,7 +270,8 @@ func executeScript(appName string, imageTag string, phase string) error {
 	if !containerCommitCmd.Execute() {
 		common.LogFail(fmt.Sprintf("Commiting of '%s' to image failed: %s", phase, command))
 	}
-	return nil
+
+	return common.PlugnTrigger("scheduler-register-retired", []string{appName, containerID}...)
 }
 
 func getEntrypointFromImage(image string) (string, error) {

--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -35,6 +35,8 @@ trigger-builder-herokuish-builder-build() {
   fi
 
   "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
+  plugn trigger scheduler-register-retired "$APP" "$CID"
+
   [[ -d $DOKKU_APP_CACHE_DIR ]] || mkdir -p "$DOKKU_APP_CACHE_DIR"
   plugn trigger pre-build-buildpack "$APP" "$SOURCECODE_WORK_DIR"
 
@@ -58,6 +60,7 @@ trigger-builder-herokuish-builder-build() {
   fi
 
   "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
+  plugn trigger scheduler-register-retired "$APP" "$CID"
 
   plugn trigger post-build-buildpack "$APP" "$SOURCECODE_WORK_DIR"
 }

--- a/plugins/builder-herokuish/builder-release
+++ b/plugins/builder-herokuish/builder-release
@@ -27,6 +27,7 @@ trigger-builder-herokuish-builder-release() {
     fi
 
     "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
+    plugn trigger scheduler-register-retired "$APP" "$CID"
   fi
   if [[ -n $(config_export app "$APP") ]]; then
     CID=$(config_export app "$APP" | "$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh")
@@ -36,6 +37,7 @@ trigger-builder-herokuish-builder-release() {
     fi
 
     "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
+    plugn trigger scheduler-register-retired "$APP" "$CID"
   fi
 
   echo "FROM $IMAGE" | suppress_output "$DOCKER_BIN" image build --label=com.dokku.image-stage=release --label=com.dokku.app-name=$APP --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=dokku -t "$IMAGE" -

--- a/plugins/builder-herokuish/pre-build-buildpack
+++ b/plugins/builder-herokuish/pre-build-buildpack
@@ -29,6 +29,7 @@ trigger-builder-herokuish-pre-build-buildpack() {
   fi
 
   "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
+  plugn trigger scheduler-register-retired "$APP" "$CID"
 
   # create build env for 'old style' buildpacks and dokku plugins
   CID=$(config_export app "$APP" --format envfile --merged | "$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "cat >> /app/.env")
@@ -38,6 +39,7 @@ trigger-builder-herokuish-pre-build-buildpack() {
   fi
 
   "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
+  plugn trigger scheduler-register-retired "$APP" "$CID"
 }
 
 trigger-builder-herokuish-pre-build-buildpack "$@"

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -420,6 +420,7 @@ copy_from_image() {
     local CID=$("$DOCKER_BIN" container create "${DOCKER_CREATE_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS "$IMAGE")
     "$DOCKER_BIN" container cp "$CID:$SRC_FILE" "$TMP_FILE_COMMAND_OUTPUT" 2>/dev/null || true
     "$DOCKER_BIN" container rm --force "$CID" &>/dev/null
+    plugn trigger scheduler-register-retired "$APP" "$CID"
 
     # docker cp exits with status 1 when run as non-root user when it tries to chown the file
     # after successfully copying the file. Thus, we suppress stderr.

--- a/plugins/scheduler-docker-local/pre-deploy
+++ b/plugins/scheduler-docker-local/pre-deploy
@@ -51,7 +51,7 @@ scheduler-docker-local-pre-deploy-chown-app() {
   fi
 
   # shellcheck disable=SC2086
-  "$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS "${ARG_ARRAY[@]}" $IMAGE /bin/bash -c "find $CONTAINER_PATHS -not -user $DOKKU_APP_USER -print0 | xargs -0 -r chown -R $DOKKU_APP_USER" || true
+  "$DOCKER_BIN" container run --rm "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS "${ARG_ARRAY[@]}" $IMAGE /bin/bash -c "find $CONTAINER_PATHS -not -user $DOKKU_APP_USER -print0 | xargs -0 -r chown -R $DOKKU_APP_USER" || true
 }
 
 scheduler-docker-local-pre-deploy-precheck() {

--- a/plugins/scheduler-docker-local/scheduler-register-retired
+++ b/plugins/scheduler-docker-local/scheduler-register-retired
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/scheduler-docker-local/internal-functions"
+
+trigger-scheduler-docker-local-scheduler-register-retired() {
+  declare desc="register a container for retiring"
+  declare trigger="scheduler-register-retired"
+  declare APP="$1" CONTAINER_ID="$2" WAIT="${3:-60}"
+
+  fn-scheduler-docker-local-register-retired-container "$APP" "$CONTAINER_ID" "$WAIT"
+}
+
+trigger-scheduler-docker-local-scheduler-register-retired "$@"


### PR DESCRIPTION
Rather than waiting for the next deploy, take advantage of the retire system to retire these containers immediately.

Note that since the retire process happens out of band, the containers may stick around for up to 5 minutes, after which point they will be removed.

Customization of the wait time to retire - currently 60 seconds - is up for future debate. The containers ultimately haven't been useful for debugging, so keeping them around for longer won't help in most cases, and folks can disable the dokku-retire service (or cron) if that is desired.
