### PR TITLE
Swap from freenode to libera.chat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,4 +135,4 @@ which contains test setup information as well as tips for running tests.
 - [Existing issues](https://github.com/dokku/dokku/issues)
 - [General GitHub documentation](https://help.github.com/)
 - [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
-- [#dokku IRC channel on freenode.org](https://webchat.freenode.net/?channels=dokku)
+- [Gliderlabs Slack in the #dokku channel](https://glider-slackin.herokuapp.com/)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://github.com/dokku/dokku/workflows/CI/badge.svg)](https://github.com/dokku/dokku/actions?query=workflow%3ACI)
 [![Ubuntu Package](https://img.shields.io/badge/package-ubuntu-brightgreen.svg?style=flat-square "Ubuntu Package")](https://packagecloud.io/dokku/dokku)
 [![Arch Package](https://img.shields.io/badge/package-arch-brightgreen.svg?style=flat-square "Arch Package")](https://aur.archlinux.org/packages/dokku/)
-[![IRC Network](https://img.shields.io/badge/irc-freenode-blue.svg?style=flat-square "IRC Freenode")](https://webchat.freenode.net/?channels=dokku)
 [![Slack Group](https://img.shields.io/badge/irc-slack-blue.svg?style=flat-square "Slack Group")](https://glider-slackin.herokuapp.com/)
 [![Documentation](https://img.shields.io/badge/docs-site-blue.svg?style=flat-square "Site")](https://dokku.com/docs/getting-started/installation/)
 [![OpenCollective](https://opencollective.com/dokku/sponsors/badge.svg?style=flat-square)](#sponsors)
@@ -117,11 +116,11 @@ Full documentation - including advanced installation docs - are available online
 
 ## Support
 
-You can use [GitHub Issues](https://github.com/dokku/dokku/issues), check [Troubleshooting](https://dokku.com/docs/getting-started/troubleshooting/) in the documentation, or join us on [freenode in #dokku](https://webchat.freenode.net/?channels=%23dokku).
+You can use [GitHub Issues](https://github.com/dokku/dokku/issues), check [Troubleshooting](https://dokku.com/docs/getting-started/troubleshooting/) in the documentation, or join us on [Gliderlabs Slack in the #dokku channel](https://glider-slackin.herokuapp.com/).
 
 ## Contribution
 
-After checking [GitHub Issues](https://github.com/dokku/dokku/issues), the [Troubleshooting Guide](https://dokku.com/docs/getting-started/troubleshooting/) or having a chat with us on [freenode in #dokku](https://webchat.freenode.net/?channels=%23dokku), feel free to fork and create a Pull Request.
+After checking [GitHub Issues](https://github.com/dokku/dokku/issues), the [Troubleshooting Guide](https://dokku.com/docs/getting-started/troubleshooting/) or having a chat with us on [Gliderlabs Slack in the #dokku channel](https://glider-slackin.herokuapp.com/), feel free to fork and create a Pull Request.
 
 While we may not merge your PR as is, they serve to start conversations and improve the general Dokku experience for all users.
 

--- a/docs/getting-started/where-to-get-help.md
+++ b/docs/getting-started/where-to-get-help.md
@@ -34,8 +34,8 @@ You may find help on these locations, but they are not actively monitored by the
 
 Tag your questions with `dokku` to enable existing users of Stack Overflow to find your questions.
 
-### IRC (on freenode)
+### IRC (on libera.chat)
 
-- [irc.freenode.net/#dokku](https://webchat.freenode.net/?channels=dokku)
+- [irc.libera.chat/#dokku](https://webchat.libera.chat/?channels=dokku)
 
 This location isn't as well monitored as Slack, and loses history.

--- a/docs/home.html
+++ b/docs/home.html
@@ -57,9 +57,6 @@
                 <a class="nav-link" href="/{{NAME}}/getting-started/installation/">Docs</a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" href="https://webchat.freenode.net/?channels=dokku">IRC</a>
-              </li>
-              <li class="nav-item">
                 <a class="nav-link" href="https://glider-slackin.herokuapp.com/">Slack</a>
               </li>
               <li class="nav-item">

--- a/docs/template.html
+++ b/docs/template.html
@@ -70,9 +70,6 @@
                 <a class="nav-link" href="/{{NAME}}/getting-started/installation/">Docs</a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" href="https://webchat.freenode.net/?channels=dokku">IRC</a>
-              </li>
-              <li class="nav-item">
                 <a class="nav-link" href="https://glider-slackin.herokuapp.com/">Slack</a>
               </li>
               <li class="nav-item">


### PR DESCRIPTION
Freenode is basically offline at this point and we've had a libera.chat for a while, so we should point to that.

Also default all real-time communication to Slack.

Finally, remove prominent links to IRC. While libera is still available, the lack of monitoring makes it not a great way to provide support to users.