### PR TITLE
Correct argument handling when setting the `--app` flag

### DIFF
--- a/dokku
+++ b/dokku
@@ -144,12 +144,7 @@ execute_dokku_cmd() {
   if [[ "$(readlink -f "$PLUGIN_ENABLED_PATH/${PLUGIN_NAME%%:*}")" == *core-plugins* ]]; then
     [[ ${argv[0]} == "$PLUGIN_CMD" ]] && shift 1
     if [[ -n $DOKKU_APP_NAME ]]; then
-      if [[ "$PLUGIN_CMD" == config* ]] && [[ ${argv[1]} == "--no-restart" ]]; then
-        shift 1
-        set -- "--no-restart" "$DOKKU_APP_NAME" "$@"
-      else
-        set -- "$DOKKU_APP_NAME" "$@"
-      fi
+      set -- "$DOKKU_APP_NAME" "$@"
     fi
     set -- "$PLUGIN_CMD" "$@"
   fi

--- a/plugins/apps/go.mod
+++ b/plugins/apps/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 // indirect
 	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 )
 
 replace github.com/dokku/dokku/plugins/common => ../common

--- a/plugins/apps/go.sum
+++ b/plugins/apps/go.sum
@@ -4,3 +4,5 @@ github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 h1:HHUr4P/aKh4qu
 github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27/go.mod h1:VQx0hjo2oUeQkQUET7wRwradO6f+fN5jzXgB/zROxxE=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 h1:utdYOikI1XjNtTFGCwSM6OmFJblU4ld4gACoJsbadJg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/plugins/apps/src/subcommands/subcommands.go
+++ b/plugins/apps/src/subcommands/subcommands.go
@@ -65,10 +65,12 @@ func main() {
 		err = apps.CommandRename(oldAppName, newAppName, *skipDeploy)
 	case "report":
 		args := flag.NewFlagSet("apps:report", flag.ExitOnError)
-		args.Parse(os.Args[2:])
-		appName := args.Arg(0)
-		infoFlag := args.Arg(1)
-		err = apps.CommandReport(appName, infoFlag)
+		osArgs, infoFlag, err := common.ParseReportArgs("apps", os.Args[2:])
+		if err == nil {
+			args.Parse(osArgs)
+			appName := args.Arg(0)
+			err = apps.CommandReport(appName, infoFlag)
+		}
 	case "unlock":
 		args := flag.NewFlagSet("apps:unlock", flag.ExitOnError)
 		args.Parse(os.Args[2:])

--- a/plugins/apps/src/subcommands/subcommands.go
+++ b/plugins/apps/src/subcommands/subcommands.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/dokku/dokku/plugins/apps"
 	"github.com/dokku/dokku/plugins/common"
+
+	flag "github.com/spf13/pflag"
 )
 
 // main entrypoint to all subcommands

--- a/plugins/apps/subcommands.go
+++ b/plugins/apps/subcommands.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 )
@@ -197,11 +196,6 @@ func CommandRename(oldAppName string, newAppName string, skipDeploy bool) error 
 
 // CommandReport displays an app report for one or more apps
 func CommandReport(appName string, infoFlag string) error {
-	if strings.HasPrefix(appName, "--") {
-		infoFlag = appName
-		appName = ""
-	}
-
 	if len(appName) == 0 {
 		apps, err := common.DokkuApps()
 		if err != nil {

--- a/plugins/buildpacks/go.mod
+++ b/plugins/buildpacks/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 // indirect
 	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3
+	github.com/spf13/pflag v1.0.5 // indirect
 )
 
 replace github.com/dokku/dokku/plugins/common => ../common

--- a/plugins/buildpacks/go.sum
+++ b/plugins/buildpacks/go.sum
@@ -4,3 +4,5 @@ github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 h1:HHUr4P/aKh4qu
 github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27/go.mod h1:VQx0hjo2oUeQkQUET7wRwradO6f+fN5jzXgB/zROxxE=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 h1:utdYOikI1XjNtTFGCwSM6OmFJblU4ld4gACoJsbadJg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/plugins/buildpacks/src/subcommands/subcommands.go
+++ b/plugins/buildpacks/src/subcommands/subcommands.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/dokku/dokku/plugins/buildpacks"
 	"github.com/dokku/dokku/plugins/common"
+
+	flag "github.com/spf13/pflag"
 )
 
 // main entrypoint to all subcommands

--- a/plugins/buildpacks/src/subcommands/subcommands.go
+++ b/plugins/buildpacks/src/subcommands/subcommands.go
@@ -44,10 +44,12 @@ func main() {
 		err = buildpacks.CommandRemove(appName, buildpack, *index)
 	case "report":
 		args := flag.NewFlagSet("buildpacks:report", flag.ExitOnError)
-		args.Parse(os.Args[2:])
-		appName := args.Arg(0)
-		infoFlag := args.Arg(1)
-		err = buildpacks.CommandReport(appName, infoFlag)
+		osArgs, infoFlag, err := common.ParseReportArgs("buildpacks", os.Args[2:])
+		if err == nil {
+			args.Parse(osArgs)
+			appName := args.Arg(0)
+			err = buildpacks.CommandReport(appName, infoFlag)
+		}
 	case "set":
 		args := flag.NewFlagSet("buildpacks:set", flag.ExitOnError)
 		index := args.Int("index", 0, "--index: the 1-based index of the URL in the list of URLs")

--- a/plugins/buildpacks/subcommands.go
+++ b/plugins/buildpacks/subcommands.go
@@ -3,7 +3,6 @@ package buildpacks
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 )
@@ -106,11 +105,6 @@ func CommandRemove(appName string, buildpack string, index int) (err error) {
 
 // CommandReport displays a buildpacks report for one or more apps
 func CommandReport(appName string, infoFlag string) error {
-	if strings.HasPrefix(appName, "--") {
-		infoFlag = appName
-		appName = ""
-	}
-
 	if len(appName) == 0 {
 		apps, err := common.DokkuApps()
 		if err != nil {

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -286,6 +286,7 @@ func GetenvWithDefault(key string, defaultValue string) (val string) {
 	return
 }
 
+// ParseReportArgs splits out flags from non-flags for input into report commands
 func ParseReportArgs(pluginName string, arguments []string) ([]string, string, error) {
 	osArgs := []string{}
 	infoFlags := []string{}

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -286,6 +286,26 @@ func GetenvWithDefault(key string, defaultValue string) (val string) {
 	return
 }
 
+func ParseReportArgs(pluginName string, arguments []string) ([]string, string, error) {
+	osArgs := []string{}
+	infoFlags := []string{}
+	for _, argument := range arguments {
+		if strings.HasPrefix(argument, "--") {
+			infoFlags = append(infoFlags, argument)
+		} else {
+			osArgs = append(osArgs, argument)
+		}
+	}
+
+	if len(infoFlags) == 0 {
+		return osArgs, "", nil
+	}
+	if len(infoFlags) == 1 {
+		return osArgs, infoFlags[0], nil
+	}
+	return osArgs, "", fmt.Errorf("%s:report command allows only a single flag", pluginName)
+}
+
 // ReportSingleApp is an internal function that displays a report for an app
 func ReportSingleApp(reportType string, appName string, infoFlag string, infoFlags map[string]string, trimPrefix bool, uppercaseFirstCharacter bool) error {
 	flags := []string{}

--- a/plugins/config/go.mod
+++ b/plugins/config/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/joho/godotenv v1.2.0
 	github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3
+	github.com/spf13/pflag v1.0.5 // indirect
 )
 
 replace github.com/dokku/dokku/plugins/common => ../common

--- a/plugins/config/go.sum
+++ b/plugins/config/go.sum
@@ -6,3 +6,5 @@ github.com/joho/godotenv v1.2.0 h1:vGTvz69FzUFp+X4/bAkb0j5BoLC+9bpqTWY8mjhA9pc=
 github.com/joho/godotenv v1.2.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 h1:utdYOikI1XjNtTFGCwSM6OmFJblU4ld4gACoJsbadJg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/plugins/config/src/subcommands/subcommands.go
+++ b/plugins/config/src/subcommands/subcommands.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 	"github.com/dokku/dokku/plugins/config"
+
+	flag "github.com/spf13/pflag"
 )
 
 func getKeys(args []string, global bool) []string {

--- a/plugins/logs/go.mod
+++ b/plugins/logs/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27
 	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 )
 
 replace github.com/dokku/dokku/plugins/common => ../common

--- a/plugins/logs/go.sum
+++ b/plugins/logs/go.sum
@@ -4,3 +4,5 @@ github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 h1:HHUr4P/aKh4qu
 github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27/go.mod h1:VQx0hjo2oUeQkQUET7wRwradO6f+fN5jzXgB/zROxxE=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 h1:utdYOikI1XjNtTFGCwSM6OmFJblU4ld4gACoJsbadJg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/plugins/logs/src/subcommands/subcommands.go
+++ b/plugins/logs/src/subcommands/subcommands.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 	"github.com/dokku/dokku/plugins/logs"
+
+	flag "github.com/spf13/pflag"
 )
 
 // main entrypoint to all subcommands

--- a/plugins/network/go.mod
+++ b/plugins/network/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27
 	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/dokku/dokku/plugins/config v0.0.0-00010101000000-000000000000
+  github.com/spf13/pflag v1.0.5 // indirect
 )
 
 replace github.com/dokku/dokku/plugins/common => ../common

--- a/plugins/network/go.sum
+++ b/plugins/network/go.sum
@@ -6,3 +6,5 @@ github.com/joho/godotenv v1.2.0 h1:vGTvz69FzUFp+X4/bAkb0j5BoLC+9bpqTWY8mjhA9pc=
 github.com/joho/godotenv v1.2.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 h1:utdYOikI1XjNtTFGCwSM6OmFJblU4ld4gACoJsbadJg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/plugins/network/src/subcommands/subcommands.go
+++ b/plugins/network/src/subcommands/subcommands.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 	"github.com/dokku/dokku/plugins/network"
+
+	flag "github.com/spf13/pflag"
 )
 
 // main entrypoint to all subcommands

--- a/plugins/network/src/subcommands/subcommands.go
+++ b/plugins/network/src/subcommands/subcommands.go
@@ -53,10 +53,12 @@ func main() {
 		err = network.CommandRebuildall()
 	case "report":
 		args := flag.NewFlagSet("network:report", flag.ExitOnError)
-		args.Parse(os.Args[2:])
-		appName := args.Arg(0)
-		infoFlag := args.Arg(1)
-		err = network.CommandReport(appName, infoFlag)
+		osArgs, infoFlag, err := common.ParseReportArgs("network", os.Args[2:])
+		if err == nil {
+			args.Parse(osArgs)
+			appName := args.Arg(0)
+			err = network.CommandReport(appName, infoFlag)
+		}
 	case "set":
 		args := flag.NewFlagSet("network:set", flag.ExitOnError)
 		args.Parse(os.Args[2:])

--- a/plugins/network/subcommands.go
+++ b/plugins/network/subcommands.go
@@ -124,11 +124,6 @@ func CommandRebuildall() error {
 
 // CommandReport displays a network report for one or more apps
 func CommandReport(appName string, infoFlag string) error {
-	if strings.HasPrefix(appName, "--") {
-		infoFlag = appName
-		appName = ""
-	}
-
 	if len(appName) == 0 {
 		apps, err := common.DokkuApps()
 		if err != nil {

--- a/plugins/proxy/go.mod
+++ b/plugins/proxy/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/dokku/dokku/plugins/config v0.0.0-00010101000000-000000000000
 	github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3
+  github.com/spf13/pflag v1.0.5 // indirect
 )
 
 replace github.com/dokku/dokku/plugins/common => ../common

--- a/plugins/proxy/go.sum
+++ b/plugins/proxy/go.sum
@@ -6,3 +6,5 @@ github.com/joho/godotenv v1.2.0 h1:vGTvz69FzUFp+X4/bAkb0j5BoLC+9bpqTWY8mjhA9pc=
 github.com/joho/godotenv v1.2.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 h1:utdYOikI1XjNtTFGCwSM6OmFJblU4ld4gACoJsbadJg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/plugins/proxy/src/subcommands/subcommands.go
+++ b/plugins/proxy/src/subcommands/subcommands.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 	"github.com/dokku/dokku/plugins/proxy"
+
+	flag "github.com/spf13/pflag"
 )
 
 // main entrypoint to all subcommands

--- a/plugins/proxy/src/subcommands/subcommands.go
+++ b/plugins/proxy/src/subcommands/subcommands.go
@@ -64,10 +64,12 @@ func main() {
 		err = proxy.CommandPortsSet(appName, portMaps)
 	case "report":
 		args := flag.NewFlagSet("proxy:report", flag.ExitOnError)
-		args.Parse(os.Args[2:])
-		appName := args.Arg(0)
-		infoFlag := args.Arg(1)
-		err = proxy.CommandReport(appName, infoFlag)
+		osArgs, infoFlag, err := common.ParseReportArgs("proxy", os.Args[2:])
+		if err == nil {
+			args.Parse(osArgs)
+			appName := args.Arg(0)
+			err = proxy.CommandReport(appName, infoFlag)
+		}
 	case "set":
 		args := flag.NewFlagSet("proxy:set", flag.ExitOnError)
 		args.Parse(os.Args[2:])

--- a/plugins/proxy/subcommands.go
+++ b/plugins/proxy/subcommands.go
@@ -155,11 +155,6 @@ func CommandPortsSet(appName string, portMaps []string) error {
 
 // CommandReport displays a proxy report for one or more apps
 func CommandReport(appName string, infoFlag string) error {
-	if strings.HasPrefix(appName, "--") {
-		infoFlag = appName
-		appName = ""
-	}
-
 	if len(appName) == 0 {
 		apps, err := common.DokkuApps()
 		if err != nil {

--- a/plugins/ps/go.mod
+++ b/plugins/ps/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dokku/dokku/plugins/docker-options v0.0.0-00010101000000-000000000000
 	github.com/gofrs/flock v0.8.0
 	github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3
+  github.com/spf13/pflag v1.0.5 // indirect
 )
 
 replace github.com/dokku/dokku/plugins/common => ../common

--- a/plugins/ps/go.sum
+++ b/plugins/ps/go.sum
@@ -10,3 +10,5 @@ github.com/joho/godotenv v1.2.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqx
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 h1:utdYOikI1XjNtTFGCwSM6OmFJblU4ld4gACoJsbadJg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/plugins/ps/src/subcommands/subcommands.go
+++ b/plugins/ps/src/subcommands/subcommands.go
@@ -32,10 +32,12 @@ func main() {
 		err = ps.CommandRebuild(appName, *allApps, *parallelCount)
 	case "report":
 		args := flag.NewFlagSet("ps:report", flag.ExitOnError)
-		args.Parse(os.Args[2:])
-		appName := args.Arg(0)
-		infoFlag := args.Arg(1)
-		err = ps.CommandReport(appName, infoFlag)
+		osArgs, infoFlag, err := common.ParseReportArgs("ps", os.Args[2:])
+		if err == nil {
+			args.Parse(osArgs)
+			appName := args.Arg(0)
+			err = ps.CommandReport(appName, infoFlag)
+		}
 	case "restart":
 		args := flag.NewFlagSet("ps:restart", flag.ExitOnError)
 		allApps := args.Bool("all", false, "--all: restart all apps")

--- a/plugins/ps/src/subcommands/subcommands.go
+++ b/plugins/ps/src/subcommands/subcommands.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 	"github.com/dokku/dokku/plugins/ps"
+
+	flag "github.com/spf13/pflag"
 )
 
 // main entrypoint to all subcommands

--- a/plugins/ps/subcommands.go
+++ b/plugins/ps/subcommands.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	dockeroptions "github.com/dokku/dokku/plugins/docker-options"
 
@@ -45,11 +44,6 @@ func CommandRebuild(appName string, allApps bool, parallelCount int) error {
 
 // CommandReport displays a ps report for one or more apps
 func CommandReport(appName string, infoFlag string) error {
-	if strings.HasPrefix(appName, "--") {
-		infoFlag = appName
-		appName = ""
-	}
-
 	if len(appName) == 0 {
 		apps, err := common.DokkuApps()
 		if err != nil {

--- a/plugins/repo/go.mod
+++ b/plugins/repo/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 // indirect
   github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
   github.com/dokku/dokku/plugins/config v0.0.0-00010101000000-000000000000
+  github.com/spf13/pflag v1.0.5 // indirect
 )
 
 replace github.com/dokku/dokku/plugins/common => ../common

--- a/plugins/repo/go.sum
+++ b/plugins/repo/go.sum
@@ -6,3 +6,5 @@ github.com/joho/godotenv v1.2.0 h1:vGTvz69FzUFp+X4/bAkb0j5BoLC+9bpqTWY8mjhA9pc=
 github.com/joho/godotenv v1.2.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 h1:utdYOikI1XjNtTFGCwSM6OmFJblU4ld4gACoJsbadJg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/plugins/repo/src/subcommands/subcommands.go
+++ b/plugins/repo/src/subcommands/subcommands.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 	"github.com/dokku/dokku/plugins/repo"
+
+	flag "github.com/spf13/pflag"
 )
 
 // main entrypoint to all subcommands

--- a/plugins/resource/go.mod
+++ b/plugins/resource/go.mod
@@ -4,8 +4,9 @@ go 1.14
 
 require (
 	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 // indirect
-  github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
+	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3
+	github.com/spf13/pflag v1.0.5 // indirect
 )
 
 replace github.com/dokku/dokku/plugins/common => ../common

--- a/plugins/resource/go.sum
+++ b/plugins/resource/go.sum
@@ -4,3 +4,5 @@ github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 h1:HHUr4P/aKh4qu
 github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27/go.mod h1:VQx0hjo2oUeQkQUET7wRwradO6f+fN5jzXgB/zROxxE=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3 h1:utdYOikI1XjNtTFGCwSM6OmFJblU4ld4gACoJsbadJg=
 github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/plugins/resource/src/subcommands/subcommands.go
+++ b/plugins/resource/src/subcommands/subcommands.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 	"github.com/dokku/dokku/plugins/resource"
+
+	flag "github.com/spf13/pflag"
 )
 
 // main entrypoint to all subcommands

--- a/plugins/resource/src/subcommands/subcommands.go
+++ b/plugins/resource/src/subcommands/subcommands.go
@@ -50,10 +50,12 @@ func main() {
 		err = resource.CommandLimitClear(appName, *processType)
 	case "report":
 		args := flag.NewFlagSet("resource:report", flag.ExitOnError)
-		args.Parse(os.Args[2:])
-		appName := args.Arg(0)
-		infoFlag := args.Arg(1)
-		err = resource.CommandReport(appName, infoFlag)
+		osArgs, infoFlag, err := common.ParseReportArgs("resource", os.Args[2:])
+		if err == nil {
+			args.Parse(osArgs)
+			appName := args.Arg(0)
+			err = resource.CommandReport(appName, infoFlag)
+		}
 	case "reserve":
 		args := flag.NewFlagSet("resource:reserve", flag.ExitOnError)
 		processType := args.String("process-type", "", "process-type: A process type to manage")

--- a/plugins/resource/subcommands.go
+++ b/plugins/resource/subcommands.go
@@ -2,7 +2,6 @@ package resource
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 )
@@ -28,11 +27,6 @@ func CommandLimitClear(appName string, processType string) error {
 
 // CommandReport displays a resource report for one or more apps
 func CommandReport(appName string, infoFlag string) error {
-	if strings.HasPrefix(appName, "--") {
-		infoFlag = appName
-		appName = ""
-	}
-
 	if len(appName) == 0 {
 		apps, err := common.DokkuApps()
 		if err != nil {

--- a/tests/unit/client.bats
+++ b/tests/unit/client.bats
@@ -33,12 +33,14 @@ teardown() {
   run /bin/bash -c "dokku config:set --global GLOBAL_KEY=VALUE"
   echo "output: $output"
   echo "status: $status"
+  assert_success
 
-  run /bin/bash -c "dokku config:set $TEST_APP GLOBAL_KEY=VALUE"
+  run /bin/bash -c "dokku config:set $TEST_APP APP_KEY=VALUE"
   echo "output: $output"
   echo "status: $status"
+  assert_success
 
-  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh config:export --merged --format shell"
+  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh --app $TEST_APP config:export --merged --format shell"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/client.bats
+++ b/tests/unit/client.bats
@@ -29,6 +29,46 @@ teardown() {
   assert_success
 }
 
+@test "(client) arg parsing" {
+  run /bin/bash -c "dokku config:set --global GLOBAL_KEY=VALUE"
+  echo "output: $output"
+  echo "status: $status"
+
+  run /bin/bash -c "dokku config:set $TEST_APP GLOBAL_KEY=VALUE"
+  echo "output: $output"
+  echo "status: $status"
+
+  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh config:export --merged --format shell"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  common_output="$output"
+  run /bin/bash -c "dokku config:export $TEST_APP --merged --format shell"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "$common_output"
+
+  run /bin/bash -c "dokku config:export --merged $TEST_APP --format shell"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "$common_output"
+
+  run /bin/bash -c "dokku config:export --merged --format shell $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "$common_output"
+
+  run /bin/bash -c "dokku --app $TEST_APP config:export --merged --format shell"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "$common_output"
+}
+
 @test "(client) apps:create AND apps:destroy with random name" {
   setup_client_repo
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh apps:create"


### PR DESCRIPTION
When setting the `--app` flag, there was a special case for the config plugin. This plugin used to take the `--no-restart` flag as the first argument - and still did until this change - resulting in an invalid call to the plugin subcommands. What is worse is that this functionality carried over to all other plugins as they were rewritten in golang, and thus the issue spread without us knowing.

The fix is to support GNU flag parsing rules, which Golang does not do by default (Because Of Reasons™). Switching to `github.com/spf13/pflag` fixes this issue, and also allows positional arguments to be placed wherever, even in the middle of flags.

Closes #4255
