### PR TITLE
Correct count check for user-auth trigger

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -795,8 +795,15 @@ dokku_auth() {
   export SSH_USER=${SSH_USER:=$USER}
   export SSH_NAME=${NAME:="default"}
 
+  local user_auth_count=$(find "$PLUGIN_PATH"/enabled/*/user-auth 2>/dev/null | wc -l)
+
+  # no plugin trigger exists
+  if [[ $user_auth_count == 0 ]]; then
+    return 0
+  fi
+
   # this plugin trigger exists in the core `20_events` plugin
-  if [[ $(find "$PLUGIN_PATH"/enabled/*/user-auth 2>/dev/null | wc -l) == 1 ]]; then
+  if [[ "$user_auth_count" == 1 ]] && [[ -f "$PLUGIN_PATH"/enabled/20_events/user-auth ]]; then
     return 0
   fi
 


### PR DESCRIPTION
There are cases where the user-auth plugin exists but the events plugin is not enabled, and this accounts for that.