### PR TITLE
Allow vmware-based vm to work on big sur

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,10 +31,12 @@ Vagrant::configure("2") do |config|
 
   config.vm.provider :vmware_fusion do |v, override|
     v.vmx["memsize"] = BOX_MEMORY
+    v.ssh_info_public = true
   end
 
   config.vm.provider :vmware_desktop do |v, override|
     v.vmx["memsize"] = BOX_MEMORY
+    v.ssh_info_public = true
   end
 
   config.vm.define "empty", autostart: false


### PR DESCRIPTION
There seems to be an issue in Vmware that causes SSH to fail for new VMs.

https://github.com/hashicorp/vagrant/issues/12045

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
