### PR TITLE
deployment docs: fix letsencrypt plugin name

### DIFF
--- a/docs/deployment/application-deployment.md
+++ b/docs/deployment/application-deployment.md
@@ -121,7 +121,7 @@ As an alternative, the Dokku project offers an optional letsencrypt plugin that 
 
 ```shell
 # on the Dokku host
-# install the postgres plugin
+# install the letsencrypt plugin
 # plugin installation requires root, hence the user change
 sudo dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git
 


### PR DESCRIPTION
**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
