### PR TITLE
Invalid link to Herokuish Buildpack Deployment in Cloud Native Buildpacks

### DIFF
--- a/docs/deployment/methods/cloud-native-buildpacks.md
+++ b/docs/deployment/methods/cloud-native-buildpacks.md
@@ -5,7 +5,7 @@
 ```
 buildpacks:set-property [--global|<app>] <key> <value>  # Set or clear a buildpacks property for an app
 ```
-Cloud Native Buildpacks are an evolution over the Buildpacks technology provided by the Herokuish builder. See the [herokuish buildpacks documentation](/docs/deployment/methods/herokuish.md) for more information on how to clear buildpack build cache for an application.
+Cloud Native Buildpacks are an evolution over the Buildpacks technology provided by the Herokuish builder. See the [herokuish buildpacks documentation](/docs/deployment/methods/herokuish-buildpacks.md) for more information on how to clear buildpack build cache for an application.
 
 > Warning: This functionality uses the `pack` cli from the [Cloud Native Buildpacks](https://buildpacks.io) project to build apps. As the integration is experimental in Dokku, it is likely to change over time.
 


### PR DESCRIPTION
The documentation of [Cloud Native Buildpacks](https://github.com/dokku/dokku/blob/master/docs/deployment/methods/cloud-native-buildpacks.md) contains a link to [Herokuish Buildpack Deployment](https://github.com/dokku/dokku/blob/master/docs/deployment/methods/herokuish-buildpacks.md). The link redirects to an invalid url and causes 404.

http://dokku.viewdocs.io/dokku/deployment/methods/cloud-native-buildpacks/