### PR TITLE
Allow named volume mounts in regex

### DIFF
--- a/plugins/storage/functions
+++ b/plugins/storage/functions
@@ -7,7 +7,7 @@ source "$PLUGIN_AVAILABLE_PATH/docker-options/functions"
 verify_paths() {
   declare desc="verifies storage paths"
   local -r passed_path=$1
-  if [[ "$passed_path" = \* ]]; then
+  if [[ "$passed_path" = /* ]]; then
     echo "$passed_path" | grep -qe '^/.*\:/' || dokku_log_fail "Storage path must be two valid paths divided by colon."
   else
     echo "$passed_path" | grep -qe '^[a-zA-Z0-9]\{1\}[a-zA-Z0-9_.-]\+\:\/' || dokku_log_fail "Volume name must be two characters or more. Volume name must not contain invalid characters. Storage path must be two valid paths divided by colon."

--- a/plugins/storage/functions
+++ b/plugins/storage/functions
@@ -6,7 +6,13 @@ source "$PLUGIN_AVAILABLE_PATH/docker-options/functions"
 
 verify_paths() {
   declare desc="verifies storage paths"
-  echo "$1" | grep -qe '^/.*\:/' || dokku_log_fail "Storage path must be two valid paths divided by colon."
+  local -r passed_path=$1
+  if [[ "$passed_path" = \* ]]; then
+    echo "$passed_path" | grep -qe '^/.*\:/' || dokku_log_fail "Storage path must be two valid paths divided by colon."
+  else
+    echo "$passed_path" | grep -qe '^[a-zA-Z0-9]\{1\}[a-zA-Z0-9_.-]\+\:\/' || dokku_log_fail "Volume name must be two characters or more. Volume name must not contain invalid characters. Storage path must be two valid paths divided by colon."
+  fi
+
 }
 
 check_if_path_exists() {

--- a/tests/unit/storage.bats
+++ b/tests/unit/storage.bats
@@ -53,4 +53,8 @@ teardown() {
   echo "status: $status"
   assert_output " !     Mount path does not exist."
   assert_failure
+  run /bin/bash -c "dokku storage:mount $TEST_APP mount_volume:/mount"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 }


### PR DESCRIPTION
**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.

- Allows the usage of named volumes in storage:mount by validating correctly in Regex
- Embeds [Docker rules on named volumes](https://github.com/moby/moby/blob/46cdcd206c56172b95ba5c77b827a722dab426c5/daemon/names/names.go#L6):
 - Min 2 characters long in name
 - Needs to follow schema `[a-zA-Z0-9][a-zA-Z0-9_.-]` 