### PR TITLE
Update ps subcommands and triggers

### DIFF
--- a/plugins/ps/Makefile
+++ b/plugins/ps/Makefile
@@ -1,5 +1,5 @@
-SUBCOMMANDS = subcommands/inspect subcommands/rebuild subcommands/report subcommands/restart subcommands/restart-policy subcommands/restore subcommands/retire subcommands/scale subcommands/set subcommands/start subcommands/stop
-TRIGGERS = triggers/app-restart triggers/install triggers/post-app-clone triggers/post-app-rename triggers/post-create triggers/post-delete triggers/post-stop triggers/pre-deploy triggers/procfile-extract triggers/procfile-get-command triggers/procfile-remove triggers/report
+SUBCOMMANDS = subcommands/inspect subcommands/rebuild subcommands/report subcommands/restart subcommands/restore subcommands/retire subcommands/scale subcommands/set subcommands/start subcommands/stop
+TRIGGERS = triggers/app-restart triggers/core-post-deploy triggers/install triggers/post-app-clone triggers/post-app-clone-setup triggers/post-app-rename triggers/post-app-rename-setup triggers/post-create triggers/post-delete triggers/post-extract triggers/post-stop triggers/pre-deploy triggers/procfile-extract triggers/procfile-get-command triggers/procfile-remove triggers/report
 BUILD = commands subcommands triggers
 PLUGIN_NAME = ps
 


### PR DESCRIPTION
- There were missing trigger symlinks due to the the rewrite omitting them
- There was an extra symlink for a subcommand that was removed

This impacts the following:

- app clones/renames
- `ps:restore` calls sometimes not properly restoring apps that have been previously stopped once after an upgrade to 0.22.x
- skipped procfile checks after an extract