### PR TITLE
Drop tmpdir environment variables when not running as dokku user

### DIFF
--- a/dokku
+++ b/dokku
@@ -88,10 +88,13 @@ if [[ "${args[0]}" =~ ^--.* ]]; then
 fi
 ! has_tty && DOKKU_QUIET_OUTPUT=1
 
-if [[ $(id -un) != "dokku" ]] && [[ ! $1 =~ plugin:* ]] && [[ $1 != "ssh-keys:add" ]] && [[ $1 != "ssh-keys:remove" ]]; then
-  export SSH_USER=$(id -un)
-  sudo -u dokku -E -H "$0" "$@"
-  exit $?
+if [[ $(id -un) != "dokku" ]]; then
+  unset TMP TMPDIR TEMP TEMPDIR
+  if [[ ! $1 =~ plugin:* ]] && [[ $1 != "ssh-keys:add" ]] && [[ $1 != "ssh-keys:remove" ]]; then
+    export SSH_USER=$(id -un)
+    sudo -u dokku -E -H "$0" "$@"
+    exit $?
+  fi
 fi
 
 if [[ $1 =~ ^plugin:.* && $1 != "plugin:help" && $1 != "plugin:list" ]] || [[ $1 == "ssh-keys:add" ]] || [[ $1 == "ssh-keys:remove" ]]; then


### PR DESCRIPTION
This ensures that tmpdir (and related calls) respect the system defaults for temporary directory access. Critically, changing user via 'sudo' will leave the root temp directory in place, which causes dokku to have undefined behavior when writing to temporary files under libpam-tmpdir.

This may break cases where users have redefined tmpdir or related variables, but those cases can be remedied by specifying a value for TMPDIR (and related variables) in /etc/default/dokku.

Closes #3149

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
