### PR TITLE
Change exit code when app does not exist

### DIFF
--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -245,14 +245,14 @@ func executeScript(appName string, image string, imageTag string, phase string) 
 
 	containerID, err := createdContainerID(appName, dockerArgs, image, script, phase)
 	if err != nil {
-		common.LogFail(fmt.Sprintf("Failed to create %s execution container: %s", phase, err.Error()))
+		return fmt.Errorf("Failed to create %s execution container: %s", phase, err.Error())
 	}
 
 	if !waitForExecution(containerID) {
 		common.LogInfo2Quiet(fmt.Sprintf("Start of %s %s task (%s) output", appName, phaseName, containerID[0:9]))
 		common.LogVerboseQuietContainerLogs(containerID)
 		common.LogInfo2Quiet(fmt.Sprintf("End of %s %s task (%s) output", appName, phaseName, containerID[0:9]))
-		common.LogFail(fmt.Sprintf("Execution of %s task failed: %s", phase, phaseName))
+		return fmt.Errorf("Execution of %s task failed: %s", phaseName, command)
 	}
 
 	common.LogInfo2Quiet(fmt.Sprintf("Start of %s %s task (%s) output", appName, phaseName, containerID[0:9]))
@@ -292,7 +292,7 @@ func executeScript(appName string, image string, imageTag string, phase string) 
 	containerCommitCmd.ShowOutput = false
 	containerCommitCmd.Command.Stderr = os.Stderr
 	if !containerCommitCmd.Execute() {
-		common.LogFail(fmt.Sprintf("Commiting of '%s' to image failed: %s", phase, command))
+		return fmt.Errorf("Commiting of '%s' to image failed: %s", phase, command)
 	}
 
 	return common.PlugnTrigger("scheduler-register-retired", []string{appName, containerID}...)

--- a/plugins/app-json/src/triggers/triggers.go
+++ b/plugins/app-json/src/triggers/triggers.go
@@ -36,6 +36,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/app-json/src/triggers/triggers.go
+++ b/plugins/app-json/src/triggers/triggers.go
@@ -32,7 +32,7 @@ func main() {
 		imageTag := flag.Arg(1)
 		err = appjson.TriggerPreDeploy(appName, imageTag)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {

--- a/plugins/apps/src/subcommands/subcommands.go
+++ b/plugins/apps/src/subcommands/subcommands.go
@@ -82,6 +82,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/apps/src/subcommands/subcommands.go
+++ b/plugins/apps/src/subcommands/subcommands.go
@@ -78,7 +78,7 @@ func main() {
 		appName := args.Arg(0)
 		err = apps.CommandUnlock(appName)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin subcommand call: %s", subcommand))
+		err = fmt.Errorf("Invalid plugin subcommand call: %s", subcommand)
 	}
 
 	if err != nil {

--- a/plugins/apps/src/triggers/triggers.go
+++ b/plugins/apps/src/triggers/triggers.go
@@ -37,7 +37,7 @@ func main() {
 		appName := flag.Arg(0)
 		err = apps.ReportSingleApp(appName, "", "")
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {

--- a/plugins/apps/src/triggers/triggers.go
+++ b/plugins/apps/src/triggers/triggers.go
@@ -41,6 +41,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/buildpacks/src/subcommands/subcommands.go
+++ b/plugins/buildpacks/src/subcommands/subcommands.go
@@ -76,6 +76,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/buildpacks/src/subcommands/subcommands.go
+++ b/plugins/buildpacks/src/subcommands/subcommands.go
@@ -72,7 +72,7 @@ func main() {
 		}
 		err = buildpacks.CommandSetProperty(appName, property, value)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin subcommand call: %s", subcommand))
+		err = fmt.Errorf("Invalid plugin subcommand call: %s", subcommand)
 	}
 
 	if err != nil {

--- a/plugins/buildpacks/src/triggers/triggers.go
+++ b/plugins/buildpacks/src/triggers/triggers.go
@@ -42,7 +42,7 @@ func main() {
 		appName := flag.Arg(0)
 		err = buildpacks.ReportSingleApp(appName, "", "")
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {

--- a/plugins/buildpacks/src/triggers/triggers.go
+++ b/plugins/buildpacks/src/triggers/triggers.go
@@ -46,6 +46,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -515,6 +515,14 @@ func isValidAppNameOld(appName string) error {
 	return errors.New("App name must begin with lowercase alphanumeric character, and cannot include uppercase characters, or colons")
 }
 
+type AppDoesNotExist struct {
+	appName string
+}
+
+func (err *AppDoesNotExist) Error() string {
+	return fmt.Sprintf("App %s does not exist", err.appName)
+}
+
 // VerifyAppName checks if an app conforming to either the old or new
 // naming conventions exists
 func VerifyAppName(appName string) error {
@@ -526,7 +534,7 @@ func VerifyAppName(appName string) error {
 
 	appRoot := AppRoot(appName)
 	if !DirectoryExists(appRoot) {
-		return fmt.Errorf("App %s does not exist", appName)
+		return &AppDoesNotExist{appName}
 	}
 
 	return nil

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -522,10 +522,13 @@ type AppDoesNotExist struct {
 	appName string
 }
 
+// ExitCode returns an exit code to use in case this error bubbles
+// up into an os.Exit() call
 func (err *AppDoesNotExist) ExitCode() int {
 	return 20
 }
 
+// Error returns a standard non-existent app error
 func (err *AppDoesNotExist) Error() string {
 	return fmt.Sprintf("App %s does not exist", err.appName)
 }

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -515,8 +515,15 @@ func isValidAppNameOld(appName string) error {
 	return errors.New("App name must begin with lowercase alphanumeric character, and cannot include uppercase characters, or colons")
 }
 
+// AppDoesNotExist wraps error to include the app name
+// and is used to distinguish between a normal error and an error
+// where the app is missing
 type AppDoesNotExist struct {
 	appName string
+}
+
+func (err *AppDoesNotExist) ExitCode() int {
+	return 20
 }
 
 func (err *AppDoesNotExist) Error() string {

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -150,13 +150,13 @@ dokku_log_fail_quiet() {
   if [[ -z "$DOKKU_QUIET_OUTPUT" ]]; then
     echo " !     $*" 1>&2
   fi
-  exit 1
+  exit ${DOKKU_FAIL_EXIT_CODE:=1}
 }
 
 dokku_log_fail() {
   declare desc="log fail formatter"
   echo " !     $*" 1>&2
-  exit 1
+  exit ${DOKKU_FAIL_EXIT_CODE:=1}
 }
 
 dokku_log_stderr() {

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -256,7 +256,7 @@ verify_app_name() {
     dokku_log_fail "App name must begin with lowercase alphanumeric character, and cannot include uppercase characters, colons, or underscores"
   fi
 
-  [[ ! -d "$DOKKU_ROOT/$APP" ]] && dokku_log_fail "App $APP does not exist"
+  [[ ! -d "$DOKKU_ROOT/$APP" ]] && DOKKU_FAIL_EXIT_CODE=20 dokku_log_fail "App $APP does not exist"
 
   return 0
 }

--- a/plugins/common/log.go
+++ b/plugins/common/log.go
@@ -8,10 +8,25 @@ import (
 	"strings"
 )
 
+// ErrWithExitCode wraps error and exposes an ExitCode method
+type ErrWithExitCode interface {
+	ExitCode() int
+}
+
 // LogFail is the failure log formatter
 // prints text to stderr and exits with status 1
 func LogFail(text string) {
 	fmt.Fprintln(os.Stderr, fmt.Sprintf(" !     %s", text))
+	os.Exit(1)
+}
+
+// LogFailWithError is the failure log formatter
+// prints text to stderr and exits with the specified exit code
+func LogFailWithError(err error) {
+	fmt.Fprintln(os.Stderr, fmt.Sprintf(" !     %s", err.Error()))
+	if errExit, ok := err.(ErrWithExitCode); ok {
+		os.Exit(errExit.ExitCode())
+	}
 	os.Exit(1)
 }
 

--- a/plugins/common/properties.go
+++ b/plugins/common/properties.go
@@ -16,7 +16,7 @@ import (
 func CommandPropertySet(pluginName, appName, property, value string, properties map[string]string, globalProperties map[string]bool) {
 	if appName != "--global" {
 		if err := VerifyAppName(appName); err != nil {
-			LogFail(err.Error())
+			LogFailWithError(err)
 		}
 	}
 	if appName == "--global" && !globalProperties[property] {
@@ -42,9 +42,8 @@ func CommandPropertySet(pluginName, appName, property, value string, properties 
 		PropertyWrite(pluginName, appName, property, value)
 	} else {
 		LogInfo2Quiet(fmt.Sprintf("Unsetting %s", property))
-		err := PropertyDelete(pluginName, appName, property)
-		if err != nil {
-			LogFail(err.Error())
+		if err := PropertyDelete(pluginName, appName, property); err != nil {
+			LogFailWithError(err)
 		}
 	}
 }

--- a/plugins/config/config.go
+++ b/plugins/config/config.go
@@ -137,9 +137,11 @@ func getEnvironment(appName string, merged bool) (env *Env) {
 	} else {
 		env, err = loadAppOrGlobalEnv(appName)
 	}
+
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
+
 	return env
 }
 

--- a/plugins/config/environment.go
+++ b/plugins/config/environment.go
@@ -77,7 +77,7 @@ func LoadMergedAppEnv(appName string) (env *Env, err error) {
 	}
 	global, err := LoadGlobalEnv()
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 	global.Merge(env)
 	global.filename = ""

--- a/plugins/config/src/commands/commands.go
+++ b/plugins/config/src/commands/commands.go
@@ -48,7 +48,7 @@ func main() {
 		appName := args.Arg(0)
 		err := config.CommandShow(appName, *global, *merged, *shell, *export)
 		if err != nil {
-			common.LogFail(err.Error())
+			common.LogFailWithError(err)
 		}
 	case "config:help":
 		usage()

--- a/plugins/config/src/subcommands/subcommands.go
+++ b/plugins/config/src/subcommands/subcommands.go
@@ -105,7 +105,7 @@ func main() {
 		keys := getKeys(args.Args(), *global)
 		err = config.CommandUnset(appName, keys, *global, *noRestart)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin subcommand call: %s", subcommand))
+		err = fmt.Errorf("Invalid plugin subcommand call: %s", subcommand)
 	}
 
 	if err != nil {

--- a/plugins/config/src/subcommands/subcommands.go
+++ b/plugins/config/src/subcommands/subcommands.go
@@ -109,6 +109,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/config/src/triggers/triggers.go
+++ b/plugins/config/src/triggers/triggers.go
@@ -36,6 +36,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/config/src/triggers/triggers.go
+++ b/plugins/config/src/triggers/triggers.go
@@ -27,12 +27,12 @@ func main() {
 	case "config-get":
 		appName := flag.Arg(0)
 		key := flag.Arg(1)
-		config.TriggerConfigGet(appName, key)
+		err = config.TriggerConfigGet(appName, key)
 	case "config-get-global":
 		key := flag.Arg(0)
-		config.TriggerConfigGetGlobal(key)
+		err = config.TriggerConfigGetGlobal(key)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {

--- a/plugins/cron/src/subcommands/subcommands.go
+++ b/plugins/cron/src/subcommands/subcommands.go
@@ -33,7 +33,7 @@ func main() {
 			err = cron.CommandReport(appName, *format, infoFlag)
 		}
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin subcommand call: %s", subcommand))
+		err = fmt.Errorf("Invalid plugin subcommand call: %s", subcommand)
 	}
 
 	if err != nil {

--- a/plugins/cron/src/subcommands/subcommands.go
+++ b/plugins/cron/src/subcommands/subcommands.go
@@ -37,6 +37,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/cron/src/triggers/triggers.go
+++ b/plugins/cron/src/triggers/triggers.go
@@ -32,6 +32,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/cron/src/triggers/triggers.go
+++ b/plugins/cron/src/triggers/triggers.go
@@ -28,7 +28,7 @@ func main() {
 		appName := flag.Arg(0)
 		err = cron.ReportSingleApp(appName, "", "")
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {

--- a/plugins/logs/src/commands/commands.go
+++ b/plugins/logs/src/commands/commands.go
@@ -54,7 +54,7 @@ func main() {
 		appName := args.Arg(0)
 		err := logs.CommandDefault(appName, *num, *ps, *tail, *quiet)
 		if err != nil {
-			common.LogFail(err.Error())
+			common.LogFailWithError(err)
 		}
 	case "logs:help":
 		usage()

--- a/plugins/logs/src/subcommands/subcommands.go
+++ b/plugins/logs/src/subcommands/subcommands.go
@@ -66,6 +66,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/logs/src/subcommands/subcommands.go
+++ b/plugins/logs/src/subcommands/subcommands.go
@@ -62,7 +62,7 @@ func main() {
 		args.Parse(os.Args[2:])
 		err = logs.CommandVectorStop()
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin subcommand call: %s", subcommand))
+		err = fmt.Errorf("Invalid plugin subcommand call: %s", subcommand)
 	}
 
 	if err != nil {

--- a/plugins/logs/src/triggers/triggers.go
+++ b/plugins/logs/src/triggers/triggers.go
@@ -38,6 +38,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/logs/src/triggers/triggers.go
+++ b/plugins/logs/src/triggers/triggers.go
@@ -34,7 +34,7 @@ func main() {
 		appName := flag.Arg(0)
 		err = logs.ReportSingleApp(appName, "", "")
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {

--- a/plugins/network/functions.go
+++ b/plugins/network/functions.go
@@ -12,7 +12,7 @@ import (
 )
 
 // attachAppToNetwork attaches a container to a network
-func attachAppToNetwork(containerID string, networkName string, appName string, phase string, processType string) {
+func attachAppToNetwork(containerID string, networkName string, appName string, phase string, processType string) error {
 	cmdParts := []string{
 		common.DockerBin(),
 		"network",
@@ -50,8 +50,10 @@ func attachAppToNetwork(containerID string, networkName string, appName string, 
 	_, err := attachCmd.Output()
 	if err != nil {
 		err = errors.New(strings.TrimSpace(stderr.String()))
-		common.LogFail(fmt.Sprintf("Unable to attach container to network: %v", err.Error()))
+		return fmt.Errorf("Unable to attach container to network: %v", err.Error())
 	}
+
+	return nil
 }
 
 // isConflictingPropertyValue returns true if the other attach property has a conflicting value

--- a/plugins/network/src/subcommands/subcommands.go
+++ b/plugins/network/src/subcommands/subcommands.go
@@ -72,6 +72,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/network/src/subcommands/subcommands.go
+++ b/plugins/network/src/subcommands/subcommands.go
@@ -68,7 +68,7 @@ func main() {
 		value := args.Arg(2)
 		err = network.CommandSet(appName, property, value)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin subcommand call: %s", subcommand))
+		err = fmt.Errorf("Invalid plugin subcommand call: %s", subcommand)
 	}
 
 	if err != nil {

--- a/plugins/network/src/triggers/triggers.go
+++ b/plugins/network/src/triggers/triggers.go
@@ -94,6 +94,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/network/src/triggers/triggers.go
+++ b/plugins/network/src/triggers/triggers.go
@@ -19,49 +19,49 @@ func main() {
 	var err error
 	switch trigger {
 	case "install":
-		network.TriggerInstall()
+		err = network.TriggerInstall()
 	case "network-build-config":
 		appName := flag.Arg(0)
-		network.BuildConfig(appName)
+		err = network.BuildConfig(appName)
 	case "network-compute-ports":
 		appName := flag.Arg(0)
 		processType := flag.Arg(1)
 		isHerokuishContainer := common.ToBool(flag.Arg(2))
-		network.TriggerNetworkComputePorts(appName, processType, isHerokuishContainer)
+		err = network.TriggerNetworkComputePorts(appName, processType, isHerokuishContainer)
 	case "network-config-exists":
 		appName := flag.Arg(0)
-		network.TriggerNetworkConfigExists(appName)
+		err = network.TriggerNetworkConfigExists(appName)
 	case "network-get-ipaddr":
 		appName := flag.Arg(0)
 		processType := flag.Arg(1)
 		containerID := flag.Arg(2)
-		network.TriggerNetworkGetIppaddr(appName, processType, containerID)
+		err = network.TriggerNetworkGetIppaddr(appName, processType, containerID)
 	case "network-get-listeners":
 		appName := flag.Arg(0)
 		processType := flag.Arg(1)
-		network.TriggerNetworkGetListeners(appName, processType)
+		err = network.TriggerNetworkGetListeners(appName, processType)
 	case "network-get-port":
 		appName := flag.Arg(0)
 		processType := flag.Arg(1)
 		containerID := flag.Arg(2)
 		isHerokuishContainer := common.ToBool(flag.Arg(3))
-		network.TriggerNetworkGetPort(appName, processType, containerID, isHerokuishContainer)
+		err = network.TriggerNetworkGetPort(appName, processType, containerID, isHerokuishContainer)
 	case "network-get-property":
 		appName := flag.Arg(0)
 		property := flag.Arg(1)
-		network.TriggerNetworkGetProperty(appName, property)
+		err = network.TriggerNetworkGetProperty(appName, property)
 	case "network-write-ipaddr":
 		appName := flag.Arg(0)
 		processType := flag.Arg(1)
 		containerIndex := flag.Arg(2)
 		ip := flag.Arg(3)
-		network.TriggerNetworkWriteIpaddr(appName, processType, containerIndex, ip)
+		err = network.TriggerNetworkWriteIpaddr(appName, processType, containerIndex, ip)
 	case "network-write-port":
 		appName := flag.Arg(0)
 		processType := flag.Arg(1)
 		containerIndex := flag.Arg(2)
 		port := flag.Arg(3)
-		network.TriggerNetworkWritePort(appName, processType, containerIndex, port)
+		err = network.TriggerNetworkWritePort(appName, processType, containerIndex, port)
 	case "post-app-clone-setup":
 		oldAppName := flag.Arg(0)
 		newAppName := flag.Arg(1)
@@ -76,21 +76,21 @@ func main() {
 		appName := flag.Arg(2)
 		phase := flag.Arg(3)
 		processType := flag.Arg(4)
-		network.TriggerPostContainerCreate(containerType, containerID, appName, phase, processType)
+		err = network.TriggerPostContainerCreate(containerType, containerID, appName, phase, processType)
 	case "post-create":
 		appName := flag.Arg(0)
-		network.TriggerPostCreate(appName)
+		err = network.TriggerPostCreate(appName)
 	case "post-delete":
 		appName := flag.Arg(0)
-		network.TriggerPostDelete(appName)
+		err = network.TriggerPostDelete(appName)
 	case "core-post-deploy":
 		appName := flag.Arg(0)
-		network.TriggerCorePostDeploy(appName)
+		err = network.TriggerCorePostDeploy(appName)
 	case "report":
 		appName := flag.Arg(0)
 		err = network.ReportSingleApp(appName, "", "")
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {

--- a/plugins/network/subcommands.go
+++ b/plugins/network/subcommands.go
@@ -79,7 +79,7 @@ func CommandExists(networkName string) error {
 	if exists {
 		common.LogInfo1Quiet("Network exists")
 	} else {
-		common.LogFail("Network does not exist")
+		return errors.New("Network does not exist")
 	}
 
 	return nil

--- a/plugins/network/triggers.go
+++ b/plugins/network/triggers.go
@@ -11,15 +11,16 @@ import (
 )
 
 // TriggerInstall runs the install step for the network plugin
-func TriggerInstall() {
+func TriggerInstall() error {
 	if err := common.PropertySetup("network"); err != nil {
-		common.LogFail(fmt.Sprintf("Unable to install the network plugin: %s", err.Error()))
+		return fmt.Errorf("Unable to install the network plugin: %s", err.Error())
 	}
 
 	apps, err := common.DokkuApps()
 	if err != nil {
-		return
+		return nil
 	}
+
 	for _, appName := range apps {
 		if common.PropertyExists("network", appName, "bind-all-interfaces") {
 			continue
@@ -36,10 +37,12 @@ func TriggerInstall() {
 			}
 		}
 	}
+
+	return nil
 }
 
 // TriggerNetworkComputePorts computes the ports for a given app container
-func TriggerNetworkComputePorts(appName string, processType string, isHerokuishContainer bool) {
+func TriggerNetworkComputePorts(appName string, processType string, isHerokuishContainer bool) error {
 	var dockerfilePorts []string
 	if !isHerokuishContainer {
 		dokkuDockerfilePorts := strings.Trim(config.GetWithDefault(appName, "DOKKU_DOCKERFILE_PORTS", ""), " ")
@@ -60,80 +63,91 @@ func TriggerNetworkComputePorts(appName string, processType string, isHerokuishC
 			ports = append(ports, port)
 		}
 	}
+
 	fmt.Println(strings.Join(ports, " "))
+	return nil
 }
 
 // TriggerNetworkConfigExists writes true or false to stdout whether a given app has network config
-func TriggerNetworkConfigExists(appName string) {
+func TriggerNetworkConfigExists(appName string) error {
 	if HasNetworkConfig(appName) {
 		fmt.Println("true")
-		return
+		return nil
 	}
 
 	fmt.Println("false")
+	return nil
 }
 
 // TriggerNetworkGetIppaddr writes the ipaddress to stdout for a given app container
-func TriggerNetworkGetIppaddr(appName string, processType string, containerID string) {
+func TriggerNetworkGetIppaddr(appName string, processType string, containerID string) error {
 	ipAddress := GetContainerIpaddress(appName, processType, containerID)
 	fmt.Println(ipAddress)
+	return nil
 }
 
 // TriggerNetworkGetListeners returns the listeners (host:port combinations) for a given app container
-func TriggerNetworkGetListeners(appName string, processType string) {
+func TriggerNetworkGetListeners(appName string, processType string) error {
 	if processType == "" {
 		common.LogWarn("Deprecated: Please specify a processType argument for the network-get-listeners plugin trigger")
 		processType = "web"
 	}
 	listeners := GetListeners(appName, processType)
 	fmt.Println(strings.Join(listeners, " "))
+	return nil
 }
 
 // TriggerNetworkGetPort writes the port to stdout for a given app container
-func TriggerNetworkGetPort(appName string, processType string, containerID string, isHerokuishContainer bool) {
+func TriggerNetworkGetPort(appName string, processType string, containerID string, isHerokuishContainer bool) error {
 	port := GetContainerPort(appName, processType, containerID, isHerokuishContainer)
 	fmt.Println(port)
+	return nil
 }
 
 // TriggerNetworkGetProperty writes the network property to stdout for a given app container
-func TriggerNetworkGetProperty(appName string, property string) {
+func TriggerNetworkGetProperty(appName string, property string) error {
 	defaultValue := GetDefaultValue(property)
 	value := common.PropertyGetDefault("network", appName, property, defaultValue)
 	fmt.Println(value)
+	return nil
 }
 
 // TriggerNetworkWriteIpaddr writes the ip to disk
-func TriggerNetworkWriteIpaddr(appName string, processType string, containerIndex string, ip string) {
+func TriggerNetworkWriteIpaddr(appName string, processType string, containerIndex string, ip string) error {
 	appRoot := common.AppRoot(appName)
 	filename := fmt.Sprintf("%v/IP.%v.%v", appRoot, processType, containerIndex)
 	f, err := os.Create(filename)
 	if err != nil {
-		common.LogFail(err.Error())
+		return err
 	}
 	defer f.Close()
 
 	ipBytes := []byte(ip)
 	_, err = f.Write(ipBytes)
 	if err != nil {
-		common.LogFail(err.Error())
+		return err
 	}
+
+	return nil
 }
 
 // TriggerNetworkWritePort writes the port to disk
-func TriggerNetworkWritePort(appName string, processType string, containerIndex string, port string) {
+func TriggerNetworkWritePort(appName string, processType string, containerIndex string, port string) error {
 	appRoot := common.AppRoot(appName)
 	filename := fmt.Sprintf("%v/PORT.%v.%v", appRoot, processType, containerIndex)
 	f, err := os.Create(filename)
 	if err != nil {
-		common.LogFail(err.Error())
+		return err
 	}
 	defer f.Close()
 
 	portBytes := []byte(port)
 	_, err = f.Write(portBytes)
 	if err != nil {
-		common.LogFail(err.Error())
+		return err
 	}
+
+	return nil
 }
 
 // TriggerPostAppCloneSetup creates new network files
@@ -170,75 +184,84 @@ func TriggerPostAppRenameSetup(oldAppName string, newAppName string) error {
 }
 
 // TriggerPostContainerCreate associates the container with a specified network
-func TriggerPostContainerCreate(containerType string, containerID string, appName string, phase string, processType string) {
+func TriggerPostContainerCreate(containerType string, containerID string, appName string, phase string, processType string) error {
 	if containerType != "app" {
-		return
+		return nil
+
 	}
 
 	property := "attach-post-create"
 	defaultValue := GetDefaultValue(property)
 	networkName := common.PropertyGetDefault("network", appName, property, defaultValue)
 	if networkName == "" {
-		return
+		return nil
+
 	}
 
 	exists, err := networkExists(networkName)
 	if err != nil {
-		common.LogFail(err.Error())
+		return err
 	}
 
 	if !exists {
-		common.LogFail(fmt.Sprintf("Network %v does not exist", networkName))
+		return fmt.Errorf("Network %v does not exist", networkName)
 	}
 
-	attachAppToNetwork(containerID, networkName, appName, phase, processType)
+	return attachAppToNetwork(containerID, networkName, appName, phase, processType)
 }
 
 // TriggerPostCreate sets bind-all-interfaces to false by default
-func TriggerPostCreate(appName string) {
+func TriggerPostCreate(appName string) error {
 	err := common.PropertyWrite("network", appName, "bind-all-interfaces", "false")
 	if err != nil {
 		common.LogWarn(err.Error())
 	}
+
+	return nil
 }
 
 // TriggerPostDelete destroys the network property for a given app container
-func TriggerPostDelete(appName string) {
+func TriggerPostDelete(appName string) error {
 	err := common.PropertyDestroy("network", appName)
 	if err != nil {
-		common.LogFail(err.Error())
+		return err
 	}
+
+	return nil
 }
 
 // TriggerCorePostDeploy associates the container with a specified network
-func TriggerCorePostDeploy(appName string) {
+func TriggerCorePostDeploy(appName string) error {
 	property := "attach-post-deploy"
 	defaultValue := GetDefaultValue(property)
 	networkName := common.PropertyGetDefault("network", appName, property, defaultValue)
 	if networkName == "" {
-		return
+		return nil
 	}
 
 	common.LogInfo1Quiet(fmt.Sprintf("Associating app with network %s", networkName))
 	containerIDs, err := common.GetAppRunningContainerIDs(appName, "")
 	if err != nil {
-		common.LogFail(err.Error())
+		return err
 	}
 
 	exists, err := networkExists(networkName)
 	if err != nil {
-		common.LogFail(err.Error())
+		return err
 	}
 
 	if !exists {
-		common.LogFail(fmt.Sprintf("Network %v does not exist", networkName))
+		return fmt.Errorf("Network %v does not exist", networkName)
 	}
 
 	for _, containerID := range containerIDs {
 		processType, err := common.DockerInspect(containerID, "{{ index .Config.Labels \"com.dokku.process-type\"}}")
 		if err != nil {
-			common.LogFail(err.Error())
+			return err
 		}
-		attachAppToNetwork(containerID, networkName, appName, "deploy", processType)
+		if err := attachAppToNetwork(containerID, networkName, appName, "deploy", processType); err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/plugins/proxy/src/subcommands/subcommands.go
+++ b/plugins/proxy/src/subcommands/subcommands.go
@@ -83,7 +83,7 @@ func main() {
 		proxyType := args.Arg(1)
 		err = proxy.CommandSet(appName, proxyType)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin subcommand call: %s", subcommand))
+		err = fmt.Errorf("Invalid plugin subcommand call: %s", subcommand)
 	}
 
 	if err != nil {

--- a/plugins/proxy/src/subcommands/subcommands.go
+++ b/plugins/proxy/src/subcommands/subcommands.go
@@ -87,6 +87,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/proxy/src/triggers/triggers.go
+++ b/plugins/proxy/src/triggers/triggers.go
@@ -38,6 +38,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/proxy/src/triggers/triggers.go
+++ b/plugins/proxy/src/triggers/triggers.go
@@ -20,21 +20,21 @@ func main() {
 	switch trigger {
 	case "proxy-is-enabled":
 		appName := flag.Arg(0)
-		proxy.TriggerProxyIsEnabled(appName)
+		err = proxy.TriggerProxyIsEnabled(appName)
 	case "proxy-type":
 		appName := flag.Arg(0)
-		proxy.TriggerProxyType(appName)
+		err = proxy.TriggerProxyType(appName)
 	case "post-certs-remove":
 		appName := flag.Arg(0)
-		proxy.TriggerPostCertsRemove(appName)
+		err = proxy.TriggerPostCertsRemove(appName)
 	case "post-certs-update":
 		appName := flag.Arg(0)
-		proxy.TriggerPostCertsUpdate(appName)
+		err = proxy.TriggerPostCertsUpdate(appName)
 	case "report":
 		appName := flag.Arg(0)
 		err = proxy.ReportSingleApp(appName, "", "")
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {

--- a/plugins/ps/src/subcommands/subcommands.go
+++ b/plugins/ps/src/subcommands/subcommands.go
@@ -86,7 +86,7 @@ func main() {
 		appName := args.Arg(0)
 		err = ps.CommandStop(appName, *allApps, *parallelCount)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin subcommand call: %s", subcommand))
+		err = fmt.Errorf("Invalid plugin subcommand call: %s", subcommand)
 	}
 
 	if err != nil {

--- a/plugins/ps/src/subcommands/subcommands.go
+++ b/plugins/ps/src/subcommands/subcommands.go
@@ -90,6 +90,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/ps/src/triggers/triggers.go
+++ b/plugins/ps/src/triggers/triggers.go
@@ -75,7 +75,7 @@ func main() {
 		appName := flag.Arg(0)
 		err = ps.ReportSingleApp(appName, "", "")
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {

--- a/plugins/ps/src/triggers/triggers.go
+++ b/plugins/ps/src/triggers/triggers.go
@@ -79,6 +79,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/repo/src/subcommands/subcommands.go
+++ b/plugins/repo/src/subcommands/subcommands.go
@@ -29,7 +29,7 @@ func main() {
 		appName := args.Arg(0)
 		err = repo.CommandPurgeCache(appName)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin subcommand call: %s", subcommand))
+		err = fmt.Errorf("Invalid plugin subcommand call: %s", subcommand)
 	}
 
 	if err != nil {

--- a/plugins/repo/src/subcommands/subcommands.go
+++ b/plugins/repo/src/subcommands/subcommands.go
@@ -33,6 +33,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/repo/src/triggers/triggers.go
+++ b/plugins/repo/src/triggers/triggers.go
@@ -25,7 +25,7 @@ func main() {
 		appName := flag.Arg(0)
 		err = repo.PurgeCache(appName)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {

--- a/plugins/repo/src/triggers/triggers.go
+++ b/plugins/repo/src/triggers/triggers.go
@@ -29,6 +29,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/resource/src/subcommands/subcommands.go
+++ b/plugins/resource/src/subcommands/subcommands.go
@@ -88,7 +88,7 @@ func main() {
 		appName := args.Arg(0)
 		err = resource.CommandReserveClear(appName, *processType)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin subcommand call: %s", subcommand))
+		err = fmt.Errorf("Invalid plugin subcommand call: %s", subcommand)
 	}
 
 	if err != nil {

--- a/plugins/resource/src/subcommands/subcommands.go
+++ b/plugins/resource/src/subcommands/subcommands.go
@@ -92,6 +92,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/resource/src/triggers/triggers.go
+++ b/plugins/resource/src/triggers/triggers.go
@@ -49,6 +49,6 @@ func main() {
 	}
 
 	if err != nil {
-		common.LogFail(err.Error())
+		common.LogFailWithError(err)
 	}
 }

--- a/plugins/resource/src/triggers/triggers.go
+++ b/plugins/resource/src/triggers/triggers.go
@@ -45,7 +45,7 @@ func main() {
 		key := flag.Arg(3)
 		err = resource.TriggerResourceGetProperty(appName, processType, resourceType, key)
 	default:
-		common.LogFail(fmt.Sprintf("Invalid plugin trigger call: %s", trigger))
+		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This will allow wrappers around dokku to avoid needing two calls to dokku - one for apps:exists, the other for the command you want to run itself - to see if the app does not exist or if the error was something else.