### PR TITLE
Add bash-completion to debian package recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: web
 Priority: optional
 Architecture: amd64
 Depends: locales, git, cpio, curl, man-db, netcat, sshcommand (>= 0.12.0), docker-engine-cs (>= 17.05.0) | docker-engine (>= 17.05.0) | docker-io (>= 17.05.0) | docker.io (>= 17.05.0) | docker-ce (>= 17.05.0) | docker-ee (>= 17.05.0) | moby-engine, docker-image-labeler (>= 0.2.2), net-tools, netrc, software-properties-common, procfile-util (>= 0.11.0), python-software-properties | python3-software-properties, rsyslog, dos2unix, jq, unzip
-Recommends: herokuish (>= 0.3.4), parallel, dokku-update, dokku-event-listener
+Recommends: herokuish (>= 0.3.4), bash-completion, parallel, dokku-update, dokku-event-listener
 Pre-Depends: gliderlabs-sigil, nginx (>= 1.8.0) | openresty, dnsutils, cgroupfs-mount | cgroup-lite, plugn (>= 0.3.0), sudo, python3, debconf
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 Description: Docker-powered PaaS that helps build and manage the lifecycle of applications


### PR DESCRIPTION
We're skipping adding this to the yum package as we're going to start phasing out support for non-debian hosts in favor of installing via the Docker image.

Closes #4538
