### PR TITLE
Ensure all byte output is trimmed of whitespace

### DIFF
--- a/plugins/apps/apps.go
+++ b/plugins/apps/apps.go
@@ -1,6 +1,8 @@
 package apps
 
 import (
+	"strings"
+
 	"github.com/dokku/dokku/plugins/common"
 )
 
@@ -12,7 +14,7 @@ func ReportSingleApp(appName, infoFlag string) error {
 
 	deploySource := ""
 	if b, err := common.PlugnTriggerSetup("deploy-source", []string{appName}...).SetInput("").Output(); err != nil {
-		deploySource = string(b[:])
+		deploySource = strings.TrimSpace(string(b[:]))
 	}
 
 	locked := "false"

--- a/plugins/apps/functions.go
+++ b/plugins/apps/functions.go
@@ -140,7 +140,7 @@ func maybeCreateApp(appName string) error {
 	}
 
 	b, _ := common.PlugnTriggerOutput("config-get-global", []string{"DOKKU_DISABLE_APP_AUTOCREATION"}...)
-	disableAutocreate := string(b[:])
+	disableAutocreate := strings.TrimSpace(string(b[:]))
 	if disableAutocreate == "true" {
 		common.LogWarn("App auto-creation disabled.")
 		return fmt.Errorf("Re-enable app auto-creation or create an app with 'dokku apps:create %s'", appName)

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -69,7 +69,7 @@ func GetAppScheduler(appName string) string {
 	}
 
 	b, _ := PlugnTriggerOutput("config-get", []string{appName, "DOKKU_SCHEDULER"}...)
-	value := string(b[:])
+	value := strings.TrimSpace(string(b[:]))
 	if value != "" {
 		return value
 	}
@@ -80,7 +80,7 @@ func GetAppScheduler(appName string) string {
 // GetGlobalScheduler fetchs the global scheduler
 func GetGlobalScheduler() string {
 	b, _ := PlugnTriggerOutput("config-get-global", []string{"DOKKU_SCHEDULER"}...)
-	value := string(b[:])
+	value := strings.TrimSpace(string(b[:]))
 	if value != "" {
 		return value
 	}
@@ -98,19 +98,19 @@ func GetDeployingAppImageName(appName, imageTag, imageRepo string) (string, erro
 	if err != nil {
 		return "", err
 	}
-	imageRemoteRepository := string(b[:])
+	imageRemoteRepository := strings.TrimSpace(string(b[:]))
 
 	b, err = PlugnTriggerOutput("deployed-app-image-tag", []string{appName}...)
 	if err != nil {
 		return "", err
 	}
-	newImageTag := string(b[:])
+	newImageTag := strings.TrimSpace(string(b[:]))
 
 	b, err = PlugnTriggerOutput("deployed-app-image-repo", []string{appName}...)
 	if err != nil {
 		return "", err
 	}
-	newImageRepo := string(b[:])
+	newImageRepo := strings.TrimSpace(string(b[:]))
 
 	if newImageRepo != "" {
 		imageRepo = newImageRepo

--- a/plugins/common/docker.go
+++ b/plugins/common/docker.go
@@ -137,7 +137,7 @@ func DockerCleanup(appName string, forceCleanup bool) error {
 		skipCleanup := false
 		if appName != "" {
 			b, _ := PlugnTriggerOutput("config-get", []string{appName, "DOKKU_SKIP_CLEANUP"}...)
-			output := string(b[:])
+			output := strings.TrimSpace(string(b[:]))
 			if output == "true" {
 				skipCleanup = true
 			}


### PR DESCRIPTION
This otherwise causes issues when interpreting the output as part of a variable, such as when constructing the deploying app image.

Closes #4229
