### PR TITLE
Switch to Github Actions for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,116 +1,13 @@
 version: 2.1
 
-commands:
-  init-tests:
-    description: "Setup dokku for testing"
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /home/circleci/project
-      - run:
-          name: resolve dokku.me
-          command: |
-            # dokku.me now resolves to 10.0.0.2. add 10.0.0.2/24 to ens4
-            # this is maybe eth0 on github
-            ifconfig
-            sudo ip addr add 10.0.0.2/24 broadcast 10.0.0.255 dev ens4
-      - run:
-          name:  install ci-dependencies
-          command: make ci-dependencies
-      - run:
-          name:  setup tests
-          command: ./tests/ci/setup.sh
-      - run:
-          name:  dokku cleanup:skip
-          command: echo 'export DOKKU_SKIP_CLEANUP=true' | sudo tee /home/dokku/.dokkurc/dokku_skip_cleanup
-      - run:
-          name:  dokku report
-          command: dokku report
-
-executors:
-  default:
-    machine:
-      image: ubuntu-1604:201903-01
-    working_directory: /home/circleci/project
-
 jobs:
-  build:
-    executor: default
+  noop:
+    docker:
+      - image: cimg/base:2020.01
     steps:
-      - checkout
-      - run:
-          name: build package
-          command: ./tests/ci/setup.sh build
-      - persist_to_workspace:
-          root: /home/circleci/project
-          paths:
-            - build
-      - store_artifacts:
-          path: /home/circleci/project/build/dokku.deb
-      - store_artifacts:
-          path: /home/circleci/project/build/dokku.rpm
-  docker-deploy-tests:
-    executor: default
-    steps:
-      - init-tests
-      - run:
-          name: run docker deploy tests
-          shell: /bin/bash
-          no_output_timeout: 20
-          command: |
-            ./tests/ci/setup.sh docker
-            DOKKU_SSH_PORT=3022 sudo -E make -e test-ci-docker
-  go-tests:
-    executor: default
-    parallelism: 4
-    steps:
-      - init-tests
-      - run:
-          name: run go tests
-          command: |
-            case $CIRCLE_NODE_INDEX  in
-              0) sudo -E make -e lint-ci go-tests ci-go-coverage ;;
-              1) sudo -E make -e deploy-test-checks-root deploy-test-config ;;
-              2) sudo -E make -e deploy-test-multi ;;
-              3) sudo -E make -e deploy-test-go-fail-predeploy deploy-test-go-fail-postdeploy ;;
-            esac
-      - store_artifacts:
-          path: ./coverage.out
-  test:
-    executor: default
-    parallelism: 4
-    steps:
-      - init-tests
-      - run:
-          name: run bats tests
-          command: |
-            if ! sudo -E make -e test-ci; then
-              sudo -E make tests-ci-retry-failed
-            fi
-          no_output_timeout: 60m
-          shell: /bin/bash
-      - run:
-          name: output oomkills
-          command: cat /var/log/syslog
-          when: on_fail
-      - store_artifacts:
-          path: ./test-results
-          destination: test-results
-      - store_test_results:
-          path: test-results
+      - run: echo "this is a noop"
 
 workflows:
-  workflow:
+  noop:
     jobs:
-      - build
-      - docker-deploy-tests:
-          requires:
-            - build
-            - test
-      - go-tests:
-          requires:
-            - build
-      - test:
-          requires:
-            - build
-            - go-tests
+      - noop

--- a/.github/commands/ci-run
+++ b/.github/commands/ci-run
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+main() {
+  declare FILE_NAME="$1"
+
+  mkdir -p test-results/bats
+  pushd tests/unit >/dev/null
+  bats --report-formatter junit --output ../../test-results/bats "$FILE_NAME.bats"
+  popd >/dev/null
+
+  ls -lah test-results/bats
+}
+
+main "$@"

--- a/.github/commands/ci-setup
+++ b/.github/commands/ci-setup
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "=====> resolve dokku.me"
+sudo apt -qq -y --no-install-recommends install net-tools
+# dokku.me now resolves to 10.0.0.2. add 10.0.0.2/24 to eth0
+ifconfig
+sudo ip addr add 10.0.0.2/24 broadcast 10.0.0.255 dev eth0
+
+echo "=====> install ci-dependencies"
+make ci-dependencies
+
+echo "=====> setup tests"
+./tests/ci/setup.sh
+
+echo "=====> dokku cleanup:skip"
+echo 'export DOKKU_SKIP_CLEANUP=true' | sudo tee /home/dokku/.dokkurc/dokku_skip_cleanup
+
+echo "=====> dokku report"
+dokku report

--- a/.github/commands/matrix
+++ b/.github/commands/matrix
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import json
+import os
+
+keys = ["index"]
+values = [[s.replace(".bats", "") for s in os.listdir("tests/unit/") if s.endswith(".bats")]]
+zi = zip(keys, values)
+data = json.dumps(dict(zi))
+print(data.replace(" ", ""))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,157 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-16.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    strategy:
+      fail-fast: true
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: build package
+      run: ./tests/ci/setup.sh build
+
+    - name: set matrix for build
+      id: set-matrix
+      run: |
+        json=$(python .github/commands/matrix)
+        echo $json
+        echo "::set-output name=matrix::$(echo "$json")"
+
+    - name: upload packages
+      uses: actions/upload-artifact@v2
+      with:
+        name: build
+        path: build
+
+  unit-tests:
+    name: unit.${{ matrix.index }}
+    needs: build
+    runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.build.outputs.matrix)}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: download packages
+      uses: actions/download-artifact@v1
+      with:
+        name: build
+
+    - name: ci-setup
+      run: ./.github/commands/ci-setup
+
+    # - name: start ssh session
+    #   uses: luchihoratiu/debug-via-ssh@main
+    #   with:
+    #     NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
+    #     SSH_PASS: ${{ secrets.SSH_PASS }}
+
+    - name: run ci
+      timeout-minutes: 30
+      run: sudo -E ./.github/commands/ci-run ${{ matrix.index }}
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: test-results-${{ matrix.index }}
+        path: test-results
+
+  docker-deploy-tests:
+    name: docker
+    needs: build
+    runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: download packages
+      uses: actions/download-artifact@v1
+      with:
+        name: build
+
+    - name: ci-setup
+      run: ./.github/commands/ci-setup
+
+    - name: test docker deploys
+      shell: bash
+      timeout-minutes: 20
+      run: |
+        ./tests/ci/setup.sh docker
+        DOKKU_SSH_PORT=3022 sudo -E make -e test-ci-docker
+
+  go-tests:
+    name: go.${{ matrix.index }}
+    needs: build
+    runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+      matrix:
+        index: [0, 1, 2, 3]
+    env:
+      GITHUB_NODE_INDEX: ${{ matrix.index }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: download packages
+      uses: actions/download-artifact@v1
+      with:
+        name: build
+
+    - name: ci-setup
+      run: ./.github/commands/ci-setup
+
+    - name: run go tests
+      run: |
+        export CIRCLE_SHA1=$GITHUB_SHA
+        echo "CODACY_TOKEN=$CODACY_TOKEN"
+        if [ "$CODACY_TOKEN" != "" ]; then
+          echo "Detected value for CODACY_TOKEN"
+        fi
+        case $GITHUB_NODE_INDEX in
+          0) sudo -E make -e lint-ci go-tests ci-go-coverage ;;
+          1) sudo -E make -e deploy-test-checks-root deploy-test-config ;;
+          2) sudo -E make -e deploy-test-multi ;;
+          3) sudo -E make -e deploy-test-go-fail-predeploy deploy-test-go-fail-postdeploy ;;
+        esac
+    - uses: actions/upload-artifact@v2
+      with:
+        name: coverage.${{ matrix.index }}
+        path: test-results/coverage
+
+  publish-test-results:
+    name: publish-test-results
+    needs: unit-tests
+    runs-on: ubuntu-16.04
+    # the build-and-test job might be skipped, we don't need to run this job then
+    if: success() || failure()
+
+    steps:
+    - name: download test-results
+      uses: actions/download-artifact@v2
+      with:
+        path: test-results
+
+    - name: Publish Unit Test Results
+      uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+      with:
+        check_name: Unit Test Results
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        files: test-results/**/*.xml
+        comment_on_pr: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "dokku dokku/hostname string $DOKKU_HOSTNAME" | debconf-set-selections 
       && cp /tmp/dhparam.pem /etc/nginx/dhparam.pem \
       && apt-get update -qq \
       && apt-get upgrade -qq -y \
-      && apt-get -qq -y --no-install-recommends install --only-upgrade openssl openssh-server \
+      && apt-get -qq -y --no-install-recommends --only-upgrade install openssl openssh-server \
       && apt-get -qq -y --no-install-recommends install rsync /tmp/dokku.deb \
       && apt-get purge -qq -y syslog-ng-core \
       && apt-get autoremove -qq -y \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Dokku
-[![Build Status](https://img.shields.io/circleci/project/github/dokku/dokku.svg?style=flat-square "Build Status")](https://circleci.com/gh/dokku/dokku/tree/master)
+[![Build Status](https://github.com/dokku/dokku/workflows/CI/badge.svg)](https://github.com/dokku/dokku/actions?query=workflow%3ACI)
 [![Ubuntu Package](https://img.shields.io/badge/package-ubuntu-brightgreen.svg?style=flat-square "Ubuntu Package")](https://packagecloud.io/dokku/dokku)
 [![Arch Package](https://img.shields.io/badge/package-arch-brightgreen.svg?style=flat-square "Arch Package")](https://aur.archlinux.org/packages/dokku/)
 [![IRC Network](https://img.shields.io/badge/irc-freenode-blue.svg?style=flat-square "IRC Freenode")](https://webchat.freenode.net/?channels=dokku)

--- a/common.mk
+++ b/common.mk
@@ -2,6 +2,8 @@ GO_ARGS ?=
 GO_PLUGIN_MAKE_TARGET ?= build
 GO_REPO_ROOT := /go/src/github.com/dokku/dokku
 BUILD_IMAGE := golang:1.15.6
+GO_BUILD_CACHE ?= /tmp/dokku-go-build-cache
+GO_MOD_CACHE ?= /tmp/dokku-go-mod-mod
 
 .PHONY: build-in-docker build clean src-clean
 
@@ -11,7 +13,8 @@ build-in-docker: clean
 	mkdir -p /tmp/dokku-go-build-cache
 	docker run --rm \
 		-v $$PWD/../..:$(GO_REPO_ROOT) \
-		-v /tmp/dokku-go-build-cache:/root/.cache \
+		-v $(GO_BUILD_CACHE):/root/.cache \
+		-v $(GO_MOD_CACHE):/go/pkg/mod \
 		-e PLUGIN_NAME=$(PLUGIN_NAME) \
 		-e GO111MODULE=on \
 		-w $(GO_REPO_ROOT)/plugins/$(PLUGIN_NAME) \

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -93,10 +93,10 @@ If Dokku was installed in a Debian or Ubuntu system, via `apt-get install dokku`
 
 ```shell
 # update your local apt cache
-sudo apt-get update
+sudo apt-get update -qq
 
 # update dokku and its dependencies
-sudo apt-get -qq -y install dokku herokuish sshcommand plugn gliderlabs-sigil
+sudo apt-get -qq -y --no-install-recommends install dokku herokuish sshcommand plugn gliderlabs-sigil dokku-update dokku-event-listener
 
 # or just upgrade every package:
 sudo apt-get upgrade

--- a/plugins/nginx-vhosts/dependencies
+++ b/plugins/nginx-vhosts/dependencies
@@ -55,8 +55,7 @@ trigger-nginx-vhosts-dependencies() {
       [[ "$ubuntu_year" -ge "16" ]] && exit 0
       [[ "$ubuntu_year" -eq "15" ]] && [[ "$ubuntu_month" -eq "10" ]] && exit 0
 
-      [[ -z "$CIRCLECI" ]] && apt-get -qq -y --no-install-recommends install software-properties-common python-software-properties
-      [[ -n "$CIRCLECI" ]] && aptitude install -q -y software-properties-common python-software-properties
+      apt-get -qq -y --no-install-recommends install software-properties-common python-software-properties
 
       add-apt-repository -y ppa:nginx/stable
       apt-get update -qq >/dev/null

--- a/tests/ci/setup.sh
+++ b/tests/ci/setup.sh
@@ -9,27 +9,37 @@ install_dependencies() {
   mkdir -p "$ROOT_DIR/build/"
   HEROKUISH_VERSION=$(grep HEROKUISH_VERSION "${ROOT_DIR}/Makefile" | head -n1 | cut -d' ' -f3)
   HEROKUISH_PACKAGE_NAME="herokuish_${HEROKUISH_VERSION}_amd64.deb"
-  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/herokuish_${HEROKUISH_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${HEROKUISH_PACKAGE_NAME}"
+  if [[ ! -f "$ROOT_DIR/build/${HEROKUISH_PACKAGE_NAME}" ]]; then
+    curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/herokuish_${HEROKUISH_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${HEROKUISH_PACKAGE_NAME}"
+  fi
 
   PLUGN_VERSION=$(grep PLUGN_VERSION "${ROOT_DIR}/Makefile" | head -n1 | cut -d' ' -f3)
   PLUGN_PACKAGE_NAME="plugn_${PLUGN_VERSION}_amd64.deb"
-  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/plugn_${PLUGN_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PLUGN_PACKAGE_NAME}"
+  if [[ ! -f "$ROOT_DIR/build/${PLUGN_PACKAGE_NAME}" ]]; then
+    curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/plugn_${PLUGN_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PLUGN_PACKAGE_NAME}"
+  fi
 
   SSHCOMMAND_VERSION=$(grep SSHCOMMAND_VERSION "${ROOT_DIR}/Makefile" | head -n1 | cut -d' ' -f3)
   SSHCOMMAND_PACKAGE_NAME="sshcommand_${SSHCOMMAND_VERSION}_amd64.deb"
-  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/sshcommand_${SSHCOMMAND_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${SSHCOMMAND_PACKAGE_NAME}"
+  if [[ ! -f "$ROOT_DIR/build/${SSHCOMMAND_PACKAGE_NAME}" ]]; then
+    curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/sshcommand_${SSHCOMMAND_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${SSHCOMMAND_PACKAGE_NAME}"
+  fi
 
   SIGIL_VERSION=$(grep SIGIL_VERSION "${ROOT_DIR}/deb.mk" | head -n1 | cut -d' ' -f3)
   SIGIL_PACKAGE_NAME="gliderlabs-sigil_${SIGIL_VERSION}_amd64.deb"
-  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/gliderlabs-sigil_${SIGIL_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${SIGIL_PACKAGE_NAME}"
+  if [[ ! -f "$ROOT_DIR/build/${SIGIL_PACKAGE_NAME}" ]]; then
+    curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/gliderlabs-sigil_${SIGIL_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${SIGIL_PACKAGE_NAME}"
+  fi
 
   PROCFILE_VERSION=$(grep PROCFILE_VERSION "${ROOT_DIR}/Makefile" | head -n1 | cut -d' ' -f3)
   PROCFILE_UTIL_PACKAGE_NAME="procfile-util_${PROCFILE_VERSION}_amd64.deb"
-  curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/procfile-util_${PROCFILE_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PROCFILE_UTIL_PACKAGE_NAME}"
+  if [[ ! -f "$ROOT_DIR/build/${PROCFILE_UTIL_PACKAGE_NAME}" ]]; then
+    curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/procfile-util_${PROCFILE_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PROCFILE_UTIL_PACKAGE_NAME}"
+  fi
 
   sudo add-apt-repository -y ppa:nginx/stable
   sudo apt-get update -qq
-  sudo apt-get -qq -y --no-install-recommends install cgroupfs-mount dos2unix jq nginx
+  sudo apt-get -qq -y --no-install-recommends install cgroupfs-mount dos2unix jq nginx debconf-utils
   sudo cp "${ROOT_DIR}/tests/dhparam.pem" /etc/nginx/dhparam.pem
 
   sudo dpkg -i "${ROOT_DIR}/build/$HEROKUISH_PACKAGE_NAME" \
@@ -58,13 +68,23 @@ install_dokku() {
     build_dokku
   fi
 
-  echo "dokku dokku/hostname string dokku.me" | sudo debconf-set-selections
-  echo "dokku dokku/key_file string /root/.ssh/id_rsa.pub" | sudo debconf-set-selections
-  echo "dokku dokku/nginx_enable boolean true" | sudo debconf-set-selections
-  echo "dokku dokku/skip_key_file boolean true" | sudo debconf-set-selections
-  echo "dokku dokku/vhost_enable boolean true" | sudo debconf-set-selections
-  echo "dokku dokku/web_config boolean false" | sudo debconf-set-selections
+  cat << EOF | sudo debconf-set-selections
+dokku dokku/hostname string dokku.me
+dokku dokku/key_file string /root/.ssh/id_rsa.pub
+dokku dokku/nginx_enable boolean true
+dokku dokku/skip_key_file boolean true
+dokku dokku/vhost_enable boolean true
+dokku dokku/web_config boolean false
+EOF
+
+  echo "-----> Start debconf selections"
+  sudo debconf-get-selections | grep ^dokku
+  echo "-----> End debconf selections"
+
+  sleep 5
+  echo "-----> Start install $(cat "${ROOT_DIR}/build/deb-filename") via dpkg"
   sudo TRACE=1 dpkg -i "$(cat "${ROOT_DIR}/build/deb-filename")"
+  echo "-----> End install $(cat "${ROOT_DIR}/build/deb-filename") via dpkg"
 }
 
 build_dokku_docker_image() {
@@ -94,7 +114,7 @@ check_container() {
   while true; do
     echo "$(date) [count: $cnt]: waiting for dokku startup"
     is_up=$(
-      docker exec -ti dokku ps -ef | grep "/usr/sbin/sshd -D" >/dev/null 2>&1
+      docker exec dokku ps -ef | grep "/usr/sbin/sshd -D" >/dev/null 2>&1
       echo $?
     )
     if [[ $is_up -eq 0 ]]; then

--- a/tests/unit/app-json.bats
+++ b/tests/unit/app-json.bats
@@ -1,5 +1,4 @@
 #!/usr/bin/env bats
-
 load test_helper
 
 setup() {
@@ -37,7 +36,7 @@ teardown() {
   CID=$(docker ps -a -q  -f "ancestor=dokku/${TEST_APP}" -f "label=dokku_phase_script=postdeploy")
   DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$TEST_APP")
   IMAGE_ID=$(docker commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" $CID dokku-test/${TEST_APP})
-  run /bin/bash -c "docker run --rm -ti $IMAGE_ID ls /app/postdeploy.test"
+  run /bin/bash -c "docker run --rm $IMAGE_ID ls /app/postdeploy.test"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/client.bats
+++ b/tests/unit/client.bats
@@ -23,9 +23,13 @@ teardown() {
 }
 
 @test "(client) no args should print help" {
-  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh | head -1 | grep -E 'Usage: dokku \[.+\] COMMAND <app>.*'"
+  # dokku container is not run with a TTY on Github Actions so we don't get normal output
+  # https://github.com/actions/runner/issues/241
+  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh"
   echo "output: $output"
   echo "status: $status"
+  assert_output_contains "Manage apps"
+  assert_output_contains "Manage buildpack settings for an app"
   assert_success
 }
 

--- a/tests/unit/nginx-vhosts_9.bats
+++ b/tests/unit/nginx-vhosts_9.bats
@@ -16,207 +16,160 @@ teardown() {
   global_teardown
 }
 
-@test "(nginx-vhosts) nginx:set proxy-read-timeout" {
+@test "(nginx-vhosts) logging" {
   deploy_app
 
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-read-timeout 45s"
+  run [ -a "/var/log/nginx/$TEST_APP-access.log" ]
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  run [ -a "/var/log/nginx/$TEST_APP-error.log" ]
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "45s;"
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-read-timeout"
+  run /bin/bash -c "dokku nginx:access-logs $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  run /bin/bash -c "dokku nginx:error-logs $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "45s;" 0
 }
 
-@test "(nginx-vhosts) nginx:set proxy-read-timeout (with SSL)" {
+@test "(nginx-vhosts) log-path" {
+  deploy_app
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP access-log-path off"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "off;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP access-log-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "off;" 0
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP error-log-path off"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "off;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP error-log-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "off;" 0
+}
+
+@test "(nginx-vhosts) access-log-format" {
+  deploy_app
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP access-log-format combined"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "-access.log combined;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP access-log-path off"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "off;"
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP access-log-format"
+  run /bin/bash -c "dokku nginx:set $TEST_APP access-log-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "-access.log;"
+}
+
+@test "(nginx-vhosts) nginx:build-config (with SSL and unrelated domain)" {
   setup_test_tls
+  add_domain "node-js-app.dokku.me"
+  add_domain "test.dokku.me"
   deploy_app
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-read-timeout 45s"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "45s;"
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-read-timeout"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "45s;" 0
+  dokku nginx:show-config $TEST_APP
+  assert_ssl_domain "node-js-app.dokku.me"
+  assert_http_redirect "http://test.dokku.me" "https://test.dokku.me:443/"
 }
 
-@test "(nginx-vhosts) nginx:set proxy-buffer-size" {
+@test "(nginx-vhosts) nginx:build-config (wildcard SSL)" {
+  setup_test_tls wildcard
+  add_domain "wildcard1.dokku.me"
+  add_domain "wildcard2.dokku.me"
   deploy_app
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffer-size 2k"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "proxy_buffer_size 2k;"
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffer-size"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "proxy_buffer_size 2k;" 0
-}
-
-@test "(nginx-vhosts) nginx:set proxy-buffering" {
-  deploy_app
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffering off"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "proxy_buffering off;"
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffering"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "proxy_buffering off;" 0
-}
-
-@test "(nginx-vhosts) nginx:set proxy-buffers" {
-  deploy_app
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffers \"64 4k\""
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "proxy_buffers 64 4k;"
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffers"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "proxy_buffers 64 4k;" 0
-}
-
-@test "(nginx-vhosts) nginx:set proxy-busy-buffers-size" {
-  deploy_app
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-busy-buffers-size 10k"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "proxy_busy_buffers_size 10k;"
-
-  run /bin/bash -c "dokku nginx:set $TEST_APP proxy-busy-buffers-size"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:build-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output_contains "proxy_busy_buffers_size 10k;" 0
+  dokku nginx:show-config $TEST_APP
+  assert_ssl_domain "wildcard1.dokku.me"
+  assert_ssl_domain "wildcard2.dokku.me"
 }


### PR DESCRIPTION
This change speeds up CI by switching to Github Actions, which allows us to increase parallelism and have runs complete in under 20 minutes. While we cannot (yet? ever?) target a restart of a single job, this at least allows us to avoid restarting jobs that take ~60 minutes to complete in favor of 10 minute (or less) job runs.

TODO:

- [x] Figure out issues with Codacy token being blank
- [x] Figure out race condition issues in debconf setting when running tests