### PR TITLE
Add ability to set client max body size via nginx:set

### DIFF
--- a/plugins/nginx-vhosts/command-functions
+++ b/plugins/nginx-vhosts/command-functions
@@ -42,6 +42,7 @@ cmd-nginx-report-single() {
     "--nginx-access-log-path: $(fn-nginx-access-log-path "$APP")"
     "--nginx-bind-address-ipv4: $(fn-plugin-property-get-default "nginx" "$APP" "bind-address-ipv4" "")"
     "--nginx-bind-address-ipv6: $(fn-plugin-property-get-default "nginx" "$APP" "bind-address-ipv6" "::")"
+    "--nginx-client-max-body-size: $(fn-plugin-property-get-default "nginx" "$APP" "client-max-body-size" "")"
     "--nginx-disable-custom-config: $(fn-plugin-property-get-default "nginx" "$APP" "disable-custom-config" "false")"
     "--nginx-error-log-path: $(fn-nginx-error-log-path "$APP")"
     "--nginx-hsts: $(fn-plugin-property-get-default "nginx" "$APP" "hsts" "true")"

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -63,6 +63,13 @@ fn-nginx-proxy-read-timeout() {
   fn-plugin-property-get-default "nginx" "$APP" "proxy-read-timeout" "60s"
 }
 
+fn-nginx-client-max-body-size() {
+  declare desc="get the configured client max body size"
+  declare APP="$1"
+
+  fn-plugin-property-get-default "nginx" "$APP" "client-max-body-size" ""
+}
+
 fn-nginx-error-log-path() {
   declare desc="get the configured access log path"
   declare APP="$1"
@@ -430,6 +437,7 @@ nginx_build_config() {
     local NGINX_ACCESS_LOG_FORMAT="$(fn-nginx-access-log-format "$APP")"
     local NGINX_ACCESS_LOG_PATH="$(fn-nginx-access-log-path "$APP")"
     local NGINX_ERROR_LOG_PATH="$(fn-nginx-error-log-path "$APP")"
+    local CLIENT_MAX_BODY_SIZE="$(fn-nginx-client-max-body-size "$APP")"
     local PROXY_READ_TIMEOUT="$(fn-nginx-proxy-read-timeout "$APP")"
     local PROXY_BUFFER_SIZE="$(fn-nginx-proxy-buffer-size "$APP")"
     local PROXY_BUFFERING="$(fn-nginx-proxy-buffering "$APP")"
@@ -486,6 +494,7 @@ nginx_build_config() {
         GRPC_SUPPORTED="$GRPC_SUPPORTED"
         DOKKU_APP_LISTEN_PORT="$DOKKU_APP_LISTEN_PORT" DOKKU_APP_LISTEN_IP="$DOKKU_APP_LISTEN_IP"
         APP_SSL_PATH="$APP_SSL_PATH" SSL_INUSE="$SSL_INUSE" SSL_SERVER_NAME="$SSL_SERVER_NAME"
+        CLIENT_MAX_BODY_SIZE="$CLIENT_MAX_BODY_SIZE"
         PROXY_READ_TIMEOUT="$PROXY_READ_TIMEOUT"
         PROXY_BUFFER_SIZE="$PROXY_BUFFER_SIZE"
         PROXY_BUFFERING="$PROXY_BUFFERING"

--- a/plugins/nginx-vhosts/subcommands/set
+++ b/plugins/nginx-vhosts/subcommands/set
@@ -9,13 +9,13 @@ cmd-nginx-set() {
   declare cmd="nginx:set"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("access-log-format" "access-log-path" "bind-address-ipv4" "bind-address-ipv6" "disable-custom-config" "error-log-path" "hsts" "hsts-include-subdomains" "hsts-preload" "hsts-max-age" "proxy-read-timeout" "proxy-buffer-size" "proxy-buffering" "proxy-buffers" "proxy-busy-buffers-size" "x-forwarded-for-value" "x-forwarded-port-value" "x-forwarded-proto-value")
+  local VALID_KEYS=("access-log-format" "access-log-path" "bind-address-ipv4" "bind-address-ipv6" "client-max-body-size" "disable-custom-config" "error-log-path" "hsts" "hsts-include-subdomains" "hsts-preload" "hsts-max-age" "proxy-read-timeout" "proxy-buffer-size" "proxy-buffering" "proxy-buffers" "proxy-busy-buffers-size" "x-forwarded-for-value" "x-forwarded-port-value" "x-forwarded-proto-value")
   verify_app_name "$APP"
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then
-    dokku_log_fail "Invalid key specified, valid keys include: access-log-format, access-log-path, bind-address-ipv4, bind-address-ipv6, disable-custom-config, error-log-path, hsts, hsts-include-subdomains, hsts-preload, hsts-max-age, proxy-read-timeout, proxy-buffer-size, proxy-buffering, proxy-buffers, proxy-busy-buffers-size, x-forwarded-for-value, x-forwarded-port-value, x-forwarded-proto-value"
+    dokku_log_fail "Invalid key specified, valid keys include: access-log-format, access-log-path, bind-address-ipv4, bind-address-ipv6, client-max-body-size, disable-custom-config, error-log-path, hsts, hsts-include-subdomains, hsts-preload, hsts-max-age, proxy-read-timeout, proxy-buffer-size, proxy-buffering, proxy-buffers, proxy-busy-buffers-size, x-forwarded-for-value, x-forwarded-port-value, x-forwarded-proto-value"
   fi
 
   if [[ -n "$VALUE" ]]; then

--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -38,6 +38,8 @@ server {
     proxy_set_header X-Forwarded-Proto {{ $.PROXY_X_FORWARDED_PROTO }};
     proxy_set_header X-Request-Start $msec;
   }
+
+  {{ if $.CLIENT_MAX_BODY_SIZE }}client_max_body_size {{ $.CLIENT_MAX_BODY_SIZE }};{{ end }}
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
   error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
@@ -101,6 +103,8 @@ server {
     proxy_set_header X-Forwarded-Proto {{ $.PROXY_X_FORWARDED_PROTO }};
     proxy_set_header X-Request-Start $msec;
   }
+
+  {{ if $.CLIENT_MAX_BODY_SIZE }}client_max_body_size {{ $.CLIENT_MAX_BODY_SIZE }};{{ end }}
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
   error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
@@ -138,6 +142,8 @@ server {
   location    / {
     grpc_pass  grpc://{{ $.APP }}-{{ $upstream_port }};
   }
+
+  {{ if $.CLIENT_MAX_BODY_SIZE }}client_max_body_size {{ $.CLIENT_MAX_BODY_SIZE }};{{ end }}
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 }
 {{ end }}{{ end }}
@@ -158,6 +164,8 @@ server {
   location    / {
     grpc_pass  grpc://{{ $.APP }}-{{ $upstream_port }};
   }
+
+  {{ if $.CLIENT_MAX_BODY_SIZE }}client_max_body_size {{ $.CLIENT_MAX_BODY_SIZE }};{{ end }}
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 }
 {{ end }}{{ end }}

--- a/tests/unit/nginx-vhosts_8.bats
+++ b/tests/unit/nginx-vhosts_8.bats
@@ -16,6 +16,40 @@ teardown() {
   global_teardown
 }
 
+@test "(nginx-vhosts) nginx:set client-max-body-size" {
+  deploy_app
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP client-max-body-size"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "client_max_body_size" 0
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP client-max-body-size 1m"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "client_max_body_size 1m;" 1
+}
+
 @test "(nginx-vhosts) nginx:set proxy-read-timeout" {
   deploy_app
 


### PR DESCRIPTION
This simplifies increasing upload size by making it a property, and is backwards compatible with installations that have set that in a custom file.
