### PR TITLE
Remove the remaining traces of dokku-update

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: web
 Priority: optional
 Architecture: amd64
 Depends: locales, git, cpio, curl, man-db, netcat, sshcommand (>= 0.12.0), docker-engine-cs (>= 17.05.0) | docker-engine (>= 17.05.0) | docker-io (>= 17.05.0) | docker.io (>= 17.05.0) | docker-ce (>= 17.05.0) | docker-ee (>= 17.05.0) | moby-engine, docker-image-labeler (>= 0.2.2), net-tools, netrc, software-properties-common, procfile-util (>= 0.11.0), python-software-properties | python3-software-properties, rsyslog, dos2unix, jq, unzip
-Recommends: herokuish (>= 0.3.4), parallel, dokku-update, dokku-event-listener
+Recommends: herokuish (>= 0.3.4), parallel, dokku-event-listener
 Pre-Depends: gliderlabs-sigil, nginx (>= 1.8.0) | openresty, dnsutils, cgroupfs-mount | cgroup-lite, plugn (>= 0.3.0), sudo, python3, debconf
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 Description: Docker-powered PaaS that helps build and manage the lifecycle of applications

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -79,16 +79,6 @@ dokku ps:rebuild --all
 > Please see the [images documentation](/docs/deployment/methods/images.md) and [tar documentation](/docs/deployment/methods/tar.md)
 > for instructions on rebuilding applications deployed by those plugins.
 
-## Upgrading using `dokku-update`
-
-We provide a helpful binary called `dokku-update`. This is a recommended package that:
-
-- Can be installed separately, so upgrading Dokku will not affect the running of this package.
-- Automates many of the upgrade instructions for you.
-- Provides a clean way for us to further enhance the upgrade process in the future.
-
-When installing from source, this is available from `contrib/dokku-update`, and is also available on Debian and RPM-based systems from our package repositories under the name `dokku-update`.
-
 ## Upgrading using `apt`
 
 If Dokku was installed in a Debian or Ubuntu system, via `apt-get install dokku` or `bootstrap.sh`, you can upgrade with `apt-get`:
@@ -98,7 +88,7 @@ If Dokku was installed in a Debian or Ubuntu system, via `apt-get install dokku`
 sudo apt-get update -qq
 
 # update dokku and its dependencies
-sudo apt-get -qq -y --no-install-recommends install dokku herokuish sshcommand plugn gliderlabs-sigil dokku-update dokku-event-listener
+sudo apt-get -qq -y --no-install-recommends install dokku herokuish sshcommand plugn gliderlabs-sigil dokku-event-listener
 
 # or just upgrade every package:
 sudo apt-get upgrade


### PR DESCRIPTION
Re: #4527 [ci skip]
I guess [dokku-update](https://github.com/dokku/dokku-update) can be archived as well?