### PR TITLE
Update ruby dependencies in test app

### DIFF
--- a/tests/apps/ruby/Gemfile
+++ b/tests/apps/ruby/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.1.5'
+ruby '2.6.2'
 
-gem 'sinatra', '~>1.4.8'
+gem 'sinatra', '~>2.1.0'
 gem 'thin'

--- a/tests/apps/ruby/Gemfile.lock
+++ b/tests/apps/ruby/Gemfile.lock
@@ -3,13 +3,17 @@ GEM
   specs:
     daemons (1.3.1)
     eventmachine (1.2.7)
-    rack (1.6.13)
-    rack-protection (1.5.5)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.3)
+    rack-protection (2.1.0)
       rack
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
+    ruby2_keywords (0.0.2)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
     thin (1.8.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -20,5 +24,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  sinatra (~> 1.4.8)
+  sinatra (~> 2.1.0)
   thin


### PR DESCRIPTION
These were not auto-upgraded by dependabot because of a hardcoded sinatra version.
