### PR TITLE
Fix typo in nginx logging configuration example

### DIFF
--- a/docs/configuration/nginx.md
+++ b/docs/configuration/nginx.md
@@ -149,7 +149,7 @@ log_format json_combined escape=json
     '"remote_addr":"$remote_addr",'
     '"remote_user":"$remote_user",'
     '"request":"$request",'
-    '"status": "$status",'
+    '"status":"$status",'
     '"body_bytes_sent":"$body_bytes_sent",'
     '"request_time":"$request_time",'
     '"http_referrer":"$http_referer",'


### PR DESCRIPTION
Remove extra space in nginx logging config example.

This causes ingestion problems on AWS Cloudwatch and brings the attribute in line with the other attributes in the example. 

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
