### PR TITLE
Update unit test publisher to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           path: test-results
 
       - name: Publish Unit Test Results
-        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1
         with:
           check_name: Unit Test Results
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
By using v1, github actions will resolve to the latest v1.x release.