### PR TITLE
Do not attempt to extract Procfile in ps:scale

### DIFF
--- a/plugins/ps/.gitignore
+++ b/plugins/ps/.gitignore
@@ -9,3 +9,4 @@
 /pre-*
 /procfile-*
 /app-restart
+/core-post-deploy

--- a/plugins/ps/subcommands.go
+++ b/plugins/ps/subcommands.go
@@ -121,21 +121,6 @@ func CommandScale(appName string, skipDeploy bool, processTuples []string) error
 	}
 
 	procfilePath := getProcfilePath(appName)
-	if !common.FileExists(procfilePath) {
-		extract := func() error {
-			image, err := common.GetDeployingAppImageName(appName, "", "")
-			if err != nil {
-				return nil
-			}
-
-			return extractProcfile(appName, image)
-		}
-
-		if err := common.SuppressOutput(extract); err != nil {
-			return err
-		}
-	}
-
 	if !hasScaleFile(appName) || common.FileExists(procfilePath) {
 		update := func() error {
 			return updateScalefile(appName, make(map[string]int))


### PR DESCRIPTION
The Procfile is now extracted in the pre-deploy step for every deploy and otherwise not removed. Thus, it should always exist when necessary - web will be scale to 1 automatically and it won't need to be present on future ps:scale calls since we'll have the scale file - and the command can execute faster.

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
