### PR TITLE
Log all triggers called by golang in trace output

### DIFF
--- a/plugins/common/subprocess.go
+++ b/plugins/common/subprocess.go
@@ -75,6 +75,7 @@ func (sc *ShellCmd) CombinedOutput() ([]byte, error) {
 
 // PlugnTrigger fire the given plugn trigger with the given args
 func PlugnTrigger(triggerName string, args ...string) error {
+	LogDebug(fmt.Sprintf("plugn trigger %s %v", triggerName, args))
 	return PlugnTriggerSetup(triggerName, args...).Run()
 }
 


### PR DESCRIPTION
Trace mode is useful for shell code, but less so for golang. Adding debug logging in golang for trigger calls makes it a little easier to see what is happening.
