### PR TITLE
GitHub Actions: Fixed unable to find version `v1`

### DIFF
--- a/docs/deployment/continuous-integration/github-actions.md
+++ b/docs/deployment/continuous-integration/github-actions.md
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@v1
+        uses: dokku/github-action@master
         with:
           git_remote_url: 'ssh://dokku@dokku.me:22/appname'
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
[ci skip]

Hey,

I just found Dokku and it's awesome. Congrats guys for this amazing product. 

I found a problem with GitHub Actions. I was getting this error:
```
Unable to resolve action `dokku/github-action@v1`, unable to find version `v1`
```

And this PR is solving this issue.

Have a nice day,
Cosmin
