### PR TITLE
Respect custom stack when using cloud native builder

### DIFF
--- a/docs/deployment/builders/cloud-native-buildpacks.md
+++ b/docs/deployment/builders/cloud-native-buildpacks.md
@@ -69,7 +69,7 @@ dokku buildpacks:set-property node-js-app stack
 
 A change in the stack builder value will execute the `post-stack-set` trigger.
 
-Finally, stack builders can be set or unset globally as a fallback. This will take precedence over a globally set `DOKKU_CNB_STACK` environment variable (`heroku/buildpacks` by default).
+Finally, stack builders can be set or unset globally as a fallback. This will take precedence over a globally set `DOKKU_CNB_BUILDER` environment variable (`heroku/buildpacks` by default).
 
 ```shell
 # set globally

--- a/plugins/builder-pack/builder-build
+++ b/plugins/builder-pack/builder-build
@@ -15,9 +15,7 @@ trigger-builder-pack-builder-build() {
 
   local stack="$(plugn trigger buildpack-stack-name "$APP")"
   if [[ -n "$stack" ]]; then
-    DOKKU_CNB_STACK="$stack"
-  else
-    DOKKU_CNB_STACK="$DOKKU_CNB_BUILDER"
+    DOKKU_CNB_BUILDER="$stack"
   fi
 
   dokku_log_info1 "Building $APP from cnb stack $DOKKU_CNB_STACK (experimental)..."
@@ -37,7 +35,7 @@ trigger-builder-pack-builder-build() {
 
   plugn trigger pre-build-pack "$APP" "$SOURCECODE_WORK_DIR"
 
-  pack build "$IMAGE" --builder "$DOKKU_CNB_STACK" --path "$SOURCECODE_WORK_DIR" --default-process web
+  pack build "$IMAGE" --builder "$DOKKU_CNB_BUILDER" --path "$SOURCECODE_WORK_DIR" --default-process web
 
   docker-image-labeler --label=com.dokku.image-stage=build --label=com.dokku.app-name=$APP --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=dokku "$IMAGE"
 

--- a/plugins/builder-pack/builder-build
+++ b/plugins/builder-pack/builder-build
@@ -18,7 +18,7 @@ trigger-builder-pack-builder-build() {
     DOKKU_CNB_BUILDER="$stack"
   fi
 
-  dokku_log_info1 "Building $APP from cnb stack $DOKKU_CNB_STACK (experimental)..."
+  dokku_log_info1 "Building $APP from cnb stack $DOKKU_CNB_BUILDER (experimental)..."
 
   if ! command -v "pack" &>/dev/null; then
     dokku_log_fail "Missing pack, install it"

--- a/plugins/builder-pack/builder-build
+++ b/plugins/builder-pack/builder-build
@@ -14,8 +14,10 @@ trigger-builder-pack-builder-build() {
   fi
 
   local stack="$(plugn trigger buildpack-stack-name "$APP")"
-  if [[ -z "$stack" ]]; then
+  if [[ -n "$stack" ]]; then
     DOKKU_CNB_STACK="$stack"
+  else
+    DOKKU_CNB_STACK="$DOKKU_CNB_BUILDER"
   fi
 
   dokku_log_info1 "Building $APP from cnb stack $DOKKU_CNB_STACK (experimental)..."
@@ -35,7 +37,7 @@ trigger-builder-pack-builder-build() {
 
   plugn trigger pre-build-pack "$APP" "$SOURCECODE_WORK_DIR"
 
-  pack build "$IMAGE" --builder "$DOKKU_CNB_BUILDER" --path "$SOURCECODE_WORK_DIR" --default-process web
+  pack build "$IMAGE" --builder "$DOKKU_CNB_STACK" --path "$SOURCECODE_WORK_DIR" --default-process web
 
   docker-image-labeler --label=com.dokku.image-stage=build --label=com.dokku.app-name=$APP --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=dokku "$IMAGE"
 


### PR DESCRIPTION
Currently dokku will not take custom stacks into account when using the cloud-native builder. Instead it will always use the heroku-stack `heroku/buildpacks`.
This PR should take custom stacks into account.