### PR TITLE
Add support for VSCode Dev Containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM dokku/dokku:latest
+
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y build-essential file nano && \
+  apt-get install --no-install-recommends -y shellcheck xmlstarlet && \
+  apt-get clean autoclean && \
+  apt-get autoremove --yes && \
+  rm -rf /var/lib/apt/lists/*
+
+ADD https://raw.githubusercontent.com/dokku/dokku/master/tests/dhparam.pem /mnt/dokku/etc/nginx/dhparam.pem
+
+COPY .devcontainer/bin/ /usr/local/bin/
+COPY . .
+
+RUN make ci-dependencies
+
+ENV DOKKU_HOSTNAME=dokku.me

--- a/.devcontainer/bin/copy-plugin
+++ b/.devcontainer/bin/copy-plugin
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+main() {
+  declare PLUGIN_NAME="$1"
+
+  make go-build-plugin copyplugin PLUGIN_NAME=$PLUGIN_NAME
+}
+
+main "$@"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "containerEnv": {
+    "DOKKU_HOST_ROOT": "${localWorkspaceFolder}/tmp/data",
+    "GO_ROOT_MOUNT": "${localWorkspaceFolder}:/go/src/github.com/dokku/dokku"
+  },
+  "initializeCommand": ["mkdir", "-p", "tmp/data"],
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+    "source=${localWorkspaceFolder}/tmp/data/,target=/mnt/dokku/,type=bind"
+  ],
+  "overrideCommand": false,
+  "postCreateCommand": ["make", "setup-deploy-tests"],
+  "runArgs": ["--init"]
+}


### PR DESCRIPTION
This cannot be used in codespaces due to the extra mount, but it does allow for local development.