### PR TITLE
feat: add ability to change the access log format

### DIFF
--- a/docs/configuration/nginx.md
+++ b/docs/configuration/nginx.md
@@ -114,6 +114,16 @@ dokku nginx:set node-js-app error-log-path
 
 In all cases, the nginx config must be regenerated after setting the above values.
 
+### Changing log format
+
+> New as of 0.21.5
+
+The format of the access log can be changed by calling the `nginx:set` command as follows:
+
+```shell
+dokku nginx:set node-js-app access-log-format custom
+```
+
 ### Specifying a read timeout
 
 > New as of 0.21.0

--- a/plugins/nginx-vhosts/command-functions
+++ b/plugins/nginx-vhosts/command-functions
@@ -38,6 +38,7 @@ cmd-nginx-report-single() {
   fi
   verify_app_name "$APP"
   local flag_map=(
+    "--nginx-access-log-format: $(fn-nginx-access-log-format "$APP")"
     "--nginx-access-log-path: $(fn-nginx-access-log-path "$APP")"
     "--nginx-bind-address-ipv4: $(fn-plugin-property-get-default "nginx" "$APP" "bind-address-ipv4" "")"
     "--nginx-bind-address-ipv6: $(fn-plugin-property-get-default "nginx" "$APP" "bind-address-ipv6" "::")"

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -13,6 +13,13 @@ fn-nginx-log-root() {
   echo "$NGINX_LOG_ROOT"
 }
 
+fn-nginx-access-log-format() {
+  declare desc="get the configured access log format"
+  declare APP="$1"
+
+  fn-plugin-property-get-default "nginx" "$APP" "access-log-format" ""
+}
+
 fn-nginx-access-log-path() {
   declare desc="get the configured access log path"
   declare APP="$1"
@@ -424,6 +431,7 @@ nginx_build_config() {
     PROXY_PORT_MAP=$(echo "$PROXY_PORT_MAP" | xargs) # trailing spaces mess up default template
 
     local NGINX_LOG_ROOT="$(fn-nginx-log-root)"
+    local NGINX_ACCESS_LOG_FORMAT="$(fn-nginx-access-log-format "$APP")"
     local NGINX_ACCESS_LOG_PATH="$(fn-nginx-access-log-path "$APP")"
     local NGINX_ERROR_LOG_PATH="$(fn-nginx-error-log-path "$APP")"
     local PROXY_READ_TIMEOUT="$(fn-nginx-proxy-read-timeout "$APP")"
@@ -469,6 +477,7 @@ nginx_build_config() {
         TLS13_SUPPORTED="$TLS13_SUPPORTED"
         HTTP2_SUPPORTED="$HTTP2_SUPPORTED"
         NGINX_LOG_ROOT="$NGINX_LOG_ROOT"
+        NGINX_ACCESS_LOG_FORMAT="$NGINX_ACCESS_LOG_FORMAT"
         NGINX_ACCESS_LOG_PATH="$NGINX_ACCESS_LOG_PATH"
         NGINX_ERROR_LOG_PATH="$NGINX_ERROR_LOG_PATH"
         NGINX_BIND_ADDRESS_IP4="$NGINX_BIND_ADDRESS_IP4"

--- a/plugins/nginx-vhosts/subcommands/set
+++ b/plugins/nginx-vhosts/subcommands/set
@@ -9,13 +9,13 @@ cmd-nginx-set() {
   declare cmd="nginx:set"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("access-log-path" "bind-address-ipv4" "bind-address-ipv6" "disable-custom-config" "error-log-path" "hsts" "hsts-include-subdomains" "hsts-preload" "hsts-max-age" "proxy-read-timeout" "proxy-buffer-size" "proxy-buffering" "proxy-buffers" "proxy-busy-buffers-size")
+  local VALID_KEYS=("access-log-format" "access-log-path" "bind-address-ipv4" "bind-address-ipv6" "disable-custom-config" "error-log-path" "hsts" "hsts-include-subdomains" "hsts-preload" "hsts-max-age" "proxy-read-timeout" "proxy-buffer-size" "proxy-buffering" "proxy-buffers" "proxy-busy-buffers-size")
 
   [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then
-    dokku_log_fail "Invalid key specified, valid keys include: access-log-path, bind-address-ipv4, bind-address-ipv6, disable-custom-config, error-log-path, hsts, hsts-include-subdomains, hsts-preload, hsts-max-age, proxy-read-timeout, proxy-buffer-size, proxy-buffering, proxy-buffers, proxy-busy-buffers-size"
+    dokku_log_fail "Invalid key specified, valid keys include: access-log-format, access-log-path, bind-address-ipv4, bind-address-ipv6, disable-custom-config, error-log-path, hsts, hsts-include-subdomains, hsts-preload, hsts-max-age, proxy-read-timeout, proxy-buffer-size, proxy-buffering, proxy-buffers, proxy-busy-buffers-size"
   fi
 
   if [[ -n "$VALUE" ]]; then

--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -9,7 +9,7 @@ server {
   listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }};
   listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }};
   {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
-  access_log  {{ $.NGINX_ACCESS_LOG_PATH }};
+  access_log  {{ $.NGINX_ACCESS_LOG_PATH }}{{ if and ($.NGINX_ACCESS_LOG_FORMAT) (ne $.NGINX_ACCESS_LOG_PATH "off") }} {{ $.NGINX_ACCESS_LOG_FORMAT }}{{ end }};
   error_log   {{ $.NGINX_ERROR_LOG_PATH }};
 {{ if (and (eq $listen_port "80") ($.SSL_INUSE)) }}
   return 301 https://$host:{{ $.PROXY_SSL_PORT }}$request_uri;
@@ -65,7 +65,7 @@ server {
   listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ else if eq $.SPDY_SUPPORTED "true" }}spdy{{ end }};
   {{ if $.SSL_SERVER_NAME }}server_name {{ $.SSL_SERVER_NAME }}; {{ end }}
   {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
-  access_log  {{ $.NGINX_ACCESS_LOG_PATH }};
+  access_log  {{ $.NGINX_ACCESS_LOG_PATH }}{{ if and ($.NGINX_ACCESS_LOG_FORMAT) (ne $.NGINX_ACCESS_LOG_PATH "off") }} {{ $.NGINX_ACCESS_LOG_FORMAT }}{{ end }};
   error_log   {{ $.NGINX_ERROR_LOG_PATH }};
 
   ssl_certificate           {{ $.APP_SSL_PATH }}/server.crt;
@@ -133,7 +133,7 @@ server {
   listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} http2;
   listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} http2;
   {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
-  access_log  {{ $.NGINX_ACCESS_LOG_PATH }};
+  access_log  {{ $.NGINX_ACCESS_LOG_PATH }}{{ if and ($.NGINX_ACCESS_LOG_FORMAT) (ne $.NGINX_ACCESS_LOG_PATH "off") }} {{ $.NGINX_ACCESS_LOG_FORMAT }}{{ end }};
   error_log   {{ $.NGINX_ERROR_LOG_PATH }};
   location    / {
     grpc_pass  grpc://{{ $.APP }}-{{ $upstream_port }};
@@ -147,7 +147,7 @@ server {
   listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} ssl http2;
   listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} ssl http2;
   {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
-  access_log  {{ $.NGINX_ACCESS_LOG_PATH }};
+  access_log  {{ $.NGINX_ACCESS_LOG_PATH }}{{ if and ($.NGINX_ACCESS_LOG_FORMAT) (ne $.NGINX_ACCESS_LOG_PATH "off") }} {{ $.NGINX_ACCESS_LOG_FORMAT }}{{ end }};
   error_log   {{ $.NGINX_ERROR_LOG_PATH }};
 
   ssl_certificate           {{ $.APP_SSL_PATH }}/server.crt;

--- a/tests/unit/nginx-vhosts_8.bats
+++ b/tests/unit/nginx-vhosts_8.bats
@@ -104,6 +104,56 @@ teardown() {
   assert_output_contains "off;" 0
 }
 
+@test "(nginx-vhosts) access-log-format" {
+  deploy_app
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP access-log-format combined"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "-access.log combined;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP access-log-path off"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "off;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP access-log-format"
+  run /bin/bash -c "dokku nginx:set $TEST_APP access-log-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "-access.log;"
+}
+
 @test "(nginx-vhosts) nginx:set proxy-read-timeout" {
   deploy_app
 


### PR DESCRIPTION
Hi @josegonzalez, thanks for all the amazing work on Dokku!

This PR adds the ability to set a custom access log format for NGINX, which can be useful for things like [anonymizing IP addresses](https://chriswiegman.com/2019/09/anonymizing-nginx-logs/).

```sh
dokku nginx:set node-js-app access-log-format custom
```

There's not a way to customize the error log format (as far as I know), and it plays nicely with `access-log-path off` :tada: Also, I wasn't sure what the next release would be for the docs.