### PR TITLE
Add support for the formation key in app.json

### DIFF
--- a/docs/appendices/0.25.0-migration-guide.md
+++ b/docs/appendices/0.25.0-migration-guide.md
@@ -10,3 +10,4 @@
 - In previous versions of Dokku, the only way to specify a custom `Dockerfile` was to use the `docker-options` plugin to set the `--file` flag for a docker build. As of 0.25.0, the `builder-dockerfile:set` command should be used instead, as outlined in the [docs here](/docs/deployment/builders/dockerfiles.md#changingthe-dockerfile-location). Usage of the old method should be migrated to the new method.
 - The `--rm` and ``--rm-container` flags may be specified but no longer have any effect on `dokku run`.
 - The `--detach` flag is deprecated in favor of the `run:detached` command.
+- The `DOKKU_SCALE` file is deprecated. Please see the [process management documentation](/docs/processes/process-management.md#manually-managing-process-scaling) for more information on it's replacement with the `formations` key of the `app.json` file.

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1800,6 +1800,21 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 # TODO
 ```
 
+### `ps-current-scale`
+
+- Description: Prints out the current scale contents (process-type=quantity) delimited by newlines.
+- Invoked by:
+- Arguments: `$APP`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+# TODO
+```
+
 ### `receive-app`
 
 - Description: Allows you to customize what occurs when an app is received. Normally just triggers an app build.

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1800,6 +1800,20 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 # TODO
 ```
 
+### `ps-can-scale`
+
+- Description: Sets whether or not a user can scale an app with `ps:scale`
+- Invoked by:
+- Arguments: `$APP`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+# TODO
+```
 ### `ps-current-scale`
 
 - Description: Prints out the current scale contents (process-type=quantity) delimited by newlines.

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1815,6 +1815,21 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 # TODO
 ```
 
+### `ps-set-scale`
+
+- Description: Sets the scale for an app based on a specified formation (process-type=quantity). Any unspecified process types will be left as is.
+- Invoked by:
+- Arguments: `$APP $SKIP_DEPLOY [$PROCESS_TUPLE...]`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+# TODO
+```
+
 ### `receive-app`
 
 - Description: Allows you to customize what occurs when an app is received. Normally just triggers an app build.

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1833,7 +1833,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 - Description: Sets the scale for an app based on a specified formation (process-type=quantity). Any unspecified process types will be left as is.
 - Invoked by:
-- Arguments: `$APP $SKIP_DEPLOY [$PROCESS_TUPLE...]`
+- Arguments: `$APP $SKIP_DEPLOY $CLEAR_EXISTING [$PROCESS_TUPLE...]`
 - Example:
 
 ```shell

--- a/docs/processes/process-management.md
+++ b/docs/processes/process-management.md
@@ -106,7 +106,7 @@ web:  1
 
 #### Via CLI
 
-> This functionality is disabled if the formation is managed via a file such as `DOKKU_SCALE`.
+> This functionality is disabled if the formation is managed via the `formations` key of `app.json`.
 
 Dokku can also manage scaling itself via the `ps:scale` command. This command can be used to scale multiple process types at the same time.
 
@@ -128,22 +128,30 @@ dokku ps:scale --skip-deploy node-js-app web=1
 
 #### Manually managing process scaling
 
-> Using a `DOKKU_SCALE` formation file disables the ability to use `ps:scale` for scaling.
+> Using a `formations` key in an `app.json` file disables the ability to use `ps:scale` for scaling.
 
-A `DOKKU_SCALE` file can be committed to the root of the pushed app repository, and must be within the built image artifact in the image's working directory as shown below.
+An `app.json` file can be committed to the root of the pushed app repository, and must be within the built image artifact in the image's working directory as shown below.
 
-- Buildpacks: `/app/DOKKU_SCALE`
-- Dockerfile: `WORKDIR/DOKKU_SCALE` or `/DOKKU_SCALE`
-- Docker Image: `WORKDIR/DOKKU_SCALE` or `/DOKKU_SCALE`
+- Buildpacks: `/app/app.json`
+- Dockerfile: `WORKDIR/app.json` or `/app.json` (if no working directory specified)
+- Docker Image: `WORKDIR/app.json` or `/app.json` (if no working directory specified)
 
-The `DOKKU_SCALE` file format is as follows:
+The `formations` key should be specified as follows in the `app.json` file:
 
 ```Procfile
-web=1
-worker=2
+{
+  "formations": {
+    "web": {
+      "quantity": 1
+    },
+    "worker": {
+      "quantity": 4
+    }
+  }
+}
 ```
 
-Removing the file will result in Dokku respecting the `ps:scale` command for setting scale values.
+Removing the file will result in Dokku respecting the `ps:scale` command for setting scale values. The values set via the `app.json` file from a previous deploy will be respected.
 
 #### The `web` process
 

--- a/docs/processes/process-management.md
+++ b/docs/processes/process-management.md
@@ -155,7 +155,7 @@ Removing the file will result in Dokku respecting the `ps:scale` command for set
 
 #### The `web` process
 
-For initial app deploys, Dokku will default to starting a single `web` process for each app. This process may be defined within the `Procfile` or as the `CMD` (for Dockerfile or Docker image deploys). Scaling of the `web` process - and others - may be managed via `ps:scale` or a `DOKKU_SCALE` formation file either before or after the initial deploy.
+For initial app deploys, Dokku will default to starting a single `web` process for each app. This process may be defined within the `Procfile` or as the `CMD` (for Dockerfile or Docker image deploys). Scaling of the `web` process - and all other processes - may be managed via `ps:scale` or the `formations` key in the `app.json` file either before or after the initial deploy.
 
 There are also a few other exceptions for the `web` process.
 

--- a/plugins/app-json/appjson.go
+++ b/plugins/app-json/appjson.go
@@ -20,8 +20,9 @@ var (
 
 // AppJSON is a struct that represents an app.json file as understood by Dokku
 type AppJSON struct {
-	Cron    []CronCommand `json:"cron"`
-	Scripts struct {
+	Cron      []CronCommand        `json:"cron"`
+	Formation map[string]Formation `json:"formation"`
+	Scripts   struct {
 		Dokku struct {
 			Predeploy  string `json:"predeploy"`
 			Postdeploy string `json:"postdeploy"`
@@ -34,6 +35,10 @@ type AppJSON struct {
 type CronCommand struct {
 	Command  string `json:"command"`
 	Schedule string `json:"schedule"`
+}
+
+type Formation struct {
+	Quantity int `json:"quantity"`
 }
 
 // GetAppjsonDirectory returns the directory containing a given app's extracted app.json file

--- a/plugins/app-json/appjson.go
+++ b/plugins/app-json/appjson.go
@@ -37,6 +37,7 @@ type CronCommand struct {
 	Schedule string `json:"schedule"`
 }
 
+// Formation is a struct that represents the scale for a process from an app.json file
 type Formation struct {
 	Quantity int `json:"quantity"`
 }

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -99,7 +99,7 @@ func getAppJSON(appName string) (AppJSON, error) {
 		return AppJSON{}, fmt.Errorf("Cannot parse app.json: %v", err)
 	}
 
-	return AppJSON{}, nil
+	return appJSON, nil
 }
 
 // getPhaseScript extracts app.json from app image and returns the appropriate json key/value

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -496,7 +496,7 @@ func setScale(appName string, image string) error {
 		return err
 	}
 
-	args := []string{appName}
+	args := []string{appName, "true"}
 	for processType, formation := range appJSON.Formation {
 		args = append(args, fmt.Sprintf("%s=%d", processType, formation.Quantity))
 	}
@@ -509,7 +509,7 @@ func setScale(appName string, image string) error {
 		return err
 	}
 
-	return common.PlugnTrigger("ps-scale-set", args...)
+	return common.PlugnTrigger("ps-set-scale", args...)
 }
 
 func injectDokkuScale(appName string, image string) error {

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -501,7 +501,7 @@ func setScale(appName string, image string) error {
 		args = append(args, fmt.Sprintf("%s=%d", processType, formation.Quantity))
 	}
 
-	if len(args) == 1 {
+	if len(args) == 2 {
 		return common.PlugnTrigger("ps-can-scale", []string{appName, "true"}...)
 	}
 

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -80,7 +80,7 @@ func constructScript(command string, shell string, isHerokuishImage bool, isCnbI
 	return []string{shell, "-c", strings.Join(script, " ")}
 }
 
-func getAppJson(appName string) (AppJSON, error) {
+func getAppJSON(appName string) (AppJSON, error) {
 	if !common.FileExists(GetAppjsonPath(appName)) {
 		return AppJSON{}, nil
 	}
@@ -104,7 +104,7 @@ func getAppJson(appName string) (AppJSON, error) {
 
 // getPhaseScript extracts app.json from app image and returns the appropriate json key/value
 func getPhaseScript(appName string, phase string) (string, error) {
-	appJSON, err := getAppJson(appName)
+	appJSON, err := getAppJSON(appName)
 	if err != nil {
 		return "", err
 	}
@@ -491,7 +491,7 @@ func setScale(appName string, image string) error {
 		return err
 	}
 
-	appJSON, err := getAppJson(appName)
+	appJSON, err := getAppJSON(appName)
 	if err != nil {
 		return err
 	}
@@ -517,7 +517,7 @@ func setScale(appName string, image string) error {
 }
 
 func injectDokkuScale(appName string, image string) error {
-	appJSON, err := getAppJson(appName)
+	appJSON, err := getAppJSON(appName)
 	if err != nil {
 		return err
 	}

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -561,13 +561,13 @@ func injectDokkuScale(appName string, image string) error {
 		}
 
 		processType := procParts[0]
-		procCount, err := strconv.Atoi(procParts[1])
+		quantity, err := strconv.Atoi(procParts[1])
 		if err != nil {
 			continue
 		}
 
 		appJSON.Formation[processType] = Formation{
-			Quantity: procCount,
+			Quantity: quantity,
 		}
 	}
 
@@ -576,5 +576,5 @@ func injectDokkuScale(appName string, image string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(dokkuScaleFile, b, 0644)
+	return ioutil.WriteFile(GetAppjsonPath(appName), b, 0644)
 }

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -541,6 +541,10 @@ func injectDokkuScale(appName string, image string) error {
 		return err
 	}
 
+	if appJSON.Formation == nil {
+		appJSON.Formation = make(map[string]Formation)
+	}
+
 	for _, line := range lines {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -535,14 +535,17 @@ func injectDokkuScale(appName string, image string) error {
 		return nil
 	}
 
-	common.LogWarn("Deprecated: Use the 'formation' key in app.json to specify scaling instead of DOKKU_SCALE")
 	lines, err := common.FileToSlice(dokkuScaleFile)
 	if err != nil {
 		return err
 	}
 
 	if appJSON.Formation == nil {
+		common.LogWarn("Deprecated: Use the 'formation' key in app.json to specify scaling instead of DOKKU_SCALE")
 		appJSON.Formation = make(map[string]Formation)
+	} else {
+		common.LogWarn("Deprecated: DOKKU_SCALE ignored in favor of 'formation' key in app.json")
+		return nil
 	}
 
 	for _, line := range lines {

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -533,9 +533,7 @@ func injectDokkuScale(appName string, image string) error {
 		os.Remove(dokkuScaleFile)
 	}
 
-	if err := common.CopyFromImage(appName, image, "DOKKU_SCALE", dokkuScaleFile); err != nil {
-		return err
-	}
+	common.CopyFromImage(appName, image, "DOKKU_SCALE", dokkuScaleFile)
 
 	if !common.FileExists(dokkuScaleFile) {
 		return nil

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -543,10 +543,10 @@ func injectDokkuScale(appName string, image string) error {
 	}
 
 	if appJSON.Formation == nil {
-		common.LogWarn("Deprecated: Use the 'formation' key in app.json to specify scaling instead of DOKKU_SCALE")
+		common.LogWarn("Deprecated: Injecting scale settings from DOKKU_SCALE file. Use the 'formation' key the app.json file to specify scaling instead of 'DOKKU_SCALE'.")
 		appJSON.Formation = make(map[string]Formation)
 	} else {
-		common.LogWarn("Deprecated: DOKKU_SCALE ignored in favor of 'formation' key in app.json")
+		common.LogWarn("Deprecated: DOKKU_SCALE ignored in favor of 'formation' key in the app.json")
 		return nil
 	}
 

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -509,11 +509,7 @@ func setScale(appName string, image string) error {
 		return err
 	}
 
-	if err := common.PlugnTrigger("ps-scale-set", args...); err != nil {
-		return err
-	}
-
-	return nil
+	return common.PlugnTrigger("ps-scale-set", args...)
 }
 
 func injectDokkuScale(appName string, image string) error {

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -496,7 +496,9 @@ func setScale(appName string, image string) error {
 		return err
 	}
 
-	args := []string{appName, "true"}
+	skipDeploy := true
+	clearExisting := false
+	args := []string{appName, strconv.FormatBool(skipDeploy), strconv.FormatBool(clearExisting)}
 	for processType, formation := range appJSON.Formation {
 		args = append(args, fmt.Sprintf("%s=%d", processType, formation.Quantity))
 	}

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -503,7 +503,7 @@ func setScale(appName string, image string) error {
 		args = append(args, fmt.Sprintf("%s=%d", processType, formation.Quantity))
 	}
 
-	if len(args) == 2 {
+	if len(args) == 3 {
 		return common.PlugnTrigger("ps-can-scale", []string{appName, "true"}...)
 	}
 

--- a/plugins/app-json/triggers.go
+++ b/plugins/app-json/triggers.go
@@ -64,6 +64,10 @@ func TriggerPreDeploy(appName string, imageTag string) error {
 		return err
 	}
 
+	if err := setScale(appName, image); err != nil {
+		return err
+	}
+
 	if common.PropertyGet("common", appName, "deployed") == "true" {
 		return nil
 	}

--- a/plugins/checks/subcommands/run
+++ b/plugins/checks/subcommands/run
@@ -29,7 +29,7 @@ check_all_processes() {
     fi
 
     check_process_type "$APP" "$PROC_TYPE" "$PROC_COUNT"
-  done <"$(plugn trigger ps-current-scale "$APP")"
+  done < <(plugn trigger ps-current-scale "$APP")
 
   if [[ "$VALID_CHECK_PROC_TYPE" == "false" ]]; then
     dokku_log_fail "Invalid process type specified ($APP.$CHECK_PROC_TYPE)"

--- a/plugins/checks/subcommands/run
+++ b/plugins/checks/subcommands/run
@@ -13,8 +13,6 @@ check_all_processes() {
   local PROC_TYPE
   local PROC_COUNT
   while read -r line || [[ -n "$line" ]]; do
-    [[ "$line" =~ ^#.* ]] && continue
-    line="$(strip_inline_comments "$line")"
     local PROC_TYPE=${line%%=*}
     local PROC_COUNT=${line#*=}
 

--- a/plugins/checks/subcommands/run
+++ b/plugins/checks/subcommands/run
@@ -7,7 +7,6 @@ source "$PLUGIN_AVAILABLE_PATH/checks/functions"
 check_all_processes() {
   local APP="$1"
   CHECK_PROC_TYPE="$2"
-  local DOKKU_SCALE_FILE="$DOKKU_ROOT/$APP/DOKKU_SCALE"
   local VALID_CHECK_PROC_TYPE=false
 
   local line
@@ -30,7 +29,7 @@ check_all_processes() {
     fi
 
     check_process_type "$APP" "$PROC_TYPE" "$PROC_COUNT"
-  done <"$DOKKU_SCALE_FILE"
+  done <"$(plugn trigger ps-current-scale "$APP")"
 
   if [[ "$VALID_CHECK_PROC_TYPE" == "false" ]]; then
     dokku_log_fail "Invalid process type specified ($APP.$CHECK_PROC_TYPE)"

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -353,6 +353,23 @@ func ParseReportArgs(pluginName string, arguments []string) ([]string, string, e
 	return osArgs, "", fmt.Errorf("%s:report command allows only a single flag", pluginName)
 }
 
+// ParseScaleOutput allows golang plugins to properly parse the output of ps-current-scale
+func ParseScaleOutput(b []byte) (map[string]int, error) {
+	scale := make(map[string]int)
+
+	for _, line := range strings.Split(string(b), "\n") {
+		s := strings.Split(line, "=")
+		processType := s[0]
+		count, err := strconv.Atoi(s[1])
+		if err != nil {
+			return scale, err
+		}
+		scale[processType] = count
+	}
+
+	return scale, nil
+}
+
 // ReportSingleApp is an internal function that displays a report for an app
 func ReportSingleApp(reportType string, appName string, infoFlag string, infoFlags map[string]string, infoFlagKeys []string, format string, trimPrefix bool, uppercaseFirstCharacter bool) error {
 	if format != "stdout" && infoFlag != "" {

--- a/plugins/common/properties.go
+++ b/plugins/common/properties.go
@@ -173,6 +173,15 @@ func PropertyListAdd(pluginName string, appName string, property string, value s
 		lines = append(lines, value)
 	}
 
+	return PropertyListWrite(pluginName, appName, property, lines)
+}
+
+// PropertyListWrite completely rewrites a list property
+func PropertyListWrite(pluginName string, appName string, property string, values []string) error {
+	if err := propertyTouch(pluginName, appName, property); err != nil {
+		return err
+	}
+
 	propertyPath := getPropertyPath(pluginName, appName, property)
 	file, err := os.OpenFile(propertyPath, os.O_RDWR|os.O_TRUNC, 0600)
 	if err != nil {
@@ -180,7 +189,7 @@ func PropertyListAdd(pluginName string, appName string, property string, value s
 	}
 
 	w := bufio.NewWriter(file)
-	for _, line := range lines {
+	for _, line := range values {
 		fmt.Fprintln(w, line)
 	}
 	if err = w.Flush(); err != nil {
@@ -389,23 +398,7 @@ func PropertyListSet(pluginName string, appName string, property string, value s
 		}
 	}
 
-	propertyPath := getPropertyPath(pluginName, appName, property)
-	file, err := os.OpenFile(propertyPath, os.O_RDWR|os.O_TRUNC, 0600)
-	if err != nil {
-		return err
-	}
-
-	w := bufio.NewWriter(file)
-	for _, line := range lines {
-		fmt.Fprintln(w, line)
-	}
-	if err = w.Flush(); err != nil {
-		return fmt.Errorf("Unable to write %s config value %s.%s: %s", pluginName, appName, property, err.Error())
-	}
-
-	file.Chmod(0600)
-	SetPermissions(propertyPath, 0600)
-	return nil
+	return PropertyListWrite(pluginName, appName, property, lines)
 }
 
 // propertyTouch ensures a given application property file exists

--- a/plugins/common/src/prop/prop.go
+++ b/plugins/common/src/prop/prop.go
@@ -159,6 +159,16 @@ func main() {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
+	case "lwrite":
+		_, args := common.ShiftString(flag.Args())
+		appName, args := common.ShiftString(args)
+		property, args := common.ShiftString(args)
+		_, values := common.ShiftString(args)
+		err := common.PropertyListWrite(pluginName, appName, property, values)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
 	case "rpush":
 		appName := flag.Arg(2)
 		property := flag.Arg(3)

--- a/plugins/network/network.go
+++ b/plugins/network/network.go
@@ -34,22 +34,6 @@ var (
 	}
 )
 
-func parseScaleOutput(b []byte) (map[string]int, error) {
-	scale := make(map[string]int)
-
-	for _, line := range strings.Split(string(b), "\n") {
-		s := strings.Split(line, "=")
-		processType := s[0]
-		count, err := strconv.Atoi(s[1])
-		if err != nil {
-			return scale, err
-		}
-		scale[processType] = count
-	}
-
-	return scale, nil
-}
-
 // BuildConfig builds network config files
 func BuildConfig(appName string) error {
 	if !common.IsDeployed(appName) {
@@ -62,7 +46,7 @@ func BuildConfig(appName string) error {
 		return err
 	}
 
-	scale, err := parseScaleOutput(s)
+	scale, err := common.ParseScaleOutput(s)
 	if err != nil {
 		return err
 	}

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -518,7 +518,7 @@ nginx_build_config() {
         UPP_PROC_TYPE="${PROC_TYPE^^}"
         UPP_PROC_TYPE="${UPP_PROC_TYPE//-/_}"
         SIGIL_PARAMS+=("DOKKU_APP_${UPP_PROC_TYPE}_LISTENERS=$LISTENERS")
-      done <"$(plugn trigger ps-current-scale "$APP")"
+      done < <(plugn trigger ps-current-scale "$APP")
 
       if grep DOKKU_APP_LISTENERS "$NGINX_TEMPLATE"; then
         dokku_log_warn "Deprecated: Usage of DOKKU_APP_LISTENERS within nginx.conf.sigil templates is deprecated in favor of DOKKU_APP_WEB_LISTENERS"

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -510,7 +510,6 @@ nginx_build_config() {
         PROXY_X_FORWARDED_PROTO="$PROXY_X_FORWARDED_PROTO"
         PROXY_X_FORWARDED_SSL="$PROXY_X_FORWARDED_SSL")
 
-      local DOKKU_SCALE_FILE="$DOKKU_ROOT/$APP/DOKKU_SCALE"
       while read -r line || [[ -n "$line" ]]; do
         [[ "$line" =~ ^#.* ]] && continue
         line="$(strip_inline_comments "$line")"
@@ -519,7 +518,7 @@ nginx_build_config() {
         UPP_PROC_TYPE="${PROC_TYPE^^}"
         UPP_PROC_TYPE="${UPP_PROC_TYPE//-/_}"
         SIGIL_PARAMS+=("DOKKU_APP_${UPP_PROC_TYPE}_LISTENERS=$LISTENERS")
-      done <"$DOKKU_SCALE_FILE"
+      done <"$(plugn trigger ps-current-scale "$APP")"
 
       if grep DOKKU_APP_LISTENERS "$NGINX_TEMPLATE"; then
         dokku_log_warn "Deprecated: Usage of DOKKU_APP_LISTENERS within nginx.conf.sigil templates is deprecated in favor of DOKKU_APP_WEB_LISTENERS"

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -511,8 +511,6 @@ nginx_build_config() {
         PROXY_X_FORWARDED_SSL="$PROXY_X_FORWARDED_SSL")
 
       while read -r line || [[ -n "$line" ]]; do
-        [[ "$line" =~ ^#.* ]] && continue
-        line="$(strip_inline_comments "$line")"
         PROC_TYPE=${line%%=*}
         LISTENERS="$(plugn trigger network-get-listeners "$APP" "$PROC_TYPE" | xargs)"
         UPP_PROC_TYPE="${PROC_TYPE^^}"

--- a/plugins/ps/.gitignore
+++ b/plugins/ps/.gitignore
@@ -7,6 +7,7 @@
 /pre-*
 /procfile-*
 /proxy-*
+/ps-*
 /report
 /subcommands/*
 /triggers

--- a/plugins/ps/Makefile
+++ b/plugins/ps/Makefile
@@ -1,5 +1,5 @@
 SUBCOMMANDS = subcommands/inspect subcommands/rebuild subcommands/report subcommands/restart subcommands/restore subcommands/retire subcommands/scale subcommands/set subcommands/start subcommands/stop
-TRIGGERS = triggers/app-restart triggers/core-post-deploy triggers/core-post-extract triggers/install triggers/post-app-clone triggers/post-app-clone-setup triggers/post-app-rename triggers/post-app-rename-setup triggers/post-create triggers/post-delete triggers/post-extract triggers/post-stop triggers/pre-deploy triggers/procfile-extract triggers/procfile-get-command triggers/procfile-remove triggers/ps-current-scale triggers/report
+TRIGGERS = triggers/app-restart triggers/core-post-deploy triggers/core-post-extract triggers/install triggers/post-app-clone triggers/post-app-clone-setup triggers/post-app-rename triggers/post-app-rename-setup triggers/post-create triggers/post-delete triggers/post-extract triggers/post-stop triggers/pre-deploy triggers/procfile-extract triggers/procfile-get-command triggers/procfile-remove triggers/ps-can-scale triggers/ps-current-scale triggers/ps-set-scale triggers/report
 BUILD = commands subcommands triggers
 PLUGIN_NAME = ps
 

--- a/plugins/ps/Makefile
+++ b/plugins/ps/Makefile
@@ -1,5 +1,5 @@
 SUBCOMMANDS = subcommands/inspect subcommands/rebuild subcommands/report subcommands/restart subcommands/restore subcommands/retire subcommands/scale subcommands/set subcommands/start subcommands/stop
-TRIGGERS = triggers/app-restart triggers/core-post-deploy triggers/core-post-extract triggers/install triggers/post-app-clone triggers/post-app-clone-setup triggers/post-app-rename triggers/post-app-rename-setup triggers/post-create triggers/post-delete triggers/post-extract triggers/post-stop triggers/pre-deploy triggers/procfile-extract triggers/procfile-get-command triggers/procfile-remove triggers/report
+TRIGGERS = triggers/app-restart triggers/core-post-deploy triggers/core-post-extract triggers/install triggers/post-app-clone triggers/post-app-clone-setup triggers/post-app-rename triggers/post-app-rename-setup triggers/post-create triggers/post-delete triggers/post-extract triggers/post-stop triggers/pre-deploy triggers/procfile-extract triggers/procfile-get-command triggers/procfile-remove triggers/ps-current-scale triggers/report
 BUILD = commands subcommands triggers
 PLUGIN_NAME = ps
 

--- a/plugins/ps/functions.go
+++ b/plugins/ps/functions.go
@@ -278,6 +278,10 @@ func readScaleFile(appName string) (map[string]int, error) {
 	}
 
 	for i, line := range lines {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
 		s := strings.Split(line, "=")
 		if len(s) != 2 {
 			common.LogWarn(fmt.Sprintf("Invalid scale entry on line %d, skipping", i))

--- a/plugins/ps/functions.go
+++ b/plugins/ps/functions.go
@@ -395,6 +395,10 @@ func scaleSet(appName string, skipDeploy bool, processTuples []string) error {
 		return err
 	}
 
+	if skipDeploy {
+		return nil
+	}
+
 	if !common.IsDeployed(appName) {
 		return nil
 	}
@@ -402,10 +406,6 @@ func scaleSet(appName string, skipDeploy bool, processTuples []string) error {
 	imageTag, err := common.GetRunningImageTag(appName)
 	if err != nil {
 		return err
-	}
-
-	if skipDeploy {
-		return nil
 	}
 
 	return common.PlugnTrigger("release-and-deploy", []string{appName, imageTag}...)

--- a/plugins/ps/functions.go
+++ b/plugins/ps/functions.go
@@ -16,7 +16,8 @@ import (
 )
 
 func canScaleApp(appName string) bool {
-	return !common.FileExists(getScalefileExtractedPath(appName))
+	canScale := common.PropertyGetDefault("ps", appName, "can-scale", "true")
+	return common.ToBool(canScale)
 }
 
 func extractProcfile(appName, image string) error {

--- a/plugins/ps/functions.go
+++ b/plugins/ps/functions.go
@@ -381,10 +381,6 @@ func scaleReport(appName string) error {
 }
 
 func scaleSet(appName string, skipDeploy bool, processTuples []string) error {
-	if !canScaleApp(appName) {
-		return fmt.Errorf("App %s contains DOKKU_SCALE file and cannot be manually scaled", appName)
-	}
-
 	scale, err := parseProcessTuples(processTuples)
 	if err != nil {
 		return err

--- a/plugins/ps/functions.go
+++ b/plugins/ps/functions.go
@@ -330,6 +330,10 @@ func updateScale(appName string, clearExisting bool, formationUpdates FormationS
 	}
 
 	for _, formation := range formations {
+		if foundProcessTypes[formation.ProcessType] {
+			continue
+		}
+
 		foundProcessTypes[formation.ProcessType] = true
 		updatedFormation = append(updatedFormation, &Formation{
 			ProcessType: formation.ProcessType,
@@ -349,7 +353,7 @@ func updateScale(appName string, clearExisting bool, formationUpdates FormationS
 	}
 
 	values := []string{}
-	for _, formation := range formations {
+	for _, formation := range updatedFormation {
 		values = append(values, fmt.Sprintf("%s=%d", formation.ProcessType, formation.Quantity))
 	}
 

--- a/plugins/ps/functions.go
+++ b/plugins/ps/functions.go
@@ -306,6 +306,24 @@ func readScaleFile(appName string) (map[string]int, error) {
 	return scale, nil
 }
 
+func getFormations(appName string) (FormationSlice, error) {
+	scale := FormationSlice{}
+	data, err := readScaleFile(appName)
+	if err != nil {
+		return scale, err
+	}
+
+	for processType, quantity := range data {
+		f := Formation{
+			ProcessType: processType,
+			Quantity:    quantity,
+		}
+		scale = append(scale, &f)
+	}
+
+	return scale, nil
+}
+
 func removeProcfile(appName string) error {
 	procfile := getProcfilePath(appName)
 	if !common.FileExists(procfile) {
@@ -332,8 +350,7 @@ func restorePrep() error {
 }
 
 func scaleReport(appName string) error {
-	scalefilePath := getScalefilePath(appName)
-	lines, err := common.FileToSlice(scalefilePath)
+	formations, err := getFormations(appName)
 	if err != nil {
 		return err
 	}
@@ -350,9 +367,9 @@ func scaleReport(appName string) error {
 		content = append(content, "proctype=qty", "--------=---")
 	}
 
-	sort.Strings(lines)
-	for _, line := range lines {
-		content = append(content, line)
+	sort.Sort(formations)
+	for _, formation := range formations {
+		content = append(content, fmt.Sprintf("%s=%d", formation.ProcessType, formation.Quantity))
 	}
 
 	for _, line := range content {

--- a/plugins/ps/ps.go
+++ b/plugins/ps/ps.go
@@ -24,12 +24,14 @@ var (
 	}
 )
 
-type FormationSlice []*Formation
-
+// Formation contains scaling information for a given process type
 type Formation struct {
 	ProcessType string `json:"process_type"`
 	Quantity    int    `json:"quantity"`
 }
+
+// FormationSlice contains a slice of Formations that can be sorted
+type FormationSlice []*Formation
 
 func (d FormationSlice) Len() int {
 	return len(d)

--- a/plugins/ps/ps.go
+++ b/plugins/ps/ps.go
@@ -24,6 +24,25 @@ var (
 	}
 )
 
+type FormationSlice []*Formation
+
+type Formation struct {
+	ProcessType string `json:"process_type"`
+	Quantity    int    `json:"quantity"`
+}
+
+func (d FormationSlice) Len() int {
+	return len(d)
+}
+
+func (d FormationSlice) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+
+func (d FormationSlice) Less(i, j int) bool {
+	return d[i].ProcessType < d[j].ProcessType
+}
+
 // Rebuild rebuilds app from base image
 func Rebuild(appName string) error {
 	return common.PlugnTrigger("receive-app", []string{appName}...)

--- a/plugins/ps/src/triggers/triggers.go
+++ b/plugins/ps/src/triggers/triggers.go
@@ -75,6 +75,9 @@ func main() {
 	case "procfile-remove":
 		appName := flag.Arg(0)
 		err = ps.TriggerProcfileRemove(appName)
+	case "ps-current-scale":
+		appName := flag.Arg(0)
+		err = ps.TriggerPsCurrentScale(appName)
 	case "report":
 		appName := flag.Arg(0)
 		err = ps.ReportSingleApp(appName, "", "")

--- a/plugins/ps/src/triggers/triggers.go
+++ b/plugins/ps/src/triggers/triggers.go
@@ -75,6 +75,11 @@ func main() {
 	case "procfile-remove":
 		appName := flag.Arg(0)
 		err = ps.TriggerProcfileRemove(appName)
+	case "ps-set-scale":
+		appName := flag.Arg(0)
+		appName, args := common.ShiftString(flag.Args())
+		skipDeploy, processTuples := common.ShiftString(args)
+		err = ps.TriggerPsSetScale(appName, common.ToBool(skipDeploy), processTuples)
 	case "ps-current-scale":
 		appName := flag.Arg(0)
 		err = ps.TriggerPsCurrentScale(appName)

--- a/plugins/ps/src/triggers/triggers.go
+++ b/plugins/ps/src/triggers/triggers.go
@@ -86,7 +86,8 @@ func main() {
 		appName := flag.Arg(0)
 		appName, args := common.ShiftString(flag.Args())
 		skipDeploy, processTuples := common.ShiftString(args)
-		err = ps.TriggerPsSetScale(appName, common.ToBool(skipDeploy), processTuples)
+		clearExisting, processTuples := common.ShiftString(args)
+		err = ps.TriggerPsSetScale(appName, common.ToBool(skipDeploy), common.ToBool(clearExisting), processTuples)
 	case "report":
 		appName := flag.Arg(0)
 		err = ps.ReportSingleApp(appName, "", "")

--- a/plugins/ps/src/triggers/triggers.go
+++ b/plugins/ps/src/triggers/triggers.go
@@ -75,14 +75,18 @@ func main() {
 	case "procfile-remove":
 		appName := flag.Arg(0)
 		err = ps.TriggerProcfileRemove(appName)
+	case "ps-can-scale":
+		appName := flag.Arg(0)
+		canScale := common.ToBool(flag.Arg(1))
+		err = ps.TriggerPsCanScale(appName, canScale)
+	case "ps-current-scale":
+		appName := flag.Arg(0)
+		err = ps.TriggerPsCurrentScale(appName)
 	case "ps-set-scale":
 		appName := flag.Arg(0)
 		appName, args := common.ShiftString(flag.Args())
 		skipDeploy, processTuples := common.ShiftString(args)
 		err = ps.TriggerPsSetScale(appName, common.ToBool(skipDeploy), processTuples)
-	case "ps-current-scale":
-		appName := flag.Arg(0)
-		err = ps.TriggerPsCurrentScale(appName)
 	case "report":
 		appName := flag.Arg(0)
 		err = ps.ReportSingleApp(appName, "", "")

--- a/plugins/ps/src/triggers/triggers.go
+++ b/plugins/ps/src/triggers/triggers.go
@@ -85,7 +85,7 @@ func main() {
 	case "ps-set-scale":
 		appName := flag.Arg(0)
 		appName, args := common.ShiftString(flag.Args())
-		skipDeploy, processTuples := common.ShiftString(args)
+		skipDeploy, args := common.ShiftString(args)
 		clearExisting, processTuples := common.ShiftString(args)
 		err = ps.TriggerPsSetScale(appName, common.ToBool(skipDeploy), common.ToBool(clearExisting), processTuples)
 	case "report":

--- a/plugins/ps/subcommands.go
+++ b/plugins/ps/subcommands.go
@@ -134,6 +134,10 @@ func CommandScale(appName string, skipDeploy bool, processTuples []string) error
 		return scaleReport(appName)
 	}
 
+	if !canScaleApp(appName) {
+		return fmt.Errorf("App %s contains DOKKU_SCALE file and cannot be manually scaled", appName)
+	}
+
 	return scaleSet(appName, skipDeploy, processTuples)
 }
 

--- a/plugins/ps/subcommands.go
+++ b/plugins/ps/subcommands.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	dockeroptions "github.com/dokku/dokku/plugins/docker-options"
 
@@ -120,24 +121,15 @@ func CommandScale(appName string, skipDeploy bool, processTuples []string) error
 		return err
 	}
 
-	procfilePath := getProcfilePath(appName)
-	if !hasScaleFile(appName) || common.FileExists(procfilePath) {
-		update := func() error {
-			return updateScalefile(appName, false, make(map[string]int))
-		}
-		if err := common.SuppressOutput(update); err != nil {
-			return err
-		}
-	}
-
 	if len(processTuples) == 0 {
 		return scaleReport(appName)
 	}
 
 	if !canScaleApp(appName) {
-		return fmt.Errorf("App %s contains DOKKU_SCALE file and cannot be manually scaled", appName)
+		return fmt.Errorf("App %s contains an app.json file with a formations key and cannot be manually scaled", appName)
 	}
 
+	common.LogInfo1(fmt.Sprintf("Scaling %s processes: %s", appName, strings.Join(processTuples, " ")))
 	return scaleSet(appName, skipDeploy, false, processTuples)
 }
 

--- a/plugins/ps/subcommands.go
+++ b/plugins/ps/subcommands.go
@@ -123,7 +123,7 @@ func CommandScale(appName string, skipDeploy bool, processTuples []string) error
 	procfilePath := getProcfilePath(appName)
 	if !hasScaleFile(appName) || common.FileExists(procfilePath) {
 		update := func() error {
-			return updateScalefile(appName, make(map[string]int))
+			return updateScalefile(appName, false, make(map[string]int))
 		}
 		if err := common.SuppressOutput(update); err != nil {
 			return err
@@ -138,7 +138,7 @@ func CommandScale(appName string, skipDeploy bool, processTuples []string) error
 		return fmt.Errorf("App %s contains DOKKU_SCALE file and cannot be manually scaled", appName)
 	}
 
-	return scaleSet(appName, skipDeploy, processTuples)
+	return scaleSet(appName, skipDeploy, false, processTuples)
 }
 
 // CommandSet sets or clears a ps property for an app

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -283,6 +283,7 @@ func TriggerPsCurrentScale(appName string) error {
 	return nil
 }
 
+// TriggerPsSetScale configures the scale parameters for a given app
 func TriggerPsSetScale(appName string, skipDeploy bool, processTuples []string) error {
 	return scaleSet(appName, skipDeploy, processTuples)
 }

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -150,7 +150,7 @@ func TriggerPostCreate(appName string) error {
 		return err
 	}
 
-	return updateScalefile(appName, make(map[string]int))
+	return updateScalefile(appName, false, make(map[string]int))
 }
 
 // TriggerPostDelete destroys the ps properties for a given app container
@@ -285,5 +285,5 @@ func TriggerPsCurrentScale(appName string) error {
 
 // TriggerPsSetScale configures the scale parameters for a given app
 func TriggerPsSetScale(appName string, skipDeploy bool, processTuples []string) error {
-	return scaleSet(appName, skipDeploy, processTuples)
+	return scaleSet(appName, skipDeploy, true, processTuples)
 }

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -282,3 +282,7 @@ func TriggerPsCurrentScale(appName string) error {
 
 	return nil
 }
+
+func TriggerPsSetScale(appName string, skipDeploy bool, processTuples []string) error {
+	return scaleSet(appName, skipDeploy, processTuples)
+}

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -315,6 +315,6 @@ func TriggerPsCurrentScale(appName string) error {
 }
 
 // TriggerPsSetScale configures the scale parameters for a given app
-func TriggerPsSetScale(appName string, skipDeploy bool, processTuples []string) error {
-	return scaleSet(appName, skipDeploy, true, processTuples)
+func TriggerPsSetScale(appName string, skipDeploy bool, clearExisting bool, processTuples []string) error {
+	return scaleSet(appName, skipDeploy, clearExisting, processTuples)
 }

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	sh "github.com/codeskyblue/go-sh"
@@ -263,6 +264,11 @@ func TriggerProcfileGetCommand(appName string, processType string, port int) err
 // TriggerProcfileRemove removes the procfile if it exists
 func TriggerProcfileRemove(appName string) error {
 	return removeProcfile(appName)
+}
+
+// TriggerPsCanScale sets whether or not a user can scale an app with ps:scale
+func TriggerPsCanScale(appName string, canScale bool) error {
+	return common.PropertyWrite("ps", appName, "can-scale", strconv.FormatBool(canScale))
 }
 
 // TriggerPsCurrentScale prints out the current scale contents (process-type=quantity) delimited by newlines

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -273,9 +273,12 @@ func TriggerPsCurrentScale(appName string) error {
 	}
 
 	sort.Sort(formations)
+	lines := []string{}
 	for _, formation := range formations {
-		fmt.Printf("%s=%d\n", formation.ProcessType, formation.Quantity)
+		lines = append(lines, fmt.Sprintf("%s=%d", formation.ProcessType, formation.Quantity))
 	}
+
+	fmt.Print(strings.Join(lines, "\n"))
 
 	return nil
 }

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -111,6 +111,7 @@ func TriggerInstall() error {
 			if err := common.PropertyWrite("ps", appName, "can-scale", strconv.FormatBool(false)); err != nil {
 				return err
 			}
+			os.Remove(dokkuScaleExtracted)
 		}
 	}
 

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -174,7 +174,12 @@ func TriggerPostCreate(appName string) error {
 		return err
 	}
 
-	formations := FormationSlice{}
+	formations := FormationSlice{
+		&Formation{
+			ProcessType: "web",
+			Quantity:    1,
+		},
+	}
 	return updateScale(appName, false, formations)
 }
 

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	sh "github.com/codeskyblue/go-sh"
@@ -262,4 +263,19 @@ func TriggerProcfileGetCommand(appName string, processType string, port int) err
 // TriggerProcfileRemove removes the procfile if it exists
 func TriggerProcfileRemove(appName string) error {
 	return removeProcfile(appName)
+}
+
+// TriggerPsCurrentScale prints out the current scale contents (process-type=quantity) delimited by newlines
+func TriggerPsCurrentScale(appName string) error {
+	formations, err := getFormations(appName)
+	if err != nil {
+		return err
+	}
+
+	sort.Sort(formations)
+	for _, formation := range formations {
+		fmt.Printf("%s=%d\n", formation.ProcessType, formation.Quantity)
+	}
+
+	return nil
 }

--- a/plugins/scheduler-docker-local/core-post-deploy
+++ b/plugins/scheduler-docker-local/core-post-deploy
@@ -16,7 +16,7 @@ trigger-scheduler-docker-local-core-post-deploy() {
   fi
 
   dokku_log_info1 "Renaming containers"
-  local PROCTYPES="$(grep -v -E "^#" "$DOKKU_ROOT/$APP/DOKKU_SCALE" | awk -F '=' '{ print $1 }' | xargs)"
+  local PROCTYPES="$(plugn trigger ps-current-scale "$APP" | awk -F '=' '{ print $1 }' | xargs)"
   local CONTAINER_FILES="$(find "$DOKKU_ROOT/$APP" -maxdepth 1 -name "CONTAINER.*" -printf "%f\n" 2>/dev/null | sort -t . -k 3 -n | xargs)"
 
   local CONTAINER_FILE

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -29,7 +29,6 @@ trigger-scheduler-docker-local-scheduler-deploy() {
   local IMAGE_SOURCE_TYPE="dockerfile"
   [[ "$DOKKU_HEROKUISH" == "true" ]] && IMAGE_SOURCE_TYPE="herokuish"
   [[ "$DOKKU_CNB" == "true" ]] && IMAGE_SOURCE_TYPE="pack"
-  local DOKKU_SCALE_FILE="$DOKKU_ROOT/$APP/DOKKU_SCALE"
   local oldids=$(get_app_container_ids "$APP")
 
   DOKKU_NETWORK_BIND_ALL="$(plugn trigger network-get-property "$APP" bind-all-interfaces)"
@@ -178,7 +177,7 @@ trigger-scheduler-docker-local-scheduler-deploy() {
       cd "$DOKKU_ROOT/$APP"
       find . -maxdepth 1 -name "$container_state_filetype.$PROC_TYPE.*" -printf "%f\n" | sort -t . -k 3 -n | tail -n +$CONTAINER_IDX_OFFSET | xargs rm -f
     done
-  done <"$DOKKU_SCALE_FILE"
+  done <"$(plugn trigger ps-current-scale "$APP")"
 
   dokku_log_info1 "Running post-deploy"
   plugn trigger core-post-deploy "$APP" "$port" "$ipaddr" "$IMAGE_TAG"

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -177,7 +177,7 @@ trigger-scheduler-docker-local-scheduler-deploy() {
       cd "$DOKKU_ROOT/$APP"
       find . -maxdepth 1 -name "$container_state_filetype.$PROC_TYPE.*" -printf "%f\n" | sort -t . -k 3 -n | tail -n +$CONTAINER_IDX_OFFSET | xargs rm -f
     done
-  done <"$(plugn trigger ps-current-scale "$APP")"
+  done < <(plugn trigger ps-current-scale "$APP")
 
   dokku_log_info1 "Running post-deploy"
   plugn trigger core-post-deploy "$APP" "$port" "$ipaddr" "$IMAGE_TAG"

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -50,8 +50,6 @@ trigger-scheduler-docker-local-scheduler-deploy() {
   local PROC_COUNT
   local CONTAINER_INDEX
   while read -r line || [[ -n "$line" ]]; do
-    [[ "$line" =~ ^#.* ]] && continue
-    line="$(strip_inline_comments "$line")"
     PROC_TYPE=${line%%=*}
     PROC_COUNT=${line#*=}
     CONTAINER_INDEX=1

--- a/tests/unit/nginx-vhosts_2.bats
+++ b/tests/unit/nginx-vhosts_2.bats
@@ -36,9 +36,14 @@ teardown() {
   assert_ssl_domain "wildcard2.dokku.me"
 }
 
-@test "(nginx-vhosts) nginx:build-config (wildcard SSL and unrelated domain)" {
+@test "(nginx-vhosts) nginx:build-config (wildcard SSL and unrelated domain) 1" {
   destroy_app
   TEST_APP="${TEST_APP}.example.com"
+  run /bin/bash -c "dokku apps:create $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   setup_test_tls wildcard
   deploy_app nodejs-express dokku@dokku.me:$TEST_APP
   run /bin/bash -c "dokku nginx:show-config $TEST_APP | grep -e '*.dokku.me' | wc -l"

--- a/tests/unit/ps-general.bats
+++ b/tests/unit/ps-general.bats
@@ -55,7 +55,7 @@ EOF
   assert_output "node worker.js"
 }
 
-@test "(ps:scale) update DOKKU_SCALE from Procfile" {
+@test "(ps:scale) update formations from Procfile" {
   local TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
 


### PR DESCRIPTION
Also deprecate the `DOKKU_SCALE` file.

TODO:

- [x] Add deprecation to migration guide
- [x] Document the formation key in the process management docs
- [x] Add the initial migration of the extracted `DOKKU_SCALE` file to the formation key in the existing app.json file
- [x] Drop all `DOKKU_SCALE` extraction from ps plugin
- [x] Write current scale to properties system
- [x] Add a `ps-can-scale` trigger that should be called with `true/false` depending on if the formation key has any values or not
- [x] Add a `ps-scale-set` trigger that will overwrite _all_ the existing scale factors
- [x] Add a way to generate a string representation of scaling for use by other plugins
  - This could be something as simple as the current `DOKKU_SCALE` file without support for comments and such, and pre-prepared so we know there aren't any "errors" in it.
    - This is what I chose. It will be `=` separated, newline delimited entries where `process-type=quantity`. This mimics the `DOKKU_SCALE` contents (for ease of use in shell) while making parsing in golang easy (with a helper function in `common.go`).
  - ~Alternative is json, but then we'd need to parse it. See https://www.starkandwayne.com/blog/bash-for-loop-over-json-array-using-jq/ for an example of that, which may be best?~
- [x] Refactor all plugins to not directly parse the `DOKKU_SCALE` file and instead use string representation from trigger

Closes #4500
