### PR TITLE
Ensure existing apps are initialized before modifying with code

### DIFF
--- a/plugins/git/git-from-directory
+++ b/plugins/git/git-from-directory
@@ -19,7 +19,8 @@ trigger-git-git-from-directory() {
   trap "rm -rf '$TMP_WORK_DIR' '$TMP_WORK_DIR_2' >/dev/null" RETURN INT TERM EXIT
 
   dokku_log_info1 "Updating git repository with specified build context"
-  if [[ "$(fn-git-cmd "$APP_ROOT" count-objects)" == "0 objects, 0 kilobytes" ]]; then
+  local git_objects="$(fn-git-cmd "$APP_ROOT" count-objects 2>/dev/null || true)"
+  if [[ -z "$git_objects" ]] || [[ "$git_objects" == "0 objects, 0 kilobytes" ]]; then
     # setup new repo
     cp -rT "$SOURCECODE_WORK_DIR" "$TMP_WORK_DIR"
     suppress_output fn-git-cmd "$TMP_WORK_DIR" init

--- a/tests/unit/git_4.bats
+++ b/tests/unit/git_4.bats
@@ -29,6 +29,28 @@ teardown() {
   assert_success
 }
 
+@test "(git) git:from-image [normal-git-init]" {
+  run rm -rf "/home/dokku/$TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run mkdir "/home/dokku/$TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run chown -R dokku:dokku "/home/dokku/$TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:from-image $TEST_APP linuxserver/foldingathome:7.5.1-ls1"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
 @test "(git) git:from-image [normal-cnb]" {
   run /bin/bash -c "dokku git:from-image $TEST_APP dokku/node-js-getting-started:latest"
   echo "output: $output"


### PR DESCRIPTION
Prior to 0.24.0, not all applications would have their repositories initialized. This was especially the case for tags and tarball deploys.

This state is now correctly detected and the repository is initialized as expected.

Closes #4485