### PR TITLE
Do not require double quotes when issuing dokku run commands

### DIFF
--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -243,6 +243,6 @@ fn-scheduler-docker-local-start-app-container() {
   declare DOCKER_ARGS=("$@")
 
   eval "$(config_export app "$APP" --merged)"
-   # shellcheck disable=SC2124
+  # shellcheck disable=SC2124
   "$DOCKER_BIN" container create ${DOCKER_ARGS[@]}
 }

--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -238,10 +238,11 @@ fn-scheduler-docker-local-register-retired() {
 
 fn-scheduler-docker-local-start-app-container() {
   declare desc="starts a single app container"
-  declare APP="$1" DOCKER_ARGS="$2"
+  declare APP="$1"
+  shift
+  declare DOCKER_ARGS=("$@")
 
-  declare -a __DOKKU_DOCKER_ARG_ARRAY
-  eval "__DOKKU_DOCKER_ARG_ARRAY=($DOCKER_ARGS)"
   eval "$(config_export app "$APP" --merged)"
-  "$DOCKER_BIN" container create "${__DOKKU_DOCKER_ARG_ARRAY[@]}"
+   # shellcheck disable=SC2124
+  "$DOCKER_BIN" container create ${DOCKER_ARGS[@]}
 }

--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -240,9 +240,14 @@ fn-scheduler-docker-local-start-app-container() {
   declare desc="starts a single app container"
   declare APP="$1"
   shift
-  declare DOCKER_ARGS=("$@")
+
+  local DOCKER_ARGS
+  for i in "$@"; do
+      DOCKER_ARGS="$DOCKER_ARGS \"$i\""
+  done
+  eval set -- $DOCKER_ARGS
 
   eval "$(config_export app "$APP" --merged)"
   # shellcheck disable=SC2124
-  "$DOCKER_BIN" container create ${DOCKER_ARGS[@]}
+  "$DOCKER_BIN" container create "$@"
 }

--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -243,7 +243,7 @@ fn-scheduler-docker-local-start-app-container() {
 
   local DOCKER_ARGS
   for i in "$@"; do
-      DOCKER_ARGS="$DOCKER_ARGS \"$i\""
+    DOCKER_ARGS="$DOCKER_ARGS \"$i\""
   done
   eval set -- $DOCKER_ARGS
 

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -82,13 +82,13 @@ trigger-scheduler-docker-local-scheduler-deploy() {
       # start the app
       local DOCKER_ARGS
       DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")
-      DOCKER_ARGS+=" --label=com.dokku.process-type=$PROC_TYPE --label=com.dokku.dyno=$DYNO "
-      DOCKER_ARGS+=" --env=DYNO=$DYNO "
-      DOCKER_ARGS+=" --name=$APP.$DYNO.upcoming-$RANDOM "
-      DOCKER_ARGS+=" --init "
+      DOCKER_ARGS+=" --label=com.dokku.process-type=$PROC_TYPE --label=com.dokku.dyno=$DYNO"
+      DOCKER_ARGS+=" --env=DYNO=$DYNO"
+      DOCKER_ARGS+=" --name=$APP.$DYNO.upcoming-$RANDOM"
+      DOCKER_ARGS+=" --init"
       DOCKER_ARGS+=" $DOCKER_RUN_LABEL_ARGS $DOKKU_GLOBAL_RUN_ARGS "
       DOCKER_ARGS+=$(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")
-      [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" --env=TRACE=true "
+      [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" --env=TRACE=true"
 
       local START_CMD
       [[ "$DOKKU_HEROKUISH" == "true" ]] && START_CMD="/start $PROC_TYPE"
@@ -105,18 +105,20 @@ trigger-scheduler-docker-local-scheduler-deploy() {
           fi
 
           if [[ "$DOKKU_NETWORK_BIND_ALL" == "true" ]]; then
-            DOCKER_ARGS+=" -p $p "
+            DOCKER_ARGS+=" -p $p"
           fi
         done
       fi
 
-      DOCKER_ARGS+=" --env=PORT=$DOKKU_PORT "
+      DOCKER_ARGS+=" --env=PORT=$DOKKU_PORT"
 
       START_CMD=$(fn-scheduler-docker-local-extract-start-cmd "$APP" "$PROC_TYPE" "$START_CMD" "$DOKKU_HEROKUISH" "$DOKKU_PORT")
-      DOCKER_ARGS+=" $IMAGE "
-      DOCKER_ARGS+=" $START_CMD "
+      DOCKER_ARGS+=" $IMAGE"
+      DOCKER_ARGS+=" $START_CMD"
 
-      cid=$(fn-scheduler-docker-local-start-app-container "$APP" "$DOCKER_ARGS")
+      declare -a ARG_ARRAY
+      eval "ARG_ARRAY=($DOCKER_ARGS)"
+      cid=$(fn-scheduler-docker-local-start-app-container "$APP" "${ARG_ARRAY[@]}")
 
       plugn trigger post-container-create "app" "$cid" "$APP" "deploy" "$PROC_TYPE"
       "$DOCKER_BIN" container start "$cid" >/dev/null || true

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -96,11 +96,9 @@ trigger-scheduler-docker-local-scheduler-run() {
     if [[ -z "$DOKKU_SHELL" ]]; then
       DOKKU_SHELL="/bin/bash"
     fi
-    # shellcheck disable=SC2206
-    ARG_ARRAY=(${ARG_ARRAY[@]} "$DOKKU_SHELL")
+    ARG_ARRAY=("${ARG_ARRAY[@]}" "$DOKKU_SHELL")
   else
-    # shellcheck disable=SC2206
-    ARG_ARRAY=(${ARG_ARRAY[@]} "${RUN_COMMAND[@]}")
+    ARG_ARRAY=("${ARG_ARRAY[@]}" "${RUN_COMMAND[@]}")
     # for run_arg in "${RUN_COMMAND[@]}"; do
     #   DOCKER_ARGS+=" ${run_arg} "
     # done

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -14,7 +14,7 @@ trigger-scheduler-docker-local-scheduler-run() {
 
   declare RUN_ENV=("${@:1:ENV_COUNT}")
   shift "$ENV_COUNT"
-  declare RUN_COMMAND=("$@")
+  declare RUN_COMMAND=()
 
   if [[ "$DOKKU_SCHEDULER" != "docker-local" ]]; then
     return
@@ -85,6 +85,7 @@ trigger-scheduler-docker-local-scheduler-run() {
   declare -a ARG_ARRAY
   eval "ARG_ARRAY=($DOCKER_ARGS)"
 
+  RUN_COMMAND=("$@")
   if [[ "${#RUN_COMMAND[@]}" -eq 0 ]]; then
     if [[ -z "$DOKKU_SHELL" ]]; then
       local DOKKU_APP_SHELL=$(config_get "$APP" DOKKU_APP_SHELL || true)

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -95,8 +95,10 @@ trigger-scheduler-docker-local-scheduler-run() {
     if [[ -z "$DOKKU_SHELL" ]]; then
       DOKKU_SHELL="/bin/bash"
     fi
+    # shellcheck disable=SC2206
     ARG_ARRAY=(${ARG_ARRAY[@]} "$DOKKU_SHELL")
   else
+    # shellcheck disable=SC2206
     ARG_ARRAY=(${ARG_ARRAY[@]} "${RUN_COMMAND[@]}")
     # for run_arg in "${RUN_COMMAND[@]}"; do
     #   DOCKER_ARGS+=" ${run_arg} "

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -14,12 +14,12 @@ trigger-scheduler-docker-local-scheduler-run() {
 
   declare RUN_ENV=("${@:1:ENV_COUNT}")
   shift "$ENV_COUNT"
+  declare RUN_COMMAND=("$@")
 
   if [[ "$DOKKU_SCHEDULER" != "docker-local" ]]; then
     return
   fi
 
-  local DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
   local IMAGE_TAG=$(get_running_image_tag "$APP")
   local IMAGE=$(get_deploying_app_image_name "$APP" "$IMAGE_TAG")
 
@@ -44,13 +44,13 @@ trigger-scheduler-docker-local-scheduler-run() {
   DOCKER_ARGS+=$(: | plugn trigger docker-args-process-run "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG")
   DOCKER_ARGS+=" -e DYNO=$PROCESS_TYPE.$DYNO_NUMBER --name $APP.$PROCESS_TYPE.$DYNO_NUMBER"
 
-  declare -a ARG_ARRAY
-  eval "ARG_ARRAY=($DOCKER_ARGS)"
-
   if [[ "$DOKKU_RM_CONTAINER" ]]; then
     DOCKER_ARGS+=" --rm"
   fi
-  has_tty && DOCKER_ARGS+=" --interactive --tty"
+  if has_tty; then
+    DOCKER_ARGS+=" --interactive"
+    DOCKER_ARGS+=" --tty"
+  fi
   for env_pair in "${RUN_ENV[@]}"; do
     DOCKER_ARGS+=" --env=$env_pair"
   done
@@ -76,13 +76,34 @@ trigger-scheduler-docker-local-scheduler-run() {
   fi
 
   # shellcheck disable=SC2124
-  DOCKER_ARGS+=" --label=com.dokku.container-type=$PROCESS_TYPE ${DOCKER_RUN_LABEL_ARGS[@]} $DOKKU_GLOBAL_RUN_ARGS"
-  DOCKER_ARGS+=" $IMAGE "
-  DOCKER_ARGS+=" $EXEC_CMD "
-  # shellcheck disable=SC2124
-  DOCKER_ARGS+=" $@"
+  DOCKER_ARGS+=" --label=com.dokku.container-type=$PROCESS_TYPE"
+  DOCKER_ARGS+=" --label=com.dokku.app-name=$APP"
+  # $DOKKU_GLOBAL_RUN_ARGS"
+  DOCKER_ARGS+=" $IMAGE"
+  DOCKER_ARGS+=" $EXEC_CMD"
 
-  CONTAINER_ID=$(fn-scheduler-docker-local-start-app-container "$APP" "$DOCKER_ARGS")
+  declare -a ARG_ARRAY
+  eval "ARG_ARRAY=($DOCKER_ARGS)"
+
+  if [[ "${#RUN_COMMAND[@]}" -eq 0 ]]; then
+    if [[ -z "$DOKKU_SHELL" ]]; then
+      local DOKKU_APP_SHELL=$(config_get "$APP" DOKKU_APP_SHELL || true)
+      local DOKKU_GLOBAL_SHELL=$(config_get --global DOKKU_APP_SHELL || true)
+      local DOKKU_SHELL=${DOKKU_APP_SHELL:="$DOKKU_GLOBAL_SHELL"}
+    fi
+
+    if [[ -z "$DOKKU_SHELL" ]]; then
+      DOKKU_SHELL="/bin/bash"
+    fi
+    ARG_ARRAY=(${ARG_ARRAY[@]} "$DOKKU_SHELL")
+  else
+    ARG_ARRAY=(${ARG_ARRAY[@]} "${RUN_COMMAND[@]}")
+    # for run_arg in "${RUN_COMMAND[@]}"; do
+    #   DOCKER_ARGS+=" ${run_arg} "
+    # done
+  fi
+
+  CONTAINER_ID=$(fn-scheduler-docker-local-start-app-container "$APP" "${ARG_ARRAY[@]}")
   plugn trigger post-container-create "app" "$CONTAINER_ID" "$APP" "run"
 
   declare -a DOCKER_START_ARGS_ARRAY


### PR DESCRIPTION
This was broken in the #4736.