### PR TITLE
Fix alternate-tags content & escaping

### DIFF
--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -168,7 +168,7 @@ cmd-git-from-image() {
   dokku_log_verbose "Setting Dockerfile"
   touch "$TMP_WORK_DIR/Dockerfile"
   echo "FROM $DOCKER_IMAGE" >>"$TMP_WORK_DIR/Dockerfile"
-  echo "LABEL com.dokku.docker-image-labeler/alternate-tags=\"[\"linuxserver/foldingathome:7.5.1-ls1\"]\"" >>"$TMP_WORK_DIR/Dockerfile"
+  echo "LABEL com.dokku.docker-image-labeler/alternate-tags=[\\\"$DOCKER_IMAGE\\\"]" >>"$TMP_WORK_DIR/Dockerfile"
 
   plugn trigger git-from-directory "$APP" "$TMP_WORK_DIR" "$USER_NAME" "$USER_EMAIL"
 }


### PR DESCRIPTION
**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.

As discussed on Slack, currently the `git:from-image` command always puts a static string into the `alternate-tags`, and also it doesn’t write the output as a valid JSON array.

This PR puts the correct image name into the `alternate-tags` image label, and fixed the escaping issues.