### PR TITLE
Switch to using uuidgen for unique app names

### DIFF
--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -10,7 +10,7 @@ PLUGIN_ENABLED_PATH=${PLUGIN_ENABLED_PATH:="$PLUGIN_PATH/enabled"}
 PLUGIN_CORE_PATH=${PLUGIN_CORE_PATH:="$DOKKU_LIB_ROOT/core-plugins"}
 PLUGIN_CORE_AVAILABLE_PATH=${PLUGIN_CORE_AVAILABLE_PATH:="$PLUGIN_CORE_PATH/available"}
 CUSTOM_TEMPLATE_SSL_DOMAIN=customssltemplate.dokku.me
-UUID=$(tr -dc 'a-z0-9' </dev/urandom | fold -w 32 | head -n 1)
+UUID=$(uuidgen)
 TEST_APP="rdmtestapp-${UUID}"
 TEST_NETWORK="test-network-${UUID}"
 SKIPPED_TEST_ERR_MSG="previous test failed! skipping remaining tests..."


### PR DESCRIPTION
`/dev/urandom` doesn't work on Github Actions. Prior to moving to github actions, lets ensure tests work on CircleCI as well.
