### PR TITLE
Output logs when container rename fails and continue on

### DIFF
--- a/plugins/scheduler-docker-local/check-deploy
+++ b/plugins/scheduler-docker-local/check-deploy
@@ -87,9 +87,9 @@ trigger-scheduler-docker-local-check-deploy() {
     local id="$1"
     rm -rf "$CHECK_DEPLOY_TMP_WORK_DIR" &>/dev/null || true
     if [[ $id ]]; then
-      dokku_log_info2_quiet "$APP $DOKKU_APP_CONTAINER_TYPE container output:"
+      dokku_log_info2_quiet "Start of $APP $DOKKU_APP_CONTAINER_TYPE container output:"
       dokku_container_log_verbose_quiet "$id"
-      dokku_log_info2_quiet "end $APP $DOKKU_APP_CONTAINER_TYPE container output"
+      dokku_log_info2_quiet "End of $APP $DOKKU_APP_CONTAINER_TYPE container output"
     fi
   }
   trap "checks_check_deploy_cleanup $DOKKU_APP_CONTAINER_ID" RETURN INT TERM EXIT

--- a/plugins/scheduler-docker-local/core-post-deploy
+++ b/plugins/scheduler-docker-local/core-post-deploy
@@ -55,8 +55,13 @@ trigger-scheduler-docker-local-core-post-deploy() {
     local ID=$(cat "$container")
     local CURRENT_NAME=$("$DOCKER_BIN" container inspect --format '{{.Name}}' "$ID" | tr -d /)
     if [[ -n "$CURRENT_NAME" ]]; then
-      dokku_log_verbose_quiet "Renaming container (${ID:0:12}) $CURRENT_NAME to $NAME"
-      "$DOCKER_BIN" container rename "$CURRENT_NAME" "$NAME" >/dev/null
+      dokku_log_verbose_quiet "Renaming container $CURRENT_NAME (${ID:0:12}) to $NAME"
+      if ! "$DOCKER_BIN" container rename "$ID" "$NAME" >/dev/null; then
+        dokku_log_warn "Failed to rename container $CURRENT_NAME (${ID:0:12})"
+        dokku_log_info2_quiet "Start $APP (${ID:0:12}) container output:"
+        dokku_container_log_verbose_quiet "$ID"
+        dokku_log_info2_quiet "End $APP (${ID:0:12}) container output"
+      fi
     fi
   done
   shopt -u nullglob

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -84,6 +84,7 @@ trigger-scheduler-docker-local-scheduler-deploy() {
       DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")
       DOCKER_ARGS+=" --label=com.dokku.process-type=$PROC_TYPE --label=com.dokku.dyno=$DYNO "
       DOCKER_ARGS+=" --env=DYNO=$DYNO "
+      DOCKER_ARGS+=" --name=$APP.$DYNO.upcoming "
       DOCKER_ARGS+=" --init "
       DOCKER_ARGS+=" $DOCKER_RUN_LABEL_ARGS $DOKKU_GLOBAL_RUN_ARGS "
       DOCKER_ARGS+=$(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -84,7 +84,7 @@ trigger-scheduler-docker-local-scheduler-deploy() {
       DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")
       DOCKER_ARGS+=" --label=com.dokku.process-type=$PROC_TYPE --label=com.dokku.dyno=$DYNO "
       DOCKER_ARGS+=" --env=DYNO=$DYNO "
-      DOCKER_ARGS+=" --name=$APP.$DYNO.upcoming "
+      DOCKER_ARGS+=" --name=$APP.$DYNO.upcoming-$RANDOM "
       DOCKER_ARGS+=" --init "
       DOCKER_ARGS+=" $DOCKER_RUN_LABEL_ARGS $DOKKU_GLOBAL_RUN_ARGS "
       DOCKER_ARGS+=$(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")


### PR DESCRIPTION
This allows folks to later investigate why the rename failed (probably an app bug) and helpfully posts the container logs.

If multiple containers fail, they may have a ton of output, but this is better than not knowing what is going on.

Also set initial container name for docker-local deploys.

Closes #3900