### PR TITLE
Add support for debug logging plugin trigger stderr and stdout

### DIFF
--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -74,13 +74,10 @@ func GetAppScheduler(appName string) string {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			b, _ := PlugnTriggerOutput("config-get", []string{appName, "DOKKU_SCHEDULER"}...)
-			value := strings.TrimSpace(string(b[:]))
-			if value != "" {
-				appScheduler = value
-			}
+			appScheduler = getAppScheduler(appName)
 		}()
 	}
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -93,6 +90,15 @@ func GetAppScheduler(appName string) string {
 		appScheduler = globalScheduler
 	}
 	return appScheduler
+}
+
+func getAppScheduler(appName string) string {
+	b, _ := PlugnTriggerOutput("config-get", []string{appName, "DOKKU_SCHEDULER"}...)
+	value := strings.TrimSpace(string(b[:]))
+	if value != "" {
+		return value
+	}
+	return ""
 }
 
 // GetGlobalScheduler fetchs the global scheduler

--- a/plugins/common/log.go
+++ b/plugins/common/log.go
@@ -110,7 +110,7 @@ func LogStderr(text string) {
 
 // LogDebug is the debug log formatter
 func LogDebug(text string) {
-	if os.Getenv("DOKKU_TRACE") == "" {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf(" ?     %s", text))
+	if os.Getenv("DOKKU_TRACE") == "1" {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf(" ?     %s", strings.TrimPrefix(text, " ?     ")))
 	}
 }


### PR DESCRIPTION

Previously, this could get a bit hazy when running the command within a goroutine. The new method creates pipes for writing stdout/stderr for each call to PluginTriggerOutput, then debug logs if if trace mode is on.

While it is a bit weird to read, it is more correct and should get rid of any parallel processing issues.