### PR TITLE
Drop support for Ubuntu 16.04

### DIFF
--- a/.github/commands/ci-setup
+++ b/.github/commands/ci-setup
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
+set -x
 
 echo "=====> set hostname"
 hostname

--- a/.github/commands/ci-setup
+++ b/.github/commands/ci-setup
@@ -2,12 +2,9 @@
 set -eo pipefail
 set -x
 
-echo "=====> ifconfig"
-ifconfig
-
 echo "=====> set hostname"
 hostname
-internal_ip="$(ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
+internal_ip="$(ifconfig eth0 | grep 'inet ' | awk '{print $2}')"
 sudo hostname "dokku.me"
 echo "dokku.me" | sudo tee /etc/hostname
 hostname

--- a/.github/commands/ci-setup
+++ b/.github/commands/ci-setup
@@ -2,6 +2,9 @@
 set -eo pipefail
 set -x
 
+echo "=====> ifconfig"
+ifconfig
+
 echo "=====> set hostname"
 hostname
 internal_ip="$(ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     strategy:
@@ -41,7 +41,7 @@ jobs:
   unit-tests:
     name: unit.${{ matrix.index }}
     needs: build
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.build.outputs.matrix)}}
@@ -78,7 +78,7 @@ jobs:
   docker-deploy-tests:
     name: docker
     needs: build
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
 
@@ -103,7 +103,7 @@ jobs:
   go-tests:
     name: go.${{ matrix.index }}
     needs: build
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
@@ -143,7 +143,7 @@ jobs:
   publish-test-results:
     name: publish-test-results
     needs: unit-tests
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     # the build-and-test job might be skipped, we don't need to run this job then
     if: success() || failure()
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Support us with a monthly donation and help us continue our activities. [[Become
 
 A fresh VM running any of the following operating systems:
 
-- Ubuntu 16.04/18.04/20.04 x64 - Any currently supported release
+- Ubuntu 18.04/20.04 x64 - Any currently supported release
 - Debian 9+ x64
 - CentOS 7 x64 *(experimental)*
 - Arch Linux x64 *(experimental)*

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 [[ $TRACE ]] && set -x
 
 # A script to bootstrap dokku.
-# It expects to be run on Ubuntu 16.04/18.04/20.04, or CentOS 7 via 'sudo'
+# It expects to be run on Ubuntu 18.04/20.04, or CentOS 7 via 'sudo'
 # If installing a tag higher than 0.3.13, it may install dokku via a package (so long as the package is higher than 0.3.13)
 # It checks out the dokku source code from Github into ~/dokku and then runs 'make install' from dokku source.
 
@@ -12,7 +12,7 @@ set -eo pipefail
 # That's good because it prevents our output overlapping with wget's.
 # It also means that we can't run a partially downloaded script.
 
-SUPPORTED_VERSIONS="Debian [9, 10], CentOS [7], Fedora (partial) [33, 34], Ubuntu [16.04, 18.04, 20.04]"
+SUPPORTED_VERSIONS="Debian [9, 10], CentOS [7], Fedora (partial) [33, 34], Ubuntu [18.04, 20.04]"
 
 log-fail() {
   declare desc="log fail formatter"
@@ -155,7 +155,7 @@ install-dokku-from-deb-package() {
   local NO_INSTALL_RECOMMENDS=${DOKKU_NO_INSTALL_RECOMMENDS:=""}
   local OS_ID
 
-  if ! in-array "$DOKKU_DISTRO_VERSION" "16.04" "18.04" "20.04" "9" "10"; then
+  if ! in-array "$DOKKU_DISTRO_VERSION" "18.04" "20.04" "9" "10"; then
     log-fail "Unsupported Linux distribution. Only the following versions are supported: $SUPPORTED_VERSIONS"
   fi
 
@@ -187,7 +187,7 @@ install-dokku-from-deb-package() {
   fi
 
   if [[ "$DOKKU_DISTRO" == "ubuntu" ]]; then
-    OS_IDS=("xenial" "bionic" "focal")
+    OS_IDS=("bionic" "focal")
     if ! in-array "$OS_ID" "${OS_IDS[@]}"; then
       OS_ID="bionic"
     fi

--- a/contrib/copy-packages
+++ b/contrib/copy-packages
@@ -16,7 +16,6 @@ def download_file(filename, url):
 
 def upload_file(filename):
     versions = [
-        "xenial"
         "focal"
     ]
     cmd_template = "package_cloud push dokku/dokku/ubuntu/{0} {1}"

--- a/contrib/release-dokku
+++ b/contrib/release-dokku
@@ -136,7 +136,7 @@ fn-publish-package() {
   [[ "$RELEASE_TYPE" == "rpm" ]] && DIST=el/7
 
   if [[ "$DIST" == "ubuntu" ]]; then
-    OS_IDS=("xenial" "bionic" "focal")
+    OS_IDS=("bionic" "focal")
     for OS_ID in "${OS_IDS[@]}"; do
       log-info "(release-dokku) pushing ${RELEASE_TYPE} to packagecloud.com/${REPOSITORY}/${DIST}"
       package_cloud push "${REPOSITORY}/${DIST}/${OS_ID}" "$PACKAGE_NAME"

--- a/contrib/release-dokku
+++ b/contrib/release-dokku
@@ -6,7 +6,7 @@ readonly ROOT_DIR="$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)"
 readonly TMP_WORK_DIR="$(mktemp -d "/tmp/dokku-release.XXXXXX")"
 readonly DOKKU_GIT_REV="$(git rev-parse HEAD)"
 
-trap 'rm -rf "$TMP_WORK_DIR" >/dev/null' RETURN INT TERM EXIT
+trap "rm -rf '$TMP_WORK_DIR' >/dev/null" RETURN INT TERM EXIT
 
 log-info() {
   # shellcheck disable=SC2034

--- a/contrib/release-plugin
+++ b/contrib/release-plugin
@@ -4,7 +4,7 @@ set -eo pipefail
 
 readonly TMP_WORK_DIR="$(mktemp -d "/tmp/dokku-plugin-release.XXXXXX")"
 
-trap 'rm -rf "$TMP_WORK_DIR" >/dev/null' RETURN INT TERM EXIT
+trap "rm -rf '$TMP_WORK_DIR' >/dev/null" RETURN INT TERM EXIT
 
 log-info() {
   # shellcheck disable=SC2034

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -9,11 +9,11 @@ We maintain the Dokku test harness within the `tests` directory:
 
 ## Continuous Integration
 
-All pull requests have tests run against them on [CircleCI](https://circleci.com/), a continuous integration platform that provides Docker support for Ubuntu Trusty 16.04.
+All pull requests have tests run against them on [Github Actions](https://github.com/features/actions), a continuous integration platform that provides Docker support for Ubuntu Trusty 18.04.
 
 If you wish to skip tests for a particular commit, e.g. documentation changes, you may add the `[ci skip]` designator to your commit message. Commits that _should_ be tested but have the above designator will not be merged.
 
-While we do provide official packages for a variety of platforms, as our test suite currently runs on Ubuntu Trusty 16.04, we only provide official installation support for that platform and the latest LTS release of Ubuntu (currently 18.04).
+While we do provide official packages for a variety of platforms, as our test suite currently runs on Ubuntu Trusty 18.04, we only provide official installation support for that platform and the latest LTS release of Ubuntu (currently 20.04).
 
 ## Local Test Execution
 

--- a/docs/getting-started/install/debian.md
+++ b/docs/getting-started/install/debian.md
@@ -13,7 +13,7 @@ wget -nv -O - https://get.docker.com/ | sh
 # install dokku
 wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -
 OS_ID="$(lsb_release -cs 2>/dev/null || echo "bionic")"
-echo "xenial bionic focal" | grep -q "$OS_ID" || OS_ID="bionic"
+echo "bionic focal" | grep -q "$OS_ID" || OS_ID="bionic"
 echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ ${OS_ID} main" | sudo tee /etc/apt/sources.list.d/dokku.list
 sudo apt-get update -qq >/dev/null
 sudo apt-get -qq -y install dokku

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ Dokku is an extensible, open source Platform as a Service that runs on a single 
 
 To start using Dokku, you'll need a system that meets the following minimum requirements:
 
-- A fresh installation of [Ubuntu 16.04/18.04/20.04 x64](https://www.ubuntu.com/download), [Debian 9+ x64](https://www.debian.org/distrib/) or [CentOS 7 x64](https://www.centos.org/download/) *(experimental)* with the FQDN set <sup>[1]</sup>
+- A fresh installation of [Ubuntu 18.04/20.04 x64](https://www.ubuntu.com/download), [Debian 9+ x64](https://www.debian.org/distrib/) or [CentOS 7 x64](https://www.centos.org/download/) *(experimental)* with the FQDN set <sup>[1]</sup>
 - At least 1 GB of system memory <sup>[2]</sup>
 
 You can *optionally* have a domain name pointed at the host's IP, though this is not necessary.

--- a/docs/home.html
+++ b/docs/home.html
@@ -140,7 +140,7 @@
           <p class="line">
             <span class="path"></span>
             <span class="prompt">$</span>
-            <span class="command">echo "xenial bionic focal" | grep -q "$OS_ID" || OS_ID="bionic"</span>
+            <span class="command">echo "bionic focal" | grep -q "$OS_ID" || OS_ID="bionic"</span>
           </p>
           <p class="line">
             <span class="path"></span>

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -391,7 +391,7 @@ fn-git-clone() {
   fi
 
   dokku_log_info1_quiet "Cloning $APP from $GIT_REMOTE#$GIT_REF"
-  trap 'rm -rf $APP_CLONE_ROOT > /dev/null' RETURN INT TERM EXIT
+  trap "rm -rf '$APP_CLONE_ROOT' > /dev/null" RETURN INT TERM EXIT
 
   is_ref=true
   if GIT_TERMINAL_PROMPT=0 git clone --depth 1 -n --branch "$GIT_REF" "$GIT_REMOTE" "$APP_CLONE_ROOT" 2>/dev/null; then

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -144,7 +144,7 @@ trigger-scheduler-docker-local-scheduler-deploy() {
       }
 
       # run checks first, then post-deploy hooks, which switches proxy traffic
-      trap 'kill_new $cid $PROC_TYPE $CONTAINER_INDEX' INT TERM EXIT
+      trap "kill_new $cid $PROC_TYPE $CONTAINER_INDEX" INT TERM EXIT
       if [[ "$(is_app_proctype_checks_disabled "$APP" "$PROC_TYPE")" == "false" ]]; then
         dokku_log_info1 "Attempting pre-flight checks ($PROC_TYPE.$CONTAINER_INDEX)"
         plugn trigger check-deploy "$APP" "$cid" "$PROC_TYPE" "$port" "$ipaddr"

--- a/tests/unit/core_2.bats
+++ b/tests/unit/core_2.bats
@@ -87,9 +87,9 @@ teardown() {
   build_nginx_config
   assert_urls "http://${TEST_APP}.dokku.me" "https://${TEST_APP}.dokku.me"
   add_domain "test.dokku.me"
-  assert_urls "http://${TEST_APP}.dokku.me" "https://${TEST_APP}.dokku.me" "https://test.dokku.me" "http://test.dokku.me"
+  assert_urls "http://${TEST_APP}.dokku.me" "http://test.dokku.me" "https://${TEST_APP}.dokku.me" "https://test.dokku.me"
   add_domain "dokku.example.com"
-  assert_urls "http://dokku.example.com" "http://${TEST_APP}.dokku.me" "https://dokku.example.com" "https://${TEST_APP}.dokku.me" "https://test.dokku.me" "http://test.dokku.me"
+  assert_urls "http://dokku.example.com" "http://${TEST_APP}.dokku.me" "http://test.dokku.me" "https://dokku.example.com" "https://${TEST_APP}.dokku.me" "https://test.dokku.me"
 }
 
 @test "(core) git-remote (off-port)" {

--- a/tests/unit/core_2.bats
+++ b/tests/unit/core_2.bats
@@ -71,7 +71,7 @@ teardown() {
   build_nginx_config
   assert_urls "http://${TEST_APP}.dokku.me" "https://${TEST_APP}.dokku.me"
   add_domain "test.dokku.me"
-  assert_urls "http://${TEST_APP}.dokku.me" "https://${TEST_APP}.dokku.me" "https://test.dokku.me" "http://test.dokku.me"
+  assert_urls "http://${TEST_APP}.dokku.me" "http://test.dokku.me" "https://${TEST_APP}.dokku.me" "https://test.dokku.me"
 }
 
 @test "(core) url (app ssl)" {

--- a/tests/unit/git_3.bats
+++ b/tests/unit/git_3.bats
@@ -204,12 +204,12 @@ teardown() {
 }
 
 @test "(git) git:sync existing [--no-build noarg]" {
-  run /bin/bash -c "dokku git:sync $TEST_APP https://github.com/dokku/smoke-test-app.git 1.0.0"
+  run /bin/bash -c "dokku --trace git:sync $TEST_APP https://github.com/dokku/smoke-test-app.git 1.0.0"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku git:sync $TEST_APP https://github.com/dokku/smoke-test-app.git"
+  run /bin/bash -c "dokku --trace git:sync $TEST_APP https://github.com/dokku/smoke-test-app.git"
   echo "output: $output"
   echo "status: $status"
   assert_success


### PR DESCRIPTION
As of April 2021, it will no longer be an LTS release, and thus us supporting it will increase maintenance burdens.

Also switch CI to use 18.04, so as to test what we currently support.
