### PR TITLE
Add note about the dokku user cron being overwritten by Dokku

### DIFF
--- a/docs/appendices/0.23.0-migration-guide.md
+++ b/docs/appendices/0.23.0-migration-guide.md
@@ -4,3 +4,4 @@
 
 - The `plugin:list` command no longer outputs the version for the `plugn` binary.
 - Users building docker images that run Dokku will need to use a new sudoer wrapper for the `docker-image-labeler` binary to work correctly. A reference version has been placed in the `docker` skeleton directory. This should only impact platform developers, and users of our Docker image will already have the file available.
+- The `dokku` user's cron is now in use by Dokku itself. Customizations will be overwritten. Users are encouraged to use a cron entry in `/etc/cron.d/dokku` to avoid this issue.

--- a/docs/processes/scheduled-cron-tasks.md
+++ b/docs/processes/scheduled-cron-tasks.md
@@ -141,7 +141,7 @@ For tasks that will properly resume, you *should* use the above method, as runni
 
 Regularly scheduled tasks can be a bit of a pain with Dokku. The following are general recommendations to follow to help ensure successful task runs.
 
-- Use the `dokku` user's crontab.
+- Use the `dokku` user in your cron entry.
   - If you do not, the `dokku` binary will attempt to execute with `sudo`, and your cron run with fail with `sudo: no tty present and no askpass program specified`.
 - Add a `MAILTO` environment variable to ship cron emails to yourself.
 - Add a `PATH` environment variable or specify the full path to binaries on the host.


### PR DESCRIPTION
This is a BC-incompatible change introduced by 0.23.0.