### PR TITLE
Add help2man os package for copyfiles make target to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ FROM dokku/dokku:latest
 
 RUN apt-get update
 RUN apt-get install --no-install-recommends -y build-essential file nano && \
-  apt-get install --no-install-recommends -y shellcheck uuid-runtime xmlstarlet && \
+  apt-get install --no-install-recommends -y help2man shellcheck uuid-runtime xmlstarlet && \
   apt-get clean autoclean && \
   apt-get autoremove --yes && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This ensures 'make copyfiles' can run appropriately within a devcontainer.