### PR TITLE
Drop old doc link to gitlab ci docs

### DIFF
--- a/docs/template.html
+++ b/docs/template.html
@@ -185,7 +185,6 @@
             <a href="/{{NAME}}/community/plugins/" class="list-group-item">Plugins</a>
 
             <a href="#" class="list-group-item disabled">Community Tutorials</a>
-            <a href="/{{NAME}}/community/tutorials/deploying-with-gitlab-ci/" class="list-group-item">Deploying with Gitlab CI</a>
             <a href="/{{NAME}}/community/tutorials/run-on-external-volume/" class="list-group-item">Run on External Volume</a>
           </div>
         </div>


### PR DESCRIPTION
[ci skip]

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
