### PR TITLE
Implement heroku's postdeploy deployment task

### DIFF
--- a/docs/advanced-usage/deployment-tasks.md
+++ b/docs/advanced-usage/deployment-tasks.md
@@ -24,6 +24,12 @@ Each "phase" has different expectations and limitations:
     - Example use-cases
         - Notifying slack that your app is deployed
         - Coordinating traffic routing with a central load balancer
+- `app.json`: `scripts.postdeploy`
+    - When to use: This should be used when you wish to run a command _once_, after the app is created and not on subsequent deploys to the app.
+    - Are changes committed to the image at this phase: No
+    - Example use-cases
+        - Setting up OAuth clients and DNS
+        - Loading seed/test data into the app’s test database
 - `Procfile`: `release`
     - When to use: This should be used in conjunction with external systems to signal the completion of your app image build.
     - Are changes committed to the image at this phase: No
@@ -44,6 +50,7 @@ Dokku provides limited support for the `app.json` manifest from Heroku (document
 
 - `scripts.dokku.predeploy`: This is run _after_ an app's docker image is built, but _before_ any containers are scheduled. Changes made to your image are committed at this phase.
 - `scripts.dokku.postdeploy`: This is run _after_ an app's containers are scheduled. Changes made to your image are *not* committed at this phase.
+- `scripts.postdeploy`: This is run _after_ an app's containers are scheduled. Changes made to your image are *not* committed at this phase.
 
 For buildpack-based deployments, the location of the `app.json` file should be at the root of your repository. Dockerfile-based app deploys should have the `app.json` in the configured `WORKDIR` directory; otherwise Dokku defaults to the buildpack app behavior of looking in `/app`.
 
@@ -57,7 +64,8 @@ The following is an example `app.json` file. Please note that only the `scripts.
     "dokku": {
       "predeploy": "touch /app/predeploy.test",
       "postdeploy": "curl https://some.external.api.service.com/deployment?state=success"
-    }
+    },
+    "postdeploy": "curl https://some.external.api.service.com/created?state=success"
   }
 }
 ```

--- a/plugins/app-json/appjson.go
+++ b/plugins/app-json/appjson.go
@@ -14,6 +14,7 @@ type AppJSON struct {
 			Predeploy  string `json:"predeploy"`
 			Postdeploy string `json:"postdeploy"`
 		} `json:"dokku"`
+		Postdeploy string `json:"postdeploy"`
 	} `json:"scripts"`
 }
 

--- a/plugins/app-json/triggers.go
+++ b/plugins/app-json/triggers.go
@@ -1,6 +1,7 @@
 package appjson
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -9,16 +10,16 @@ import (
 
 // TriggerInstall initializes app restart policies
 func TriggerInstall() error {
+	if err := common.PropertySetup("common"); err != nil {
+		return fmt.Errorf("Unable to install the common plugin: %s", err.Error())
+	}
+
 	directory := filepath.Join(common.MustGetEnv("DOKKU_LIB_ROOT"), "data", "app-json")
 	if err := os.MkdirAll(directory, 0755); err != nil {
 		return err
 	}
 
-	if err := common.SetPermissions(directory, 0755); err != nil {
-		return err
-	}
-
-	return nil
+	return common.SetPermissions(directory, 0755)
 }
 
 // TriggerPostDelete destroys the app-json data for a given app container
@@ -41,10 +42,7 @@ func TriggerPostDeploy(appName string, imageTag string) error {
 		return err
 	}
 
-	if err := executeScript(appName, image, imageTag, "postdeploy"); err != nil {
-		return err
-	}
-	return nil
+	return executeScript(appName, image, imageTag, "postdeploy")
 }
 
 // TriggerPreDeploy is a trigger to execute predeploy and release deployment tasks
@@ -65,5 +63,19 @@ func TriggerPreDeploy(appName string, imageTag string) error {
 	if err := executeScript(appName, image, imageTag, "release"); err != nil {
 		return err
 	}
-	return nil
+
+	if common.PropertyGet("common", appName, "deployed") == "true" {
+		return nil
+	}
+
+	// Ensure that a failed postdeploy does not trigger twice
+	if common.PropertyGet("app-json", appName, "heroku.postdeploy") == "executed" {
+		return nil
+	}
+
+	if err := common.PropertyWrite("app-json", appName, "heroku.postdeploy", "executed"); err != nil {
+		return err
+	}
+
+	return executeScript(appName, image, imageTag, "heroku.postdeploy")
 }

--- a/tests/unit/app-json.bats
+++ b/tests/unit/app-json.bats
@@ -18,7 +18,7 @@ teardown() {
 }
 
 @test "(app-json) app.json scripts" {
-  run deploy_app nodejs-express
+  run deploy_app python
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -46,6 +46,16 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+}
+
+
+@test "(app-json) app.json scripts postdeploy" {
+  run deploy_app python dokku@dokku.me:$TEST_APP add_postdeploy_command
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "touch /app/release.test" 2
+  assert_output_contains "python3 release.py" 2
 }
 
 @test "(app-json) app.json scripts missing" {

--- a/tests/unit/app-json.bats
+++ b/tests/unit/app-json.bats
@@ -54,8 +54,8 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains "touch /app/release.test" 2
-  assert_output_contains "python3 release.py" 2
+  assert_output_contains "touch /app/heroku-postdeploy.test"
+  assert_output_contains "python3 release.py"
 }
 
 @test "(app-json) app.json scripts missing" {

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -514,6 +514,17 @@ add_release_command() {
   echo "release: touch /app/release.test" >>"$APP_REPO_DIR/Procfile"
 }
 
+
+add_postdeploy_command() {
+  local APP="$1"
+  local APP_REPO_DIR="$2"
+  [[ -z "$APP" ]] && local APP="$TEST_APP"
+  touch "$APP_REPO_DIR/app.json"
+  contents=$(jq '.scripts.postdeploy = "touch /app/heroku-postdeploy.test"' "$APP_REPO_DIR/app.json")
+  echo "${contents}" > "$APP_REPO_DIR/app.json"
+}
+
+
 add_requirements_txt() {
   local APP="$1"
   local APP_REPO_DIR="$2"

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -514,16 +514,14 @@ add_release_command() {
   echo "release: touch /app/release.test" >>"$APP_REPO_DIR/Procfile"
 }
 
-
 add_postdeploy_command() {
   local APP="$1"
   local APP_REPO_DIR="$2"
   [[ -z "$APP" ]] && local APP="$TEST_APP"
   touch "$APP_REPO_DIR/app.json"
   contents=$(jq '.scripts.postdeploy = "touch /app/heroku-postdeploy.test"' "$APP_REPO_DIR/app.json")
-  echo "${contents}" > "$APP_REPO_DIR/app.json"
+  echo "${contents}" >"$APP_REPO_DIR/app.json"
 }
-
 
 add_requirements_txt() {
   local APP="$1"


### PR DESCRIPTION
This occurs during the postdeploy on the first deploy of an app, mimicking heroku. It currently happens ~_before_ the `postdeploy` and `release` phases. We'll need to verify that this is when it should happen, as it may need to happen _after_ the release.~ after the `release` task, during the `pre-deploy` trigger, which more or less mimics the `release` phase.

This also makes me think that we should refactor Dokku internals to properly represent build/release/run, but that would be a HEAVY bc-break that gives me a headache. Probably a problem for next year @savant.

- [x] Add tests
- [x] Verify order