### PR TITLE
Make scripts a list

### DIFF
--- a/docs/deployment/continuous-integration/gitlab-ci.md
+++ b/docs/deployment/continuous-integration/gitlab-ci.md
@@ -18,8 +18,10 @@ deploy:
     - master
   variables:
     GIT_REMOTE_URL: ssh://dokku@dokku.me:22/appname
-  script: dokku-deploy
-  after_script: dokku-unlock
+  script: 
+    - dokku-deploy
+  after_script: 
+    - dokku-unlock
 ```
 
 For further usage documentation and other advanced examples, see Dokku's [gitlab-ci](https://github.com/dokku/gitlab-ci) repository.


### PR DESCRIPTION
Without this, the config is invalid.

Technically this is only necessary for `after_script`, but changed both for consistency.

![image](https://user-images.githubusercontent.com/6527489/123525752-f3fb4280-d6ca-11eb-8b26-878c4c0dae22.png)
