### PR TITLE
Docs: Fix instructions for enabling Docker Buildkit

### DIFF
--- a/docs/deployment/builders/dockerfiles.md
+++ b/docs/deployment/builders/dockerfiles.md
@@ -148,12 +148,8 @@ RUN echo $NODE_ENV
 If your Dockerfile is using Docker engine's [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) (not to be confused with buildpacks), then the `DOCKER_BUILDKIT=1` environment variable needs to be set. Additionally, complete build log output can be forced via `BUILDKIT_PROGRESS=plain`. Both of these environment variables can be set as follows:
 
 ```shell
-# via config:set
-dokku config:set --global DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain
-
-# on the /etc/default/dokku file
-echo DOCKER_BUILDKIT=1 | sudo tee -a /etc/default/dokku
-echo BUILDKIT_PROGRESS=plain | sudo tee -a /etc/default/dokku
+echo "export DOCKER_BUILDKIT=1" | sudo tee -a /etc/default/dokku
+echo "export BUILDKIT_PROGRESS=plain" | sudo tee -a /etc/default/dokku
 ```
 
 #### Buildkit directory caching


### PR DESCRIPTION
Docker Buildkit must be enabled via `/etc/default/dokku`. It cannot be enabled via `dokku config` because those variables are not made available during the `build` phase of Docker containers for security reasons (see https://dokku.com/docs/deployment/builders/dockerfiles/#build-time-configuration-variables).

See: https://github.com/dokku/dokku/pull/4723#issuecomment-927381185

Tested and works ✅ Credit for this goes to @josegonzalez (thanks again! 🙌)