### PR TITLE
Switch to upstream bats-core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DOKKU_VERSION ?= master
 
 HEROKUISH_VERSION ?= 0.5.19
 PROCFILE_VERSION ?= 0.11.0
-PLUGN_VERSION ?= 0.6.0
+PLUGN_VERSION ?= 0.6.1
 SIGIL_VERSION ?= 0.6.0
 SSHCOMMAND_VERSION ?= 0.12.0
 SSHCOMMAND_URL ?= https://github.com/dokku/sshcommand/releases/download/v${SSHCOMMAND_VERSION}/sshcommand_${SSHCOMMAND_VERSION}_linux_x86_64.tgz

--- a/tests.mk
+++ b/tests.mk
@@ -7,7 +7,7 @@ ifneq ($(shell bats --version >/dev/null 2>&1 ; echo $$?),0)
 	brew install bats-core
 endif
 else
-	git clone https://github.com/josegonzalez/bats-core.git /tmp/bats
+	git clone https://github.com/bats-core/bats-core.git /tmp/bats
 	cd /tmp/bats && sudo ./install.sh /usr/local
 	rm -rf /tmp/bats
 endif
@@ -282,7 +282,7 @@ test: setup-deploy-tests lint unit-tests deploy-tests
 test-ci:
 	@mkdir -p test-results/bats
 	@cd tests/unit && echo "executing tests: $(shell cd tests/unit ; circleci tests glob *.bats | circleci tests split --split-by=timings --timings-type=classname | xargs)"
-	cd tests/unit && bats --formatter bats-format-junit -e -T -o ../../test-results/bats $(shell cd tests/unit ; circleci tests glob *.bats | circleci tests split --split-by=timings --timings-type=classname | xargs)
+	cd tests/unit && bats --report-formatter junit --timing -o ../../test-results/bats $(shell cd tests/unit ; circleci tests glob *.bats | circleci tests split --split-by=timings --timings-type=classname | xargs)
 
 tests-ci-retry-failed:
 	wget -qO /tmp/bats-retry.tgz https://github.com/josegonzalez/go-bats-retry/releases/download/v0.2.1/bats-retry_0.2.1_linux_x86_64.tgz


### PR DESCRIPTION
Bats core now has junit report formatting, so there is no need to continue using a fork.

Additionally, we update plugn to ensure we properly handle functions exported by bats-core (`readlinkf`).