### PR TITLE
Handle udp ports when fetching network config

### DIFF
--- a/plugins/network/network.go
+++ b/plugins/network/network.go
@@ -174,11 +174,14 @@ func GetContainerPort(appName, processType string, containerID string, isHerokui
 				break
 			}
 		}
-		cmd := sh.Command(common.DockerBin(), "container", "port", containerID, port)
-		cmd.Stderr = ioutil.Discard
-		b, err := cmd.Output()
-		if err == nil {
-			port = strings.Split(string(b[:]), ":")[1]
+
+		if port != "" {
+			cmd := sh.Command(common.DockerBin(), "container", "port", containerID, port)
+			cmd.Stderr = ioutil.Discard
+			b, err := cmd.Output()
+			if err == nil {
+				port = strings.Split(string(b[:]), ":")[1]
+			}
 		}
 	} else {
 		port = "5000"

--- a/tests/unit/network.bats
+++ b/tests/unit/network.bats
@@ -241,3 +241,25 @@ teardown() {
   echo "status: $status"
   assert_success
 }
+
+@test "(network) handle single-udp app" {
+  run /bin/bash -c "dokku docker-options:add $TEST_APP -p 1194:1194"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku checks:disable $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # The app _should_ fail to deploy because it requires some config file
+  # but we really only care about getting to pre-flight checks so that is fine.
+  # It does not because of some yet unknown bug in deploying when zero-downtime is disable...
+  run /bin/bash -c "dokku git:from-image $TEST_APP kylemanna/openvpn:latest"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "Attempting pre-flight checks" 0
+  assert_output_contains "Application deployed"
+}


### PR DESCRIPTION
When an app only has UDP ports exposed, deploys will fail as we expect there to be a single TCP port.

While we _should_ support both, the easier fix is to ignore things and move on. Users can manually expose UDP ports as necessary via the -p flag (or by not specifying the port as a UDP port).

One quirk discovered during tests is that disabling zero-downtime deploys results in odd output, but also a deploy can succeed even if one of the processes that skipped zero-downtime fails. We should fix this in another PR, but this is documented in tests for now.

Closes #4804