### PR TITLE
Update deeplink to digitalocean marketplace image on homepage

### DIFF
--- a/docs/home.html
+++ b/docs/home.html
@@ -215,7 +215,7 @@
       </div>
 
       <div class="alternate-instructions">
-        <p>Hate <code>curl | bash</code>? See our official <a href="https://github.com/Azure/azure-quickstart-templates/tree/master/dokku-vm" target="_blank">Azure</a>, <a href="https://www.digitalocean.com/features/one-click-apps/dokku/" target="_blank">DigitalOcean</a>, and <a href="/{{NAME}}~{{REF}}/getting-started/install/dreamhost/">DreamHost Cloud</a> instructions.</p>
+        <p>Hate <code>curl | bash</code>? See our official <a href="https://github.com/Azure/azure-quickstart-templates/tree/master/dokku-vm" target="_blank">Azure</a>, <a href="https://marketplace.digitalocean.com/apps/dokku?refcode=fe06b043a083 target="_blank">DigitalOcean</a>, and <a href="/{{NAME}}~{{REF}}/getting-started/install/dreamhost/">DreamHost Cloud</a> instructions.</p>
         <p>Still no love? <a href="https://github.com/dokku/dokku/blob/master/CONTRIBUTING.md" target="_blank">Contributions welcome</a>!</a></p>
       </div>
     </div>


### PR DESCRIPTION
The images have changed location. Also add a referral code to make it possible to run Dokku tests without breaking the bank.
