### PR TITLE
Add the correct log mount for app logs

### DIFF
--- a/plugins/logs/functions.go
+++ b/plugins/logs/functions.go
@@ -73,6 +73,7 @@ func startVectorContainer(vectorImage string) error {
 		"--volume", "/var/lib/dokku/data/logs/vector.json:/etc/vector/vector.json",
 		"--volume", "/var/run/docker.sock:/var/run/docker.sock",
 		"--volume", common.MustGetEnv("DOKKU_LOGS_HOST_DIR") + ":/var/logs/dokku/apps",
+		"--volume", common.MustGetEnv("DOKKU_LOGS_HOST_DIR") + "/apps:/var/log/dokku/apps",
 		vectorImage,
 		"--config", "/etc/vector/vector.json", "--watch-config", "1"}, " "))
 	cmd.ShowOutput = false


### PR DESCRIPTION
As per documentation, the `/var/log/dokku/apps` should be mounted from the host to the container. The existing mount was `/var/log/dokku` mounted to `/var/logs/dokku/apps`.

The broken mount will be removed in the next minor.

Closes #4469