### PR TITLE
Retry failing and skipped tests once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,9 @@ jobs:
       - run:
           name: run bats tests
           command: |
-            sudo -E make -e test-ci
+            if ! sudo -E make -e test-ci; then
+              sudo -E make tests-ci-retry-failed
+            fi
           no_output_timeout: 60m
           shell: /bin/bash
       - run:

--- a/tests.mk
+++ b/tests.mk
@@ -284,4 +284,10 @@ test-ci:
 	@cd tests/unit && echo "executing tests: $(shell cd tests/unit ; circleci tests glob *.bats | circleci tests split --split-by=timings --timings-type=classname | xargs)"
 	cd tests/unit && bats --formatter bats-format-junit -e -T -o ../../test-results/bats $(shell cd tests/unit ; circleci tests glob *.bats | circleci tests split --split-by=timings --timings-type=classname | xargs)
 
+tests-ci-retry-failed:
+	wget -qO /tmp/bats-retry.tgz https://github.com/josegonzalez/go-bats-retry/releases/download/v0.1.0/bats-retry_0.1.0_linux_x86_64.tgz
+	tar xzf /tmp/bats-retry.tgz -C /usr/local/bin
+	bats-retry test-results/bats bats-retry-script
+	./bats-retry-script
+
 test-ci-docker: setup-docker-deploy-tests deploy-test-checks-root deploy-test-config deploy-test-multi deploy-test-go-fail-predeploy deploy-test-go-fail-postdeploy


### PR DESCRIPTION
Plugn is fairly brittle since the upgrade to bash 5, so this might help decrease the need to retry the whole circleci job.
