### PR TITLE
Use a Dockerfile to speed up env var injection for herokuish app builds

### DIFF
--- a/plugins/builder-herokuish/builder-release
+++ b/plugins/builder-herokuish/builder-release
@@ -15,32 +15,21 @@ trigger-builder-herokuish-builder-release() {
 
   local CID
   local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
-  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
-  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
+  local DOCKER_BUILD_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP  --label=com.dokku.image-stage=release --label=dokku"
 
   plugn trigger pre-release-buildpack "$APP" "$IMAGE_TAG"
-  if [[ -n $(config_export global) ]]; then
-    CID=$(config_export global | "$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh")
-    if test "$("$DOCKER_BIN" container wait "$CID")" -ne 0; then
-      dokku_log_warn "Failure injecting global environment variables"
-      return 1
-    fi
 
-    "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
-    plugn trigger scheduler-register-retired "$APP" "$CID"
-  fi
-  if [[ -n $(config_export app "$APP") ]]; then
-    CID=$(config_export app "$APP" | "$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh")
-    if test "$("$DOCKER_BIN" container wait "$CID")" -ne 0; then
-      dokku_log_warn "Failure injecting app environment variables"
-      return 1
-    fi
+  TMP_WORK_DIR="$(mktemp -d "/tmp/dokku-${DOKKU_PID}-${FUNCNAME[0]}.XXXXXX")"
+  trap "rm -rf '$TMP_WORK_DIR' >/dev/null" RETURN INT TERM EXIT
 
-    "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
-    plugn trigger scheduler-register-retired "$APP" "$CID"
+  config_export global>"$TMP_WORK_DIR/00-global-env.sh"
+  config_export app "$APP">"$TMP_WORK_DIR/01-app-env.sh"
+
+  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/builder-release.Dockerfile" --build-arg APP_IMAGE="$IMAGE" -t $IMAGE "$TMP_WORK_DIR"; then
+      dokku_log_warn "Failure injecting environment variables"
+    return 1
   fi
 
-  docker-image-labeler --label=com.dokku.image-stage=release --label=com.dokku.app-name=$APP --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=dokku "$IMAGE"
   plugn trigger post-release-buildpack "$APP" "$IMAGE_TAG"
   plugn trigger post-release-builder "$BUILDER_TYPE" "$APP" "$IMAGE"
 }

--- a/plugins/builder-herokuish/builder-release
+++ b/plugins/builder-herokuish/builder-release
@@ -22,11 +22,11 @@ trigger-builder-herokuish-builder-release() {
   TMP_WORK_DIR="$(mktemp -d "/tmp/dokku-${DOKKU_PID}-${FUNCNAME[0]}.XXXXXX")"
   trap "rm -rf '$TMP_WORK_DIR' >/dev/null" RETURN INT TERM EXIT
 
-  config_export global>"$TMP_WORK_DIR/00-global-env.sh"
-  config_export app "$APP">"$TMP_WORK_DIR/01-app-env.sh"
+  config_export global >"$TMP_WORK_DIR/00-global-env.sh"
+  config_export app "$APP" >"$TMP_WORK_DIR/01-app-env.sh"
 
   if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/builder-release.Dockerfile" --build-arg APP_IMAGE="$IMAGE" -t $IMAGE "$TMP_WORK_DIR"; then
-      dokku_log_warn "Failure injecting environment variables"
+    dokku_log_warn "Failure injecting environment variables"
     return 1
   fi
 

--- a/plugins/builder-herokuish/dockerfiles/builder-release.Dockerfile
+++ b/plugins/builder-herokuish/dockerfiles/builder-release.Dockerfile
@@ -1,0 +1,4 @@
+ARG APP_IMAGE
+FROM $APP_IMAGE
+
+COPY 00-global-env.sh 01-app-env.sh /app/.profile.d/

--- a/plugins/builder-herokuish/dockerfiles/pre-build.Dockerfile
+++ b/plugins/builder-herokuish/dockerfiles/pre-build.Dockerfile
@@ -1,0 +1,5 @@
+ARG APP_IMAGE
+FROM $APP_IMAGE
+
+COPY .env.d /tmp/env
+COPY .env /app/.env

--- a/plugins/builder-herokuish/pre-build-buildpack
+++ b/plugins/builder-herokuish/pre-build-buildpack
@@ -8,10 +8,9 @@ trigger-builder-herokuish-pre-build-buildpack() {
   declare desc="builder-herokuish pre-build-buildpack plugin trigger"
   declare trigger="pre-build-buildpack"
   declare APP="$1"
-  local IMAGE CID
+  local IMAGE TMP_WORK_DIR
 
-  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
-  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
+  local DOCKER_BUILD_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
 
   IMAGE=$(get_app_image_name "$APP")
 
@@ -19,26 +18,23 @@ trigger-builder-herokuish-pre-build-buildpack() {
   [[ -z $(config_get --global CURL_TIMEOUT) ]] && config_set --global CURL_TIMEOUT=600
 
   dokku_log_info1 "Adding BUILD_ENV to build environment..."
+  TMP_WORK_DIR="$(mktemp -d "/tmp/dokku-${DOKKU_PID}-${FUNCNAME[0]}.XXXXXX")"
+  trap "rm -rf '$TMP_WORK_DIR' >/dev/null" RETURN INT TERM EXIT
+  mkdir -p "$TMP_WORK_DIR/.env.d"
+
   # create build env files for use in buildpacks like this:
   # https://github.com/niteoweb/heroku-buildpack-buildout/blob/5879fa3418f7d8e079f1aa5816ba1adde73f4948/bin/compile#L34
-  CID=$(config_bundle --merged "$APP" | "$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "mkdir -p /tmp/env; cat | tar -x -C /tmp/env")
-  if test "$("$DOCKER_BIN" container wait "$CID")" -ne 0; then
+  config_bundle --merged "$APP" | tar -x -C "$TMP_WORK_DIR/.env.d"
+
+  # create build env for 'old style' buildpacks and dokku plugins
+  config_export app "$APP" --format envfile --merged  >"$TMP_WORK_DIR/.env"
+
+  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/pre-build.Dockerfile" --build-arg APP_IMAGE="$IMAGE" -t $IMAGE "$TMP_WORK_DIR"; then
     dokku_log_warn "Failure injecting BUILD_ENV into build environment"
     return 1
   fi
 
-  "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
-  plugn trigger scheduler-register-retired "$APP" "$CID"
-
-  # create build env for 'old style' buildpacks and dokku plugins
-  CID=$(config_export app "$APP" --format envfile --merged | "$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$IMAGE" /bin/bash -c "cat >> /app/.env")
-  if test "$("$DOCKER_BIN" container wait "$CID")" -ne 0; then
-    dokku_log_warn "Failure injecting old-style BUILD_ENV"
-    return 1
-  fi
-
-  "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
-  plugn trigger scheduler-register-retired "$APP" "$CID"
+  dokku_log_verbose_quiet "BUILD_ENV added successfully"
 }
 
 trigger-builder-herokuish-pre-build-buildpack "$@"

--- a/plugins/builder-herokuish/pre-build-buildpack
+++ b/plugins/builder-herokuish/pre-build-buildpack
@@ -27,7 +27,7 @@ trigger-builder-herokuish-pre-build-buildpack() {
   config_bundle --merged "$APP" | tar -x -C "$TMP_WORK_DIR/.env.d"
 
   # create build env for 'old style' buildpacks and dokku plugins
-  config_export app "$APP" --format envfile --merged  >"$TMP_WORK_DIR/.env"
+  config_export app "$APP" --format envfile --merged >"$TMP_WORK_DIR/.env"
 
   if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/pre-build.Dockerfile" --build-arg APP_IMAGE="$IMAGE" -t $IMAGE "$TMP_WORK_DIR"; then
     dokku_log_warn "Failure injecting BUILD_ENV into build environment"


### PR DESCRIPTION
Herokuish app builds currently spin up a temporary container and then commit that container. The new approach uses a Dockerfile to perform those same actions, avoiding the need for the temporary container.