### PR TITLE
Add calls to verify app name in subcommands

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -451,7 +451,6 @@ echo -n "$STDIN$output"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 # TODO
 ```
@@ -470,7 +469,6 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 
 APP="$1"; IMAGE_SOURCE_TYPE="$2"
-verify_app_name "$APP"
 
 # TODO
 ```
@@ -488,7 +486,6 @@ verify_app_name "$APP"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 APP="$1"; $IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3"; PROC_TYPE="$4"; CONTAINER_INDEX="$5"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 # TODO
 ```
@@ -506,7 +503,6 @@ verify_app_name "$APP"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 APP="$1"; IMAGE_SOURCE_TYPE="$3"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 # TODO
 ```
@@ -526,7 +522,6 @@ verify_app_name "$APP"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 # TODO
 ```
@@ -1060,7 +1055,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-APP="$1"; verify_app_name "$APP"
+APP="$1"
 
 # TODO
 ```
@@ -1077,7 +1072,7 @@ APP="$1"; verify_app_name "$APP"
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-APP="$1"; verify_app_name "$APP"
+APP="$1"
 
 # TODO
 ```
@@ -1199,7 +1194,7 @@ sudo service haproxy reload
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-APP="$1"; verify_app_name "$APP"
+APP="$1"
 TMP_WORK_DIR="$2"
 REV="$3" # optional, may not be sent for tar-based builds
 
@@ -1224,7 +1219,7 @@ popd >/dev/null
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/haproxy/functions"
-APP="$1"; verify_app_name "$APP"
+APP="$1"
 
 haproxy-build-config "$APP"
 ```
@@ -1244,7 +1239,6 @@ haproxy-build-config "$APP"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 # TODO
 ```
@@ -1267,7 +1261,6 @@ verify_app_name "$APP"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 # TODO
 ```
@@ -1287,7 +1280,6 @@ verify_app_name "$APP"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 # TODO
 ```
@@ -1373,7 +1365,6 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 
 APP="$1"; GULP_CACHE_DIR="$DOKKU_ROOT/$APP/gulp"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 if [[ -d $GULP_CACHE_DIR ]]; then
   docker run "${DOCKER_COMMIT_LABEL_ARGS[@]}" --rm -v "$GULP_CACHE_DIR:/gulp" "$IMAGE" find /gulp -depth -mindepth 1 -maxdepth 1 -exec rm -Rf {} \; || true
@@ -1394,7 +1385,6 @@ fi
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 dokku_log_info1 "Running gulp"
 CID=$(docker run "${DOCKER_COMMIT_LABEL_ARGS[@]}" -d $IMAGE /bin/bash -c "cd /app && gulp default")
@@ -1415,7 +1405,7 @@ docker commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" $CID $IMAGE >/dev/null
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-APP="$1"; verify_app_name "$APP"
+APP="$1"
 
 # TODO
 ```
@@ -1432,7 +1422,7 @@ APP="$1"; verify_app_name "$APP"
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
-APP="$1"; verify_app_name "$APP"
+APP="$1"
 
 # TODO
 ```
@@ -1470,7 +1460,6 @@ echo "$APP" > "$TMP_WORK_DIR/dokku-is-awesome"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 dokku_log_info1 "Installing GraphicsMagick..."
 
@@ -1518,7 +1507,6 @@ APP="$1"; IMAGE_TAG="$2";
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 APP="$1"; IMAGE_TAG="$2"; IMAGE=$(get_app_image_name $APP $IMAGE_TAG)
-verify_app_name "$APP"
 
 # TODO
 ```

--- a/plugins/00_dokku-standard/subcommands/urls
+++ b/plugins/00_dokku-standard/subcommands/urls
@@ -8,8 +8,7 @@ cmd-urls() {
   declare cmd="url"
   declare APP="$2"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
-
+  verify_app_name "$APP"
   get_app_urls "$@"
 }
 

--- a/plugins/apps/functions.go
+++ b/plugins/apps/functions.go
@@ -12,7 +12,7 @@ import (
 
 // checks if an app exists
 func appExists(appName string) error {
-	return common.VerifyAppName()
+	return common.VerifyAppName(appName)
 }
 
 // checks if an app is locked

--- a/plugins/apps/functions.go
+++ b/plugins/apps/functions.go
@@ -12,15 +12,7 @@ import (
 
 // checks if an app exists
 func appExists(appName string) error {
-	if err := common.IsValidAppName(appName); err != nil {
-		return err
-	}
-
-	if !common.DirectoryExists(common.AppRoot(appName)) {
-		return fmt.Errorf("App %s does not exist", appName)
-	}
-
-	return nil
+	return common.VerifyAppName()
 }
 
 // checks if an app is locked

--- a/plugins/apps/functions.go
+++ b/plugins/apps/functions.go
@@ -44,10 +44,6 @@ func createApp(appName string) error {
 
 // destroys an app
 func destroyApp(appName string) error {
-	if err := common.VerifyAppName(appName); err != nil {
-		return err
-	}
-
 	if os.Getenv("DOKKU_APPS_FORCE_DELETE") != "1" {
 		if err := common.AskForDestructiveConfirmation(appName, "app"); err != nil {
 			return err

--- a/plugins/apps/subcommands.go
+++ b/plugins/apps/subcommands.go
@@ -79,10 +79,6 @@ func CommandDestroy(appName string, force bool) error {
 
 // CommandExists checks if an app exists
 func CommandExists(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
-	}
-
 	return appExists(appName)
 }
 
@@ -104,10 +100,6 @@ func CommandList() error {
 
 // CommandLock locks an app for deployment
 func CommandLock(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
-	}
-
 	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}
@@ -123,10 +115,6 @@ func CommandLock(appName string) error {
 
 // CommandLocked checks if an app is locked for deployment
 func CommandLocked(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
-	}
-
 	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}
@@ -206,10 +194,6 @@ func CommandReport(appName string, infoFlag string) error {
 
 // CommandUnlock unlocks an app for deployment
 func CommandUnlock(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
-	}
-
 	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}

--- a/plugins/builder-herokuish/pre-build-buildpack
+++ b/plugins/builder-herokuish/pre-build-buildpack
@@ -13,7 +13,6 @@ trigger-builder-herokuish-pre-build-buildpack() {
   local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
   local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
 
-  verify_app_name "$APP"
   IMAGE=$(get_app_image_name "$APP")
 
   [[ -z $(config_get --global CURL_CONNECT_TIMEOUT) ]] && config_set --global CURL_CONNECT_TIMEOUT=90

--- a/plugins/buildpacks/subcommands.go
+++ b/plugins/buildpacks/subcommands.go
@@ -9,8 +9,8 @@ import (
 
 // CommandAdd implements buildpacks:add
 func CommandAdd(appName string, buildpack string, index int) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	buildpack, err := validBuildpackURL(buildpack)
@@ -23,8 +23,8 @@ func CommandAdd(appName string, buildpack string, index int) error {
 
 // CommandClear implements buildpacks:clear
 func CommandClear(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	return common.PropertyDelete("buildpacks", appName, "buildpacks")
@@ -32,8 +32,8 @@ func CommandClear(appName string) error {
 
 // CommandList implements buildpacks:list
 func CommandList(appName string) (err error) {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	buildpacks, err := common.PropertyListGet("buildpacks", appName, "buildpacks")
@@ -50,8 +50,8 @@ func CommandList(appName string) (err error) {
 
 // CommandRemove implements buildpacks:remove
 func CommandRemove(appName string, buildpack string, index int) (err error) {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	if index != 0 && buildpack != "" {
@@ -123,8 +123,8 @@ func CommandReport(appName string, infoFlag string) error {
 
 // CommandSet implements buildpacks:set
 func CommandSet(appName string, buildpack string, index int) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	buildpack, err := validBuildpackURL(buildpack)

--- a/plugins/certs/functions
+++ b/plugins/certs/functions
@@ -6,7 +6,6 @@ source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 is_ssl_enabled() {
   declare desc="returns 0 if ssl is enabled for given app"
   local APP=$1
-  verify_app_name "$APP"
   local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
 
   if [[ -e "$APP_SSL_PATH/server.crt" ]] && [[ -e "$APP_SSL_PATH/server.key" ]]; then
@@ -19,7 +18,6 @@ is_ssl_enabled() {
 get_ssl_hostnames() {
   declare desc="returns a string of ssl hostnames extracted from an app's ssl certificate"
   local APP=$1
-  verify_app_name "$APP"
   local SSL_PATH="$DOKKU_ROOT/$APP/tls"
 
   local SSL_HOSTNAME=$(openssl x509 -in "$SSL_PATH/server.crt" -noout -subject | tr '/' '\n' | grep CN= | cut -c4-)

--- a/plugins/certs/subcommands/add
+++ b/plugins/certs/subcommands/add
@@ -34,7 +34,6 @@ cmd-certs-set() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" CRT_FILE="$2" KEY_FILE="$3"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
   local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
 

--- a/plugins/certs/subcommands/generate
+++ b/plugins/certs/subcommands/generate
@@ -9,7 +9,6 @@ cmd-certs-generate() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" DOMAIN="$2"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
   local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
 

--- a/plugins/certs/subcommands/remove
+++ b/plugins/certs/subcommands/remove
@@ -9,7 +9,6 @@ cmd-certs-remove() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
   local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
 

--- a/plugins/certs/subcommands/show
+++ b/plugins/certs/subcommands/show
@@ -10,7 +10,6 @@ cmd-certs-show() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY_TYPE="$2"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
   local APP_SSL_PATH="$DOKKU_ROOT/$APP/tls"
 

--- a/plugins/checks/functions
+++ b/plugins/checks/functions
@@ -7,7 +7,6 @@ source "$PLUGIN_AVAILABLE_PATH/config/functions"
 is_app_proctype_checks_disabled() {
   declare desc="return true if app's proctype(s) checks are disabled"
   local APP="$1"
-  verify_app_name "$APP"
   local PROCTYPE="$2" status=false
   local DOKKU_CHECKS_DISABLED=$(config_get "$APP" DOKKU_CHECKS_DISABLED || true)
 
@@ -21,7 +20,6 @@ is_app_proctype_checks_disabled() {
 is_app_proctype_checks_skipped() {
   declare desc="return true if app's proctype(s) checks are skipped"
   local APP="$1"
-  verify_app_name "$APP"
   local PROCTYPE="$2" status=false
   local DOKKU_CHECKS_SKIPPED=$(config_get "$APP" DOKKU_CHECKS_SKIPPED || true)
 

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -90,10 +90,6 @@ func GetGlobalScheduler() string {
 
 // GetDeployingAppImageName returns deploying image identifier for a given app, tag tuple. validate if tag is presented
 func GetDeployingAppImageName(appName, imageTag, imageRepo string) (string, error) {
-	if appName == "" {
-		LogFail("(GetDeployingAppImageName) APP must not be empty")
-	}
-
 	b, err := PlugnTriggerOutput("deployed-app-repository", []string{appName}...)
 	if err != nil {
 		return "", err
@@ -140,10 +136,6 @@ func GetAppImageRepo(appName string) string {
 // GetAppContainerIDs returns a list of docker container ids for given app and optional container_type
 func GetAppContainerIDs(appName string, containerType string) ([]string, error) {
 	var containerIDs []string
-	if err := VerifyAppName(appName); err != nil {
-		return containerIDs, err
-	}
-
 	appRoot := AppRoot(appName)
 	containerFilePath := fmt.Sprintf("%v/CONTAINER", appRoot)
 	_, err := os.Stat(containerFilePath)
@@ -170,10 +162,6 @@ func GetAppContainerIDs(appName string, containerType string) ([]string, error) 
 // GetAppRunningContainerIDs return a list of running docker container ids for given app and optional container_type
 func GetAppRunningContainerIDs(appName string, containerType string) ([]string, error) {
 	var runningContainerIDs []string
-	if err := VerifyAppName(appName); err != nil {
-		return runningContainerIDs, err
-	}
-
 	if !IsDeployed(appName) {
 		LogFail(fmt.Sprintf("App %v has not been deployed", appName))
 	}
@@ -193,10 +181,6 @@ func GetAppRunningContainerIDs(appName string, containerType string) ([]string, 
 
 // GetRunningImageTag retrieves current image tag for a given app and returns empty string if no deployed containers are found
 func GetRunningImageTag(appName string) (string, error) {
-	if err := VerifyAppName(appName); err != nil {
-		return "", err
-	}
-
 	containerIDs, err := GetAppContainerIDs(appName, "")
 	if err != nil {
 		return "", err
@@ -241,11 +225,6 @@ func DokkuApps() (apps []string, err error) {
 
 // GetAppImageName returns image identifier for a given app, tag tuple. validate if tag is presented
 func GetAppImageName(appName, imageTag, imageRepo string) (imageName string) {
-	err := VerifyAppName(appName)
-	if err != nil {
-		LogFail(err.Error())
-	}
-
 	if imageRepo == "" {
 		imageRepo = GetAppImageRepo(appName)
 	}

--- a/plugins/common/docker.go
+++ b/plugins/common/docker.go
@@ -22,10 +22,6 @@ func ContainerIsRunning(containerID string) bool {
 
 // CopyFromImage copies a file from named image to destination
 func CopyFromImage(appName string, image string, source string, destination string) error {
-	if err := VerifyAppName(appName); err != nil {
-		return err
-	}
-
 	if !VerifyImage(image) {
 		return fmt.Errorf("Invalid docker image for copying content")
 	}

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -612,6 +612,7 @@ cmd-deploy() {
   declare APP="$1" IMAGE_TAG="$2"
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
+  verify_app_name "$APP"
   local DOKKU_SCHEDULER=$(get_app_scheduler "$APP")
   plugn trigger scheduler-deploy "$DOKKU_SCHEDULER" "$APP" "$IMAGE_TAG"
 }

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -303,7 +303,6 @@ get_app_scheduler() {
 get_running_image_tag() {
   declare desc="retrieve current image tag for a given app. returns empty string if no deployed containers are found"
   local APP="$1"
-  verify_app_name "$APP"
 
   local CIDS=($(get_app_container_ids "$APP"))
   local RUNNING_IMAGE_TAG=$("$DOCKER_BIN" container inspect --format '{{ .Config.Image }}' "${CIDS[0]}" 2>/dev/null | awk -F: '{ print $2 }' || echo '')
@@ -435,7 +434,6 @@ copy_from_image() {
   declare desc="copy file from named image to destination"
   declare IMAGE="$1" SRC_FILE="$2" DST_FILE="$3"
   local WORK_DIR=""
-  verify_app_name "$APP"
 
   local DOCKER_CREATE_LABEL_ARGS="--label=com.dokku.app-name=$APP"
 
@@ -483,7 +481,6 @@ get_app_container_ids() {
   declare desc="returns list of docker container ids for given app and optional container_type"
   local APP="$1"
   local CONTAINER_TYPE="$2"
-  verify_app_name "$APP"
   [[ -f $DOKKU_ROOT/$APP/CONTAINER ]] && DOKKU_CIDS+=$(<"$DOKKU_ROOT/$APP/CONTAINER")
 
   if [[ -n "$CONTAINER_TYPE" ]]; then
@@ -581,7 +578,6 @@ is_app_running() {
   local APP="$1"
 
   dokku_log_warn "Deprecated: ps#fn-ps-is-app-running"
-  verify_app_name "$APP"
 
   local APP_RUNNING_CONTAINER_IDS=$(get_app_running_container_ids "$APP" 2>/dev/null)
 
@@ -596,7 +592,6 @@ dokku_build() {
   declare desc="build phase"
   declare APP="$1" IMAGE_SOURCE_TYPE="$2" SOURCECODE_WORK_DIR="$3"
 
-  verify_app_name "$APP"
   plugn trigger builder-build "$IMAGE_SOURCE_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
 }
 
@@ -629,8 +624,6 @@ release_and_deploy() {
   local IMAGE_TAG="$2"
   local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
   local DOKKU_DOCKERFILE_PORTS
-
-  verify_app_name "$APP"
 
   if verify_image "$IMAGE"; then
     if is_image_herokuish_based "$IMAGE" "$APP"; then
@@ -855,7 +848,6 @@ get_app_raw_tcp_ports() {
   source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
   local APP="$1"
-  verify_app_name "$APP"
   local DOCKERFILE_PORTS="$(config_get "$APP" DOKKU_DOCKERFILE_PORTS)"
   for p in $DOCKERFILE_PORTS; do
     if [[ ! "$p" =~ .*udp.* ]]; then
@@ -870,7 +862,6 @@ get_app_raw_tcp_ports() {
 get_container_ports() {
   declare desc="returns published ports from app containers"
   local APP="$1"
-  verify_app_name "$APP"
   local APP_CIDS="$(get_app_container_ids "$APP")"
   local cid
 
@@ -886,7 +877,6 @@ get_app_urls() {
   declare URL_TYPE="$1" APP="$2"
   local urls
 
-  verify_app_name "$APP"
   urls=$(plugn trigger app-urls "$APP" "$URL_TYPE")
   if [[ -n "$urls" ]]; then
     echo "$urls" | sort
@@ -1045,7 +1035,6 @@ merge_dedupe_list() {
 acquire_app_deploy_lock() {
   declare desc="acquire advisory lock for use in git/tar deploys"
   local APP="$1"
-  verify_app_name "$APP"
   local LOCK_TYPE="${2:-waiting}"
   local APP_DEPLOY_LOCK_FILE="$DOKKU_ROOT/$APP/.deploy.lock"
   local LOCK_WAITING_MSG="$APP currently has a deploy lock in place. Waiting..."
@@ -1057,7 +1046,6 @@ acquire_app_deploy_lock() {
 release_app_deploy_lock() {
   declare desc="release advisory lock used in git/tar deploys"
   local APP="$1"
-  verify_app_name "$APP"
   local APP_DEPLOY_LOCK_FILE="$DOKKU_ROOT/$APP/.deploy.lock"
 
   release_advisory_lock "$APP_DEPLOY_LOCK_FILE"

--- a/plugins/config/docker-args-deploy
+++ b/plugins/config/docker-args-deploy
@@ -13,7 +13,6 @@ trigger-config-docker-args() {
   IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
   STDIN=$(cat)
   trigger="$0 config_docker_args"
-  verify_app_name "$APP"
 
   if ! is_image_herokuish_based "$IMAGE" "$APP"; then
     ENV_ARGS="$(config_export app "$APP" --format docker-args --merged)"

--- a/plugins/docker-options/subcommands/clear
+++ b/plugins/docker-options/subcommands/clear
@@ -10,7 +10,6 @@ cmd-docker-options-clear() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" PHASES="$2"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
 
   if [[ -z "$PHASES" ]]; then

--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -7,7 +7,6 @@ set -eo pipefail
 disable_app_vhost() {
   declare desc="disable vhost support for given application"
   declare APP=$1 RESTART_APP="$2"
-  verify_app_name "$APP"
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
   local APP_URLS_PATH="$DOKKU_ROOT/$APP/URLS"
 
@@ -24,7 +23,6 @@ disable_app_vhost() {
 
 domains_setup() {
   declare desc="setup domains to default state"
-  verify_app_name "$1"
   local APP="$1"
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
   local GLOBAL_VHOST_PATH="$DOKKU_ROOT/VHOST"
@@ -45,7 +43,6 @@ domains_setup() {
 
 domains_add() {
   declare desc="add list of domains to app"
-  verify_app_name "$1"
   local APP="$1"
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
 
@@ -74,7 +71,6 @@ domains_add() {
 
 domains_remove() {
   declare desc="remove list of app domains"
-  verify_app_name "$1"
   local APP="$1"
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
   shift 1
@@ -89,7 +85,6 @@ domains_remove() {
 
 domains_set() {
   declare desc="set list of domains for app"
-  verify_app_name "$1"
   local APP="$1"
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
 
@@ -113,7 +108,6 @@ domains_set() {
 
 domains_disable() {
   declare desc="disable domains/VHOST support"
-  verify_app_name "$1"
   local APP="$1"
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
 
@@ -127,7 +121,6 @@ domains_disable() {
 
 domains_enable() {
   declare desc="enable domains/VHOST support"
-  verify_app_name "$1"
   local APP="$1" RESTART_APP="$2"
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
   local DEFAULT_VHOSTS="$(get_default_vhosts "$APP")"
@@ -202,7 +195,6 @@ domains_set_global() {
 enable_app_vhost() {
   declare desc="enable vhost support for given application"
   declare APP=$1 RESTART_APP="$2"
-  verify_app_name "$APP"
 
   plugn trigger pre-enable-vhost "$APP"
   [[ "$RESTART_APP" == "--no-restart" ]] && local CONFIG_SET_ARGS=$RESTART_APP
@@ -212,7 +204,6 @@ enable_app_vhost() {
 
 get_app_domains() {
   declare desc="return app domains"
-  verify_app_name "$1"
   local APP=$1
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
   local GLOBAL_HOSTNAME_PATH="$DOKKU_ROOT/HOSTNAME"
@@ -228,7 +219,6 @@ get_app_domains() {
 
 get_default_vhosts() {
   declare desc="return default vhosts"
-  verify_app_name "$1"
   local APP="$1"
   local RE_IPV4="$(get_ipv4_regex)"
   local RE_IPV6="$(get_ipv6_regex)"
@@ -264,7 +254,6 @@ is_app_vhost_enabled() {
   declare desc="returns true or false if vhost support is enabled for a given application"
 
   local APP=$1
-  verify_app_name "$APP"
   local NO_VHOST=$(config_get "$APP" NO_VHOST)
   local APP_VHOST_ENABLED=true
 

--- a/plugins/domains/subcommands/add
+++ b/plugins/domains/subcommands/add
@@ -10,8 +10,8 @@ cmd-domains-add() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" DOMAIN_NAME="$2"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   [[ -z "$DOMAIN_NAME" ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 $2 <domain> [<domain> ...]"
+  verify_app_name "$APP"
   domains_add "$@"
 }
 

--- a/plugins/domains/subcommands/clear
+++ b/plugins/domains/subcommands/clear
@@ -10,7 +10,6 @@ cmd-domains-clear() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
 

--- a/plugins/domains/subcommands/disable
+++ b/plugins/domains/subcommands/disable
@@ -10,7 +10,7 @@ cmd-domains-disable() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$APP"
   domains_disable "$APP"
 }
 

--- a/plugins/domains/subcommands/enable
+++ b/plugins/domains/subcommands/enable
@@ -10,7 +10,7 @@ cmd-domains-enable() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$APP"
   domains_enable "$APP"
 }
 

--- a/plugins/domains/subcommands/remove
+++ b/plugins/domains/subcommands/remove
@@ -10,8 +10,8 @@ cmd-domains-remove() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" DOMAIN_NAME="$2"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   [[ -z "$DOMAIN_NAME" ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 $2 <domain> [<domain> ...]"
+  verify_app_name "$APP"
   domains_remove "$@"
 }
 

--- a/plugins/domains/subcommands/set
+++ b/plugins/domains/subcommands/set
@@ -10,8 +10,8 @@ cmd-domains-set() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" DOMAIN_NAME="$2"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   [[ -z "$DOMAIN_NAME" ]] && dokku_log_fail "Please specify a domain name. Usage: dokku $1 $2 <domain> [<domain> ...]"
+  verify_app_name "$APP"
   domains_set "$@"
 }
 

--- a/plugins/domains/subcommands/setup
+++ b/plugins/domains/subcommands/setup
@@ -10,7 +10,7 @@ cmd-domains-setup() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$APP"
   domains_setup "$APP"
 }
 

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -239,7 +239,6 @@ fn-git-create-hook() {
   declare APP="$1"
   local APP_PATH="$DOKKU_ROOT/$APP"
   local PRERECEIVE_HOOK="$APP_PATH/hooks/pre-receive"
-  verify_app_name "$APP"
 
   if [[ ! -d "$APP_PATH/refs" ]]; then
     git init --bare "$APP_PATH" >/dev/null

--- a/plugins/git/subcommands/initialize
+++ b/plugins/git/subcommands/initialize
@@ -10,7 +10,7 @@ cmd-git-initialize() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"
 
-  is_valid_app_name "$APP"
+  verify_app_name "$APP"
   dokku_log_info1_quiet "Initializing git repository for $APP"
   fn-git-create-hook "$APP"
 }

--- a/plugins/git/subcommands/set
+++ b/plugins/git/subcommands/set
@@ -10,8 +10,8 @@ cmd-git-set() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
   local VALID_KEYS=("deploy-branch" "keep-git-dir" "rev-env-var")
+  verify_app_name "$APP"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then

--- a/plugins/git/subcommands/set
+++ b/plugins/git/subcommands/set
@@ -10,7 +10,7 @@ cmd-git-set() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
   local VALID_KEYS=("deploy-branch" "keep-git-dir" "rev-env-var")
-  verify_app_name "$APP"
+  [[ "$APP" == "--global" ]] || verify_app_name "$APP"
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 

--- a/plugins/logs/subcommands.go
+++ b/plugins/logs/subcommands.go
@@ -1,7 +1,6 @@
 package logs
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -10,10 +9,6 @@ import (
 
 // CommandDefault displays recent log output
 func CommandDefault(appName string, num int64, process string, tail, quiet bool) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
-	}
-
 	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}

--- a/plugins/network/network.go
+++ b/plugins/network/network.go
@@ -26,10 +26,6 @@ var (
 
 // BuildConfig builds network config files
 func BuildConfig(appName string) error {
-	if err := common.VerifyAppName(appName); err != nil {
-		return err
-	}
-
 	if !common.IsDeployed(appName) {
 		return nil
 	}

--- a/plugins/network/subcommands.go
+++ b/plugins/network/subcommands.go
@@ -142,6 +142,10 @@ func CommandReport(appName string, infoFlag string) error {
 
 // CommandSet set or clear a network property for an app
 func CommandSet(appName string, property string, value string) error {
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
+	}
+
 	if property == "bind-all-interfaces" && value == "" {
 		value = "false"
 	}

--- a/plugins/network/triggers.go
+++ b/plugins/network/triggers.go
@@ -104,14 +104,6 @@ func TriggerNetworkGetProperty(appName string, property string) {
 
 // TriggerNetworkWriteIpaddr writes the ip to disk
 func TriggerNetworkWriteIpaddr(appName string, processType string, containerIndex string, ip string) {
-	if appName == "" {
-		common.LogFail("Please specify an app to run the command on")
-	}
-	err := common.VerifyAppName(appName)
-	if err != nil {
-		common.LogFail(err.Error())
-	}
-
 	appRoot := common.AppRoot(appName)
 	filename := fmt.Sprintf("%v/IP.%v.%v", appRoot, processType, containerIndex)
 	f, err := os.Create(filename)
@@ -129,14 +121,6 @@ func TriggerNetworkWriteIpaddr(appName string, processType string, containerInde
 
 // TriggerNetworkWritePort writes the port to disk
 func TriggerNetworkWritePort(appName string, processType string, containerIndex string, port string) {
-	if appName == "" {
-		common.LogFail("Please specify an app to run the command on")
-	}
-	err := common.VerifyAppName(appName)
-	if err != nil {
-		common.LogFail(err.Error())
-	}
-
 	appRoot := common.AppRoot(appName)
 	filename := fmt.Sprintf("%v/PORT.%v.%v", appRoot, processType, containerIndex)
 	f, err := os.Create(filename)

--- a/plugins/nginx-vhosts/command-functions
+++ b/plugins/nginx-vhosts/command-functions
@@ -112,5 +112,6 @@ cmd-nginx-validate-config() {
   fi
   declare APP="$1" FLAG="$2"
 
+  verify_app_name "$APP"
   validate_nginx "$APP" "$FLAG"
 }

--- a/plugins/nginx-vhosts/command-functions
+++ b/plugins/nginx-vhosts/command-functions
@@ -112,6 +112,5 @@ cmd-nginx-validate-config() {
   fi
   declare APP="$1" FLAG="$2"
 
-  verify_app_name "$APP"
   validate_nginx "$APP" "$FLAG"
 }

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -126,7 +126,6 @@ restart_nginx() {
 nginx_logs() {
   declare desc="display app nginx logs"
   declare NGINX_LOGS_TYPE="${1#nginx:}" APP="$2"
-  verify_app_name "$APP"
 
   local NGINX_LOGS_TYPE=${NGINX_LOGS_TYPE%-logs}
   local NGINX_LOGS_PATH="$("fn-nginx-${NGINX_LOGS_TYPE}-log-path" "$APP")"
@@ -147,7 +146,6 @@ nginx_logs() {
 configure_nginx_ports() {
   declare desc="configure nginx listening ports"
   local APP=$1
-  verify_app_name "$APP"
   local RAW_TCP_PORTS="$(get_app_raw_tcp_ports "$APP")"
   local DOKKU_PROXY_PORT=$(config_get "$APP" DOKKU_PROXY_PORT)
   local DOKKU_PROXY_SSL_PORT=$(config_get "$APP" DOKKU_PROXY_SSL_PORT)
@@ -204,7 +202,6 @@ configure_nginx_ports() {
 validate_ssl_domains() {
   declare desc="check configured domains against SSL cert contents and show warning if mismatched"
   local APP=$1
-  verify_app_name "$APP"
   local VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
   local SSL_HOSTNAME=$(get_ssl_hostnames "$APP")
   local SSL_HOSTNAME_REGEX=$(echo "$SSL_HOSTNAME" | xargs | sed 's|\.|\\.|g' | sed 's/\*/\[^\.\]\*/g' | sed 's/ /|/g')
@@ -227,7 +224,6 @@ validate_ssl_domains() {
 get_custom_nginx_template() {
   declare desc="attempts to copy custom nginx template from app image"
   local APP="$1"
-  verify_app_name "$APP"
   local DESTINATION_FILE="$2"
   local IMAGE_TAG="$(get_running_image_tag "$APP")"
   local IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
@@ -350,7 +346,6 @@ is_grpc_enabled() {
 nginx_build_config() {
   declare desc="build nginx config to proxy app containers using sigil"
   declare APP="$1" DOKKU_APP_LISTEN_PORT="$2" DOKKU_APP_LISTEN_IP="$3"
-  verify_app_name "$APP"
   local VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
   local APP_URLS_PATH="$DOKKU_ROOT/$APP/URLS"
   local NGINX_TEMPLATE_NAME="nginx.conf.sigil"

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -99,6 +99,7 @@ validate_nginx() {
   fi
 
   if [[ -n "$APP" ]]; then
+    verify_app_name "$APP"
     nginx_vhosts_validate_single_func "$APP" "$FLAG"
   else
     for app in $(dokku_apps); do

--- a/plugins/nginx-vhosts/proxy-disable
+++ b/plugins/nginx-vhosts/proxy-disable
@@ -8,7 +8,6 @@ trigger-nginx-vhosts-proxy-disable() {
   declare trigger="proxy-disable"
   declare APP="$1"
 
-  verify_app_name "$APP"
   if [[ "$(plugn trigger proxy-type "$APP")" == "nginx" ]]; then
     plugn trigger domains-disable "$APP" false
     plugn trigger app-restart "$APP"

--- a/plugins/nginx-vhosts/proxy-enable
+++ b/plugins/nginx-vhosts/proxy-enable
@@ -8,7 +8,6 @@ trigger-nginx-vhosts-proxy-enable() {
   declare trigger="proxy-enable"
   declare APP="$1"
 
-  verify_app_name "$APP"
   if [[ "$(plugn trigger proxy-type "$APP")" == "nginx" ]]; then
     plugn trigger domains-enable "$APP" "false"
     plugn trigger app-restart "$APP"

--- a/plugins/nginx-vhosts/subcommands/access-logs
+++ b/plugins/nginx-vhosts/subcommands/access-logs
@@ -6,9 +6,9 @@ source "$PLUGIN_AVAILABLE_PATH/nginx-vhosts/functions"
 
 cmd-nginx-logs() {
   declare desc="display app nginx logs from command line"
-  declare cmd="$1"
+  declare cmd="$1" APP="$2"
 
-  [[ -z $2 ]] && dokku_log_fail "Please specify an app to run the command on"
+  verify_app_name "$APP"
   nginx_logs "$@"
 }
 

--- a/plugins/nginx-vhosts/subcommands/build-config
+++ b/plugins/nginx-vhosts/subcommands/build-config
@@ -8,9 +8,9 @@ cmd-nginx-build-config() {
   declare cmd="nginx:build-config"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"
+  verify_app_name "$APP"
   dokku_log_warn "Deprecated: Please use proxy:build-config"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   local PROXY_APP_TYPE
   PROXY_APP_TYPE="$(plugn trigger proxy-type "$APP")"
 

--- a/plugins/nginx-vhosts/subcommands/set
+++ b/plugins/nginx-vhosts/subcommands/set
@@ -10,8 +10,8 @@ cmd-nginx-set() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
   local VALID_KEYS=("access-log-format" "access-log-path" "bind-address-ipv4" "bind-address-ipv6" "disable-custom-config" "error-log-path" "hsts" "hsts-include-subdomains" "hsts-preload" "hsts-max-age" "proxy-read-timeout" "proxy-buffer-size" "proxy-buffering" "proxy-buffers" "proxy-busy-buffers-size")
+  verify_app_name "$APP"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then

--- a/plugins/proxy/proxy.go
+++ b/plugins/proxy/proxy.go
@@ -35,11 +35,6 @@ func inRange(value int, min int, max int) bool {
 
 // IsAppProxyEnabled returns true if proxy is enabled; otherwise return false
 func IsAppProxyEnabled(appName string) bool {
-	err := common.VerifyAppName(appName)
-	if err != nil {
-		common.LogFail(err.Error())
-	}
-
 	proxyEnabled := true
 	disableProxy := config.GetWithDefault(appName, "DOKKU_DISABLE_PROXY", "")
 	if disableProxy != "" {

--- a/plugins/proxy/subcommands.go
+++ b/plugins/proxy/subcommands.go
@@ -10,10 +10,6 @@ import (
 
 // CommandBuildConfig rebuilds config for a given app
 func CommandBuildConfig(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
-	}
-
 	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}
@@ -23,8 +19,8 @@ func CommandBuildConfig(appName string) error {
 
 // CommandDisable disables the proxy for app via command line
 func CommandDisable(appName string, skipRestart bool) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	if !IsAppProxyEnabled(appName) {
@@ -46,8 +42,8 @@ func CommandDisable(appName string, skipRestart bool) error {
 
 // CommandEnable enables the proxy for app via command line
 func CommandEnable(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	if IsAppProxyEnabled(appName) {
@@ -66,8 +62,8 @@ func CommandEnable(appName string) error {
 
 // CommandPorts is a cmd wrapper to list proxy port mappings for an app
 func CommandPorts(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	return listAppProxyPorts(appName)
@@ -75,8 +71,8 @@ func CommandPorts(appName string) error {
 
 // CommandPortsAdd adds proxy port mappings to an app
 func CommandPortsAdd(appName string, portMaps []string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	if len(portMaps) == 0 {
@@ -97,8 +93,8 @@ func CommandPortsAdd(appName string, portMaps []string) error {
 
 // CommandPortsClear clears all proxy port mappings for an app
 func CommandPortsClear(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	keys := []string{"DOKKU_PROXY_PORT_MAP"}
@@ -111,8 +107,8 @@ func CommandPortsClear(appName string) error {
 
 // CommandPortsRemove removes specific proxy port mappings from an app
 func CommandPortsRemove(appName string, portMaps []string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	if len(portMaps) == 0 {
@@ -133,8 +129,8 @@ func CommandPortsRemove(appName string, portMaps []string) error {
 
 // CommandPortsSet sets proxy port mappings for an app
 func CommandPortsSet(appName string, portMaps []string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	if len(portMaps) == 0 {
@@ -173,8 +169,8 @@ func CommandReport(appName string, infoFlag string) error {
 
 // CommandSet sets a proxy for an app
 func CommandSet(appName string, proxyType string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	if len(proxyType) < 2 {

--- a/plugins/ps/subcommands.go
+++ b/plugins/ps/subcommands.go
@@ -13,10 +13,6 @@ import (
 
 // CommandInspect displays a sanitized version of docker inspect for an app
 func CommandInspect(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
-	}
-
 	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}
@@ -29,10 +25,6 @@ func CommandInspect(appName string) error {
 func CommandRebuild(appName string, allApps bool, parallelCount int) error {
 	if allApps {
 		return common.RunCommandAgainstAllApps(Rebuild, "rebuild", parallelCount)
-	}
-
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
 	}
 
 	if err := common.VerifyAppName(appName); err != nil {
@@ -64,10 +56,6 @@ func CommandReport(appName string, infoFlag string) error {
 func CommandRestart(appName string, allApps bool, parallelCount int) error {
 	if allApps {
 		return common.RunCommandAgainstAllApps(Restart, "restart", parallelCount)
-	}
-
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
 	}
 
 	if err := common.VerifyAppName(appName); err != nil {
@@ -128,10 +116,6 @@ func CommandRetire() error {
 
 // CommandScale gets or sets how many instances of a given process to run
 func CommandScale(appName string, skipDeploy bool, processTuples []string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
-	}
-
 	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}
@@ -189,10 +173,6 @@ func CommandStart(appName string, allApps bool, parallelCount int) error {
 		return common.RunCommandAgainstAllApps(Start, "start", parallelCount)
 	}
 
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
-	}
-
 	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}
@@ -204,10 +184,6 @@ func CommandStart(appName string, allApps bool, parallelCount int) error {
 func CommandStop(appName string, allApps bool, parallelCount int) error {
 	if allApps {
 		return common.RunCommandAgainstAllApps(Stop, "stop", parallelCount)
-	}
-
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
 	}
 
 	if err := common.VerifyAppName(appName); err != nil {

--- a/plugins/repo/repo.go
+++ b/plugins/repo/repo.go
@@ -11,11 +11,6 @@ import (
 
 // PurgeCache deletes the contents of the build cache stored in the repository
 func PurgeCache(appName string) error {
-	err := common.VerifyAppName(appName)
-	if err != nil {
-		return err
-	}
-
 	cacheDir := strings.Join([]string{common.AppRoot(appName), "cache"}, "/")
 	cacheHostDir := strings.Join([]string{common.AppHostRoot(appName), "cache"}, "/")
 	dokkuGlobalRunArgs := common.MustGetEnv("DOKKU_GLOBAL_RUN_ARGS")

--- a/plugins/repo/subcommands.go
+++ b/plugins/repo/subcommands.go
@@ -1,18 +1,12 @@
 package repo
 
 import (
-	"errors"
-
 	"github.com/dokku/dokku/plugins/common"
 )
 
 // CommandGc runs 'git gc --aggressive' against the application's repo
 func CommandGc(appName string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
-	}
-	err := common.VerifyAppName(appName)
-	if err != nil {
+	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}
 
@@ -28,8 +22,8 @@ func CommandGc(appName string) error {
 
 // CommandPurgeCache deletes the contents of the build cache stored in the repository
 func CommandPurgeCache(appName string) error {
-	if appName == "" {
-		common.LogFail("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	return PurgeCache(appName)

--- a/plugins/resource/subcommands.go
+++ b/plugins/resource/subcommands.go
@@ -1,15 +1,13 @@
 package resource
 
 import (
-	"errors"
-
 	"github.com/dokku/dokku/plugins/common"
 )
 
 // CommandLimit implements resource:limit
 func CommandLimit(appName string, processType string, r Resource) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	return setResourceType(appName, processType, r, "limit")
@@ -17,8 +15,8 @@ func CommandLimit(appName string, processType string, r Resource) error {
 
 // CommandLimitClear implements resource:limit-clear
 func CommandLimitClear(appName string, processType string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	clearByResourceType(appName, processType, "limit")
@@ -45,8 +43,8 @@ func CommandReport(appName string, infoFlag string) error {
 
 // CommandReserve implements resource:reserve
 func CommandReserve(appName string, processType string, r Resource) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	return setResourceType(appName, processType, r, "reserve")
@@ -54,8 +52,8 @@ func CommandReserve(appName string, processType string, r Resource) error {
 
 // CommandReserveClear implements resource:reserve-clear
 func CommandReserveClear(appName string, processType string) error {
-	if appName == "" {
-		return errors.New("Please specify an app to run the command on")
+	if err := common.VerifyAppName(appName); err != nil {
+		return err
 	}
 
 	clearByResourceType(appName, processType, "reserve")

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -21,7 +21,6 @@ trigger-scheduler-docker-local-scheduler-deploy() {
   local DOKKU_DOCKER_STOP_TIMEOUT DOKKU_HEROKUISH DOKKU_NETWORK_BIND_ALL IMAGE
   DOKKU_HEROKUISH=false
   IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
-  verify_app_name "$APP"
   plugn trigger pre-deploy "$APP" "$IMAGE_TAG"
 
   is_image_herokuish_based "$IMAGE" "$APP" && DOKKU_HEROKUISH=true

--- a/plugins/scheduler-docker-local/subcommands/set
+++ b/plugins/scheduler-docker-local/subcommands/set
@@ -10,8 +10,8 @@ cmd-scheduler-docker-local-set() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
   local VALID_KEYS=("disable-chown")
+  verify_app_name "$APP"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then

--- a/plugins/storage/internal-functions
+++ b/plugins/storage/internal-functions
@@ -81,9 +81,8 @@ cmd-storage-list() {
   declare cmd="storage:list"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"
-
   local passed_phases="deploy"
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
+
   verify_app_name "$APP"
   dokku_log_quiet "$APP volume bind-mounts:"
   get_bind_mounts "$(get_phase_file_path "$passed_phases")"

--- a/plugins/storage/subcommands/mount
+++ b/plugins/storage/subcommands/mount
@@ -12,9 +12,6 @@ cmd-storage-mount() {
   declare APP="$1" MOUNT_PATH="$2"
   local passed_phases=(deploy run)
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
-  [[ -z "$MOUNT_PATH" ]] && dokku_log_fail "Please specify two paths delimited by colon."
-
   verify_app_name "$APP"
   verify_paths "$MOUNT_PATH"
   check_if_path_exists "$MOUNT_PATH" "$(get_phase_file_path "${passed_phases[@]}")" && dokku_log_fail "Mount path already exists."

--- a/plugins/storage/subcommands/unmount
+++ b/plugins/storage/subcommands/unmount
@@ -12,8 +12,6 @@ cmd-storage-unmount() {
   declare APP="$1" MOUNT_PATH="$2"
   local passed_phases=(deploy run)
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
-  [[ -z "$MOUNT_PATH" ]] && dokku_log_fail "Please specify two paths delimited by colon."
   verify_app_name "$APP"
   verify_paths "$MOUNT_PATH"
   check_if_path_exists "$MOUNT_PATH" "$(get_phase_file_path "${passed_phases[@]}")" || dokku_log_fail "Mount path does not exist."

--- a/plugins/tags/subcommands/create
+++ b/plugins/tags/subcommands/create
@@ -10,7 +10,6 @@ cmd-tags-create() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" IMAGE_TAG="$2"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
 
   local IMAGE_REPO=$(get_app_image_repo "$APP")

--- a/plugins/tags/subcommands/default
+++ b/plugins/tags/subcommands/default
@@ -9,7 +9,6 @@ cmd-tags-default() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
 
   local IMAGE_REPO=$(get_app_image_repo "$APP")

--- a/plugins/tags/subcommands/deploy
+++ b/plugins/tags/subcommands/deploy
@@ -9,7 +9,6 @@ cmd-tags-deploy() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" IMAGE_TAG="$2"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
 
   local IMAGE="$(get_app_image_name "$APP" "$IMAGE_TAG")"

--- a/plugins/tags/subcommands/destroy
+++ b/plugins/tags/subcommands/destroy
@@ -10,7 +10,6 @@ cmd-tags-destroy() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" IMAGE_TAG="$2"
 
-  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app to run the command on"
   verify_app_name "$APP"
 
   local IMAGE_REPO=$(get_app_image_repo "$APP")

--- a/plugins/tar/functions
+++ b/plugins/tar/functions
@@ -7,7 +7,6 @@ source "$PLUGIN_AVAILABLE_PATH/config/functions"
 tar_build() {
   declare desc="builds apps from tarball via command line"
   local APP="$1"
-  verify_app_name "$APP"
   shift 1
 
   # clean up after ourselves

--- a/tests/unit/buildpacks.bats
+++ b/tests/unit/buildpacks.bats
@@ -4,9 +4,11 @@ load test_helper
 
 setup() {
   global_setup
+  create_app
 }
 
 teardown() {
+  destroy_app
   global_teardown
 }
 
@@ -263,11 +265,6 @@ teardown() {
 }
 
 @test "(buildpacks) buildpacks deploy" {
-  create_app
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
   run /bin/bash -c "dokku buildpacks:set $TEST_APP https://github.com/dokku/buildpack-null"
   echo "output: $output"
   echo "status: $status"


### PR DESCRIPTION
This ensures subcommands don't call code on invalid apps, but also removes the need for duplicate internal checks for this information.