### PR TITLE
Ensure alternate-tags is properly injected for git:from-image deploys

### DIFF
--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -167,7 +167,8 @@ cmd-git-from-image() {
 
   dokku_log_verbose "Setting Dockerfile"
   touch "$TMP_WORK_DIR/Dockerfile"
-  echo "FROM $DOCKER_IMAGE" >"$TMP_WORK_DIR/Dockerfile"
+  echo "FROM $DOCKER_IMAGE" >>"$TMP_WORK_DIR/Dockerfile"
+  echo "LABEL com.dokku.docker-image-labeler/alternate-tags=\"[\"linuxserver/foldingathome:7.5.1-ls1\"]\"" >>"$TMP_WORK_DIR/Dockerfile"
 
   plugn trigger git-from-directory "$APP" "$TMP_WORK_DIR" "$USER_NAME" "$USER_EMAIL"
 }

--- a/tests/unit/git_4.bats
+++ b/tests/unit/git_4.bats
@@ -123,7 +123,7 @@ EOF
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "docker image inspect dokku/$TEST_APP:latest | grep 'alternate-tags'"
+  run /bin/bash -c "docker image inspect dokku/$TEST_APP:latest --format '{{ index .Config.Labels \"com.dokku.docker-image-labeler/alternate-tags\" }}'"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/git_4.bats
+++ b/tests/unit/git_4.bats
@@ -118,12 +118,12 @@ EOF
 }
 
 @test "(git) git:from-image labels correctly" {
-  run /bin/bash -c "dokku git:from-image $TEST_APP gliderlabs/logspout:v3.2.14"
+  run /bin/bash -c "dokku git:from-image $TEST_APP linuxserver/foldingathome:7.5.1-ls1"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "docker image inspect dokku/$TEST_APP:latest | grep 'alternate-tags' | grep 'gliderlabs/logspout:v3.2.14'"
+  run /bin/bash -c "docker image inspect dokku/$TEST_APP:latest | grep 'alternate-tags' | grep 'linuxserver/foldingathome:7.5.1-ls1'"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/git_4.bats
+++ b/tests/unit/git_4.bats
@@ -119,6 +119,10 @@ EOF
 
 @test "(git) git:from-image labels correctly" {
   run /bin/bash -c "dokku git:from-image $TEST_APP gliderlabs/logspout:v3.2.14"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "docker image inspect dokku/$TEST_APP:latest | grep 'alternate-tags' | grep 'gliderlabs/logspout:v3.2.14'"
   echo "output: $output"
   echo "status: $status"

--- a/tests/unit/git_4.bats
+++ b/tests/unit/git_4.bats
@@ -123,8 +123,9 @@ EOF
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "docker image inspect dokku/$TEST_APP:latest | grep 'alternate-tags' | grep 'linuxserver/foldingathome:7.5.1-ls1'"
+  run /bin/bash -c "docker image inspect dokku/$TEST_APP:latest | grep 'alternate-tags'"
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "linuxserver/foldingathome:7.5.1-ls1"
 }

--- a/tests/unit/git_4.bats
+++ b/tests/unit/git_4.bats
@@ -116,3 +116,11 @@ EOF
   echo "status: $status"
   assert_failure
 }
+
+@test "(git) git:from-image labels correctly" {
+  run /bin/bash -c "dokku git:from-image $TEST_APP gliderlabs/logspout:v3.2.14"
+  run /bin/bash -c "docker image inspect dokku/$TEST_APP:latest | grep 'alternate-tags' | grep 'gliderlabs/logspout:v3.2.14'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}


### PR DESCRIPTION
This PR will (hopefully) add a test that indicates a failure in image labeling using `docker-image-labeler` during `git:from-image` deployment.