### PR TITLE
Tough netrc file when setting git:auth entries

### DIFF
--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -112,7 +112,6 @@ cmd-git-auth() {
   if [[ -z "$USERNAME" ]]; then
     dokku_log_info1 "Removing netrc auth entry for host $HOST"
     netrc unset "$HOST"
-    rm "${DOKKU_ROOT}/.netrc"
     return $?
   fi
 

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -112,10 +112,12 @@ cmd-git-auth() {
   if [[ -z "$USERNAME" ]]; then
     dokku_log_info1 "Removing netrc auth entry for host $HOST"
     netrc unset "$HOST"
+    rm "${DOKKU_ROOT}/.netrc"
     return $?
   fi
 
   dokku_log_info1 "Setting netrc auth entry for host $HOST"
+  touch "${DOKKU_ROOT}/.netrc"
   netrc set "$HOST" "$USERNAME" "$PASSWORD"
 }
 


### PR DESCRIPTION
**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.

Creating .netrc file before setting gith auth values

Removing .netrc file after removing gith auth values