### PR TITLE
Reformat existing buildpacks files

### DIFF
--- a/plugins/buildpacks/functions.go
+++ b/plugins/buildpacks/functions.go
@@ -3,18 +3,51 @@ package buildpacks
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/dokku/dokku/plugins/common"
 )
+
+func rewriteBuildpacksFile(sourceWorkDir string) error {
+	buildpacksPath := filepath.Join(sourceWorkDir, ".buildpacks")
+	if !common.FileExists(buildpacksPath) {
+		return nil
+	}
+
+	buildpacks, err := common.FileToSlice(buildpacksPath)
+	if err != nil {
+		return err
+	}
+
+	for i, buildpack := range buildpacks {
+		if buildpack == "" {
+			continue
+		}
+
+		buildpack, err = validBuildpackURL(buildpack)
+		if err != nil {
+			return fmt.Errorf("Unable to parse .buildpacks file, line %d: %s", i, err)
+		}
+
+		buildpacks[i] = buildpack
+	}
+
+	return common.WriteSliceToFile(buildpacksPath, buildpacks)
+}
 
 func validBuildpackURL(buildpack string) (string, error) {
 	if buildpack == "" {
 		return buildpack, errors.New("Must specify a buildpack to add")
 	}
 
-	reHerokuValue := regexp.MustCompile(`(?m)^([\w]+\/[\w]+)$`)
+	reHerokuValue := regexp.MustCompile(`(?m)^([\w-]+\/[\w-]+)$`)
 	if found := reHerokuValue.Find([]byte(buildpack)); found != nil {
 		parts := strings.SplitN(buildpack, "/", 2)
+		if parts[0] == "heroku-community" {
+			parts[0] = "heroku"
+		}
 		return fmt.Sprintf("https://github.com/%s/heroku-buildpack-%s.git", parts[0], parts[1]), nil
 	}
 

--- a/plugins/buildpacks/triggers.go
+++ b/plugins/buildpacks/triggers.go
@@ -78,7 +78,7 @@ func TriggerPostExtract(appName string, sourceWorkDir string) error {
 	}
 
 	if len(buildpacks) == 0 {
-		return nil
+		return rewriteBuildpacksFile(sourceWorkDir)
 	}
 
 	buildpacksPath := filepath.Join(sourceWorkDir, ".buildpacks")

--- a/tests/unit/buildpacks.bats
+++ b/tests/unit/buildpacks.bats
@@ -290,3 +290,28 @@ teardown() {
   echo "status: $status"
   assert_success
 }
+
+@test "(buildpacks) cleanup existing .buildpacks file" {
+  run deploy_app python dokku@dokku.me:$TEST_APP template_buildpacks_cleanup
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "heroku-buildpack-apt"
+  assert_output_contains "heroku-buildpack-python"
+}
+
+template_buildpacks_cleanup() {
+  local APP="$1"
+  local APP_REPO_DIR="$2"
+  [[ -z "$APP" ]] && local APP="$TEST_APP"
+  echo "injecting .buildpacks with shorthand -> $APP_REPO_DIR/.buildpacks"
+  cat <<EOF >"$APP_REPO_DIR/.buildpacks"
+heroku-community/apt
+heroku/python
+EOF
+
+  echo "injecting Aptfile -> $APP_REPO_DIR/Aptfile"
+  cat <<EOF >"$APP_REPO_DIR/Aptfile"
+hello
+EOF
+}


### PR DESCRIPTION
Previously, the shorthand was not properly supported. While this _should_ be the domain of the gliderlabs/herokuish repository, we do it here as a courtesy to Dokku users.

Additionally, support the heroku-community => heroku mapping.

Closes #4452