### PR TITLE
Updated bootstrap.sh to not show when $DOKKU_TAG equals nothing

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,7 +22,11 @@ log-fail() {
 
 ensure-environment() {
   local FREE_MEMORY
-  echo "Preparing to install $DOKKU_TAG from $DOKKU_REPO..."
+  if [ ! $DOKKU_TAG ]; then
+    echo "Preparing to install $DOKKU_REPO..."
+  else
+    echo "Preparing to install $DOKKU_TAG from $DOKKU_REPO..."
+  fi
 
   hostname -f >/dev/null 2>&1 || {
     log-fail "This installation script requires that you have a hostname set for the instance. Please set a hostname for 127.0.0.1 in your /etc/hosts"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,7 +22,7 @@ log-fail() {
 
 ensure-environment() {
   local FREE_MEMORY
-  if [ ! $DOKKU_TAG ]; then
+  if [[ -z "$DOKKU_TAG" ]]; then
     echo "Preparing to install $DOKKU_REPO..."
   else
     echo "Preparing to install $DOKKU_TAG from $DOKKU_REPO..."


### PR DESCRIPTION
Sometimes when `$DOKKU_TAG` is nothing it will display `Preparing to install  from repo...` with an extra space between "install" and "from"
A `if` statement has been added to just show `Preparing to install repo...`