### PR TITLE
Add initial support for installing onto Fedora

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 # That's good because it prevents our output overlapping with wget's.
 # It also means that we can't run a partially downloaded script.
 
-SUPPORTED_VERSIONS="Debian [9, 10], CentOS [7], Ubuntu [16.04, 18.04, 20.04]"
+SUPPORTED_VERSIONS="Debian [9, 10], CentOS [7], Fedora (partial) [33, 34], Ubuntu [16.04, 18.04, 20.04]"
 
 log-fail() {
   declare desc="log fail formatter"
@@ -131,7 +131,7 @@ install-dokku-from-package() {
     debian | ubuntu)
       install-dokku-from-deb-package "$@"
       ;;
-    centos | rhel)
+    centos | fedora | rhel)
       install-dokku-from-rpm-package "$@"
       ;;
     *)

--- a/plugins/20_events/install
+++ b/plugins/20_events/install
@@ -17,7 +17,7 @@ trigger-events-install() {
   # shellcheck disable=SC2174
   mkdir -m 775 -p "$DOKKU_LOGS_DIR"
   case "$DOKKU_DISTRO" in
-    arch | debian | centos | rhel)
+    arch | debian | centos | fedora | rhel)
       chgrp dokku "$DOKKU_LOGS_DIR"
       ;;
     *)
@@ -28,7 +28,7 @@ trigger-events-install() {
   if [[ ! -f "$DOKKU_EVENTS_LOGFILE" ]]; then
     touch "$DOKKU_EVENTS_LOGFILE"
     case "$DOKKU_DISTRO" in
-      arch | debian | centos | rhel)
+      arch | debian | centos | fedora | rhel)
         chgrp dokku "$DOKKU_EVENTS_LOGFILE"
         ;;
       *)

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -45,7 +45,7 @@ trigger-nginx-vhosts-install() {
       echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl reload $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       ;;
 
-    centos | rhel)
+    centos | fedora | rhel)
       echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl reload $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       echo "Defaults:dokku !requiretty" >>"$NGINX_SUDOERS_FILE"
       ;;

--- a/plugins/nginx-vhosts/internal-functions
+++ b/plugins/nginx-vhosts/internal-functions
@@ -119,7 +119,7 @@ fn-nginx-vhosts-nginx-init-cmd() {
       sudo /sbin/service "$NGINX_INIT_NAME" "$CMD"
       ;;
 
-    arch | centos | rhel)
+    arch | centos | fedora | rhel)
       sudo /usr/bin/systemctl "$CMD" "$NGINX_INIT_NAME"
       ;;
   esac


### PR DESCRIPTION
This pull request adds the beginnings of Fedora support for install.

Closes #4634

## Caveats

- I install via RPMs staged at packagecloud, not with the bootstrap script. Because the RPMs are prebuilt, the install fails and I have to run `dokku plugin:install --color` manually, which doesn't call the `postinstall` which fails and I have to run that manually from source

- I couldn't test the bootstrap script since install from source looks only support Debian

- Originally got working on Fedora Server 33 and tested against 34.


## Manual testing notes

I originally got this working against Fedora Server 33 on EC2 but I ran the manual test against a local VM running a pristine installation of Fedora Server 34.

My test app was a static buildpack app with a single HTML file in it.

I did get the following warning during pushes which looks like it's coming from `/etc/profile.d/which2.sh`:

```
[david@x testproject]$ git push test-dokku-vm master 
Enumerating objects: 48, done.
Counting objects: 100% (48/48), done.
Delta compression using up to 8 threads
Compressing objects: 100% (40/40), done.
Writing objects: 100% (48/48), 59.96 KiB | 14.99 MiB/s, done.
Total 48 (delta 16), reused 0 (delta 0), pack-reused 0
remote: /tmp/bashenv.614554456: line 63: export: `BASH_FUNC_which%%=() {  ( alias;
remote:  eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
remote: }': not a valid identifier
remote: /tmp/bashenv.972282145: line 62: export: `BASH_FUNC_which%%=() {  ( alias;
remote:  eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
remote: }': not a valid identifier
remote: /tmp/bashenv.101626620: line 62: export: `BASH_FUNC_which%%=() {  ( alias;
remote:  eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
remote: }': not a valid identifier
-----> Cleaning up...
remote: /tmp/bashenv.461716766: line 62: export: `BASH_FUNC_which%%=() {  ( alias;
remote:  eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
remote: }': not a valid identifier
-----> Building test from herokuish...
remote: /tmp/bashenv.142351285: line 63: export: `BASH_FUNC_which%%=() {  ( alias;
remote:  eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
remote: }': not a valid identifier
remote: /tmp/bashenv.558175866: line 63: export: `BASH_FUNC_which%%=() {  ( alias;
remote:  eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
remote: }': not a valid identifier
-----> Adding BUILD_ENV to build environment...
-----> Multipack app detected
=====> Downloading Buildpack: https://github.com/heroku/heroku-buildpack-static
=====> Detected Framework: Static HTML
remote:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
remote:                                  Dload  Upload   Total   Spent    Left  Speed
remote: 100  838k  100  838k    0     0  3327k      0 --:--:-- --:--:-- --:--:-- 3327k
-----> Installed directory to /app/bin
       Using release configuration from last framework (Static HTML).
-----> Discovering process types
       Default types for  -> web
-----> Releasing test...
remote: /tmp/bashenv.880008635: line 63: export: `BASH_FUNC_which%%=() {  ( alias;
remote:  eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
remote: }': not a valid identifier
-----> Deploying test...
remote: /tmp/bashenv.181775087: line 63: export: `BASH_FUNC_which%%=() {  ( alias;
remote:  eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
remote: }': not a valid identifier
-----> App Procfile file found
-----> DOKKU_SCALE file not found in app image. Generating one based on Procfile...
       DOKKU_SCALE declares scale -> web=1
=====> Processing deployment checks
-----> Attempting pre-flight checks (web.1)
       CHECKS expected result:
       http://localhost/ => ""
       Attempt 1/5. Waiting for 5 seconds ...
       All checks successful!
=====> test web container output:
       Starting log redirection...
       Starting nginx...
       172.17.0.1 - - [07/Jun/2021:14:11:45 +0000] "GET / HTTP/1.1" 200 2058 "-" "curl/7.76.1"
=====> end test web container output
-----> Running post-deploy
-----> Creating new app virtual host file...
-----> Configuring test.fedora...(using built-in template)
-----> Creating http nginx.conf
       Reloading nginx
-----> Renaming containers
       Renaming container (3af1a40c6ae1) quirky_jepsen to test.web.1
=====> Application deployed:
remote: /tmp/bashenv.955668314: line 63: export: `BASH_FUNC_which%%=() {  ( alias;
remote:  eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
remote: }': not a valid identifier
remote: /tmp/bashenv.481767413: line 63: export: `BASH_FUNC_which%%=() {  ( alias;
remote:  eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
remote: }': not a valid identifier
       http://test.fedora

To 192.168.122.151:test
 * [new branch]      master -> master
```

It looks like Fedora 34 updated that script from this:

```bash
if [ "$0" = "ksh" -o "$0" = "-ksh" -o "$0" = "mksh" -o "$0" = "-mksh" ] ; then
  alias which='(alias; typeset -f) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot'
else
  alias which='(alias; declare -f) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot'
fi
```

to this:

```bash
# shellcheck shell=sh
# Initialization script for bash, sh, mksh and ksh

which_declare="declare -f"
which_opt="-f"
which_shell="$(cat /proc/$$/comm)"

if [ "$which_shell" = "ksh" ] || [ "$which_shell" = "mksh" ] || [ "$which_shell" = "zsh" ] ; then
  which_declare="typeset -f"
  which_opt=""
fi
 
which ()
{
(alias; eval ${which_declare}) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"
}

export which_declare
export ${which_opt} which
[root@fedora ~]# cat >/etc/profile.d/which2.sh
if [ "$0" = "ksh" -o "$0" = "-ksh" -o "$0" = "mksh" -o "$0" = "-mksh" ] ; then
  alias which='(alias; typeset -f) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot'
else
  alias which='(alias; declare -f) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot'
fi
```

After replacing 34's `which2.sh` with the one bundled with 33, the warning goes away. I'm gonna keep the VM around for a few days in case more info is needed.