### PR TITLE
Scope return 301 in nginx config to allow proper letsencrypt usage

### DIFF
--- a/plugins/common/property-functions
+++ b/plugins/common/property-functions
@@ -10,7 +10,7 @@ fn-plugin-property-get() {
 }
 
 fn-plugin-property-clone() {
-  declare desc="destroy the properties for an app"
+  declare desc="clone the properties for an app"
   declare PLUGIN="$1" OLD_APP="$2" NEW_APP="$3"
   "$PLUGIN_CORE_AVAILABLE_PATH/common/prop" "clone" "$PLUGIN" "$OLD_APP" "$NEW_APP"
 }

--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -12,7 +12,10 @@ server {
   access_log  {{ $.NGINX_ACCESS_LOG_PATH }}{{ if and ($.NGINX_ACCESS_LOG_FORMAT) (ne $.NGINX_ACCESS_LOG_PATH "off") }} {{ $.NGINX_ACCESS_LOG_FORMAT }}{{ end }};
   error_log   {{ $.NGINX_ERROR_LOG_PATH }};
 {{ if (and (eq $listen_port "80") ($.SSL_INUSE)) }}
-  return 301 https://$host:{{ $.PROXY_SSL_PORT }}$request_uri;
+  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
+  location / {
+    return 301 https://$host:{{ $.PROXY_SSL_PORT }}$request_uri;
+  }
 {{ else }}
   location    / {
 

--- a/plugins/proxy/functions
+++ b/plugins/proxy/functions
@@ -8,7 +8,7 @@ is_app_proxy_enabled() {
   declare desc="return true if proxy is enabled; otherwise return false"
   declare APP="$1"
   declare deprecated=true
-  dokku_log_warn "Deprecated: plugn#proxy-is-enabled"
+  dokku_log_warn "Deprecated: Use plugn#proxy-is-enabled"
 
   plugn trigger proxy-is-enabled "$APP"
 }
@@ -17,7 +17,7 @@ get_app_proxy_type() {
   declare desc="return app proxy type"
   declare APP="$1"
   declare deprecated=true
-  dokku_log_warn "Deprecated: plugn#proxy-type"
+  dokku_log_warn "Deprecated: Use plugn#proxy-type"
 
   plugn trigger proxy-type "$APP"
 }


### PR DESCRIPTION
Previously, there was an edge-case where it was possible to return a 301 response to letsencrypt auth requests. This change scopes the 301 to just the `location /` block, allowing other `location` blocks in app-specific includes to work as expected.

Refs dokku/dokku-letsencrypt#228