### PR TITLE
Fix generation of crontab

### DIFF
--- a/plugins/cron/functions.go
+++ b/plugins/cron/functions.go
@@ -33,7 +33,7 @@ func (t templateCommand) CronCommand() string {
 		return t.AltCommand
 	}
 
-	return fmt.Sprintf("dokku --rm run --cron-id %s %s", t.ID, t.App, t.Command)
+	return fmt.Sprintf("dokku --rm run --cron-id %s %s %s", t.ID, t.App, t.Command)
 }
 
 func fetchCronEntries(appName string) ([]templateCommand, error) {


### PR DESCRIPTION
There was a missing placeholder in the template string.
That caused that `%!(EXTRA string=...` is added to the crontab file which causes commands to fail.

(I did not yet test this. If you can do it, fine, otherwise I will try to test tomorrow.)