### PR TITLE
point to current testing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,21 +127,9 @@ requests:
 - backwards incompatible change (minor)
 - major feature (minor)
 
-### Test cases and codesniffs
+### Tests and testing
 
-Dokku tests require [bats](https://github.com/sstephenson/bats).
-To run the test cases locally use the following command:
-
-    make ci-dependencies
-    make unit-tests deploy-tests
-
-To run the shellcheck sniffs for Dokku coding standards:
-
-    make ci-dependencies
-    make lint
-
-The [testing docs](http://dokku.viewdocs.io/dokku/development/testing/)
-contains installation info for bats and shellcheck.
+Please read the [testing documentation](http://dokku.viewdocs.io/dokku/development/testing/)
 
 # Additional Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,9 +127,10 @@ requests:
 - backwards incompatible change (minor)
 - major feature (minor)
 
-### Tests and testing
+### Running tests locally
 
-Please read the [testing documentation](http://dokku.viewdocs.io/dokku/development/testing/)
+Please read the [testing docs](http://dokku.viewdocs.io/dokku/development/testing/),
+which contains test setup information as well as tips for running tests.
 
 # Additional Resources
 


### PR DESCRIPTION
The CONTRIBUTING.md had it's own tests/testing docs.. this changes it to point to the current documentation.

[ci skip]


