### PR TITLE
tests: Remove ci skip note in PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,0 @@
-**Note:** If this PR is just doc changes, please put `[ci skip]` in the body that way tests do not run.


### PR DESCRIPTION
Tests are no longer skippable.

