### PR TITLE
Cleanup docker options during post-delete

### DIFF
--- a/plugins/docker-options/post-delete
+++ b/plugins/docker-options/post-delete
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-docker-options-post-delete() {
+  declare desc="deletes docker options files for an app"
+  declare trigger="post-delete"
+  declare APP="$1"
+
+  rm -f "$(fn-get-phase-file-path "$APP" "build")" "$(fn-get-phase-file-path "$APP" "deploy")" "$(fn-get-phase-file-path "$APP" "run")"
+}
+
+trigger-docker-options-post-delete "$@"


### PR DESCRIPTION
While the directory removal should be enough, we should also force-clean just to be sure.
