### PR TITLE
Respect debconf selections where possible

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -135,9 +135,10 @@ case "$1" in
 
     setup-user
     setup-storage
+
+    dpkg-handling
     setup-plugins
     setup-sshcommand
-    dpkg-handling
     ;;
 
   *)


### PR DESCRIPTION
This will continue to not override anyone's global domain preferences, but will at least ensure we set the domain prior to the default injected in 00_dokku-standard#install.

Closes #4065