### PR TITLE
Fix doc link and add 0.24.0 appendix to migration guides

### DIFF
--- a/docs/deployment/methods/git.md
+++ b/docs/deployment/methods/git.md
@@ -146,7 +146,7 @@ Finally, certain images may require a custom build context in order for `ONBUILD
 dokku git:from-image --build-dir path/to/build node-js-app dokku/node-js-getting-started:latest "Camila" "camila@example.com"
 ```
 
-See the [dockerfile documentation](/docs/deployment/methods/dockerfiles.md) to learn about the different ways to configure Dockerfile-based deploys.
+See the [dockerfile documentation](/docs/deployment/builders/dockerfiles.md) to learn about the different ways to configure Dockerfile-based deploys.
 
 ### Initializing an app repository from an archive file
 

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -19,6 +19,7 @@ Docker releases updates periodically to their engine. We recommend reading their
 
 Before upgrading, check the migration guides to get comfortable with new features and prepare your deployment to be upgraded.
 
+- [Upgrading to 0.24](/docs/appendices/0.24.0-migration-guide.md)
 - [Upgrading to 0.23](/docs/appendices/0.23.0-migration-guide.md)
 - [Upgrading to 0.22](/docs/appendices/0.22.0-migration-guide.md)
 - [Upgrading to 0.21](/docs/appendices/0.21.0-migration-guide.md)


### PR DESCRIPTION
[ci skip]
