### PR TITLE
Cleanup log output for failure case

### DIFF
--- a/docs/appendices/0.22.0-migration-guide.md
+++ b/docs/appendices/0.22.0-migration-guide.md
@@ -10,6 +10,7 @@
 - Process type names specified in Procfile may no longer use characters not valid in DNS Label Names ([RFC 1123](https://tools.ietf.org/html/rfc1123)).
 - The minimum Docker version is now 17.05.0.
 - The `common.GetDeployingAppImageName()` function now returns an `error` as the second return argument instead of calling `common.LogFail()` internally.
+- Setting `DOKKU_DISABLE_ANSI_PREFIX_REMOVAL` is deprecated; Dokku 0.23.0 will avoid removing the `remote:` ansi prefix entirely. No warning will be added in this release.
 
 ## Removals
 

--- a/plugins/app-json/appjson.go
+++ b/plugins/app-json/appjson.go
@@ -138,6 +138,7 @@ func getDokkuAppShell(appName string) string {
 }
 
 func executeScript(appName string, imageTag string, phase string) error {
+	common.LogInfo1(fmt.Sprintf("Checking for %s task", phase))
 	image, err := common.GetDeployingAppImageName(appName, imageTag, "")
 	if err != nil {
 		common.LogFail(err.Error())
@@ -156,6 +157,7 @@ func executeScript(appName string, imageTag string, phase string) error {
 	}
 
 	if command == "" {
+		common.LogVerbose(fmt.Sprintf("No %s task found, skipping", phase))
 		return nil
 	}
 

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -137,14 +137,14 @@ dokku_log_exit() {
 dokku_log_fail_quiet() {
   declare desc="log fail formatter"
   if [[ -z "$DOKKU_QUIET_OUTPUT" ]]; then
-    echo "$@" 1>&2
+    echo " !     $@" 1>&2
   fi
   exit 1
 }
 
 dokku_log_fail() {
   declare desc="log fail formatter"
-  echo "$@" 1>&2
+  echo " !     $@" 1>&2
   exit 1
 }
 

--- a/plugins/common/log.go
+++ b/plugins/common/log.go
@@ -9,7 +9,7 @@ import (
 // LogFail is the failure log formatter
 // prints text to stderr and exits with status 1
 func LogFail(text string) {
-	fmt.Fprintln(os.Stderr, fmt.Sprintf("FAILED: %s", text))
+	fmt.Fprintln(os.Stderr, fmt.Sprintf(" !     %s", text))
 	os.Exit(1)
 }
 
@@ -17,7 +17,7 @@ func LogFail(text string) {
 // prints text to stderr and exits with status 1
 func LogFailQuiet(text string) {
 	if os.Getenv("DOKKU_QUIET_OUTPUT") == "" {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("FAILED: %s", text))
+		fmt.Fprintln(os.Stderr, fmt.Sprintf(" !     %s", text))
 	}
 	os.Exit(1)
 }

--- a/tests/unit/config.bats
+++ b/tests/unit/config.bats
@@ -79,7 +79,7 @@ teardown() {
   run /bin/bash -c "dokku config:set $TEST_APP"
   echo "output: $output"
   echo "status: $status"
-  assert_output "FAILED: At least one env pair must be given"
+  assert_output " !     At least one env pair must be given"
   assert_failure
 
   run /bin/bash -c "dokku config:get $TEST_APP test_var1 | grep true"
@@ -104,7 +104,7 @@ teardown() {
   run /bin/bash -c "dokku --app $TEST_APP config:set"
   echo "output: $output"
   echo "status: $status"
-  assert_output "FAILED: At least one env pair must be given"
+  assert_output " !     At least one env pair must be given"
   assert_failure
 
   run /bin/bash -c "dokku --app $TEST_APP config:get test_var1 | grep true"
@@ -164,7 +164,7 @@ teardown() {
   run /bin/bash -c "dokku config:unset $TEST_APP"
   echo "output: $output"
   echo "status: $status"
-  assert_output "FAILED: At least one key must be given"
+  assert_output " !     At least one key must be given"
   assert_failure
 }
 

--- a/tests/unit/storage.bats
+++ b/tests/unit/storage.bats
@@ -38,7 +38,7 @@ teardown() {
   run /bin/bash -c "dokku storage:mount $TEST_APP /tmp/mount:/mount"
   echo "output: $output"
   echo "status: $status"
-  assert_output "Mount path already exists."
+  assert_output " !     Mount path already exists."
   assert_failure
   run /bin/bash -c "dokku storage:unmount $TEST_APP /tmp/mount:/mount"
   echo "output: $output"
@@ -51,6 +51,6 @@ teardown() {
   run /bin/bash -c "dokku storage:unmount $TEST_APP /tmp/mount:/mount"
   echo "output: $output"
   echo "status: $status"
-  assert_output "Mount path does not exist."
+  assert_output " !     Mount path does not exist."
   assert_failure
 }


### PR DESCRIPTION
Also mark DOKKU_DISABLE_ANSI_PREFIX_REMOVAL as deprecated (it will be removed in 0.23.0 and no prefixes will be removed at that time).
