### PR TITLE
Allow symbolic links for certificate and key files

### DIFF
--- a/plugins/certs/subcommands/add
+++ b/plugins/certs/subcommands/add
@@ -16,9 +16,9 @@ is_file_import() {
   local KEY_FILE="$2"
 
   if [[ $CRT_FILE ]] && [[ $KEY_FILE ]]; then
-    if [[ ! -f $CRT_FILE ]]; then
+    if [[ ! -r $CRT_FILE ]]; then
       dokku_log_fail "CRT file specified not found, please check file paths"
-    elif [[ ! -f $KEY_FILE ]]; then
+    elif [[ ! -r $KEY_FILE ]]; then
       dokku_log_fail "KEY file specified not found, please check file paths"
     else
       return 0

--- a/tests/unit/certs.bats
+++ b/tests/unit/certs.bats
@@ -69,6 +69,22 @@ teardown() {
   assert_success
 }
 
+@test "(certs) certs:add with symbolic link for certificate" {
+  ln -s $BATS_TMPDIR/tls/server.crt $BATS_TMPDIR/tls/linked_server.crt
+  run /bin/bash -c "dokku certs:add $TEST_APP $BATS_TMPDIR/tls/linked_server.crt $BATS_TMPDIR/tls/server.key"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
+@test "(certs) certs:add with symbolic link for private key" {
+  ln -s $BATS_TMPDIR/tls/server.key $BATS_TMPDIR/tls/linked_server.key
+  run /bin/bash -c "dokku certs:add $TEST_APP $BATS_TMPDIR/tls/server.crt $BATS_TMPDIR/tls/linked_server.key"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
 @test "(certs) certs:remove" {
   run /bin/bash -c "dokku certs:add $TEST_APP < $BATS_TEST_DIRNAME/server_ssl.tar && dokku certs:remove $TEST_APP"
   echo "output: $output"


### PR DESCRIPTION
This corrects an issue where if a symbolic link was given to the
`certs:add` command, an error would be thrown even though the file was
valid.

Issue: #4251
