### PR TITLE
Fix typo in docs for GitHub Actions

### DIFF
--- a/docs/deployment/continuous-integration/github-actions.md
+++ b/docs/deployment/continuous-integration/github-actions.md
@@ -1,6 +1,6 @@
-# Github Actions
+# GitHub Actions
 
-The Dokku project has an official Githb Action available on the [Github Marketplace](https://github.com/marketplace/actions/dokku). The simplest usage example is as follows:
+The Dokku project has an official GitHub Action available on the [GitHub Marketplace](https://github.com/marketplace/actions/dokku). The simplest usage example is as follows:
 
 ```yaml
 ---
@@ -28,4 +28,4 @@ jobs:
 ```
 
 
-For further usage documentation and other advanced examples, see the entry on the [Github Marketplace](https://github.com/marketplace/actions/dokku).
+For further usage documentation and other advanced examples, see the entry on the [GitHub Marketplace](https://github.com/marketplace/actions/dokku).


### PR DESCRIPTION
The PR fixes a small typo in the docs

**Note:** If this PR is just doc changes, please put [ci skip] in the body that way tests do not run.
