### PR TITLE
🐛 Make the dokku-update command compatible with Dokku 0.22+

### DIFF
--- a/contrib/dokku-update
+++ b/contrib/dokku-update
@@ -101,7 +101,7 @@ main() {
 
   # rebuild all applications
   dokku-log-info "Rebuilding all applications"
-  dokku ps:rebuildall
+  dokku ps:rebuild --all
 
   dokku-log-info "Waiting for old containers to stop"
   sleep 120


### PR DESCRIPTION
Dokku 0.22 changed the usage of the `ps` command, but the `dokku-update` helper command was not updated to reflect this change.