### PR TITLE
Set the DOKKU_HOST_ROOT on docker container start

### DIFF
--- a/docker/etc/my_init.d/10_dokku_init
+++ b/docker/etc/my_init.d/10_dokku_init
@@ -62,6 +62,12 @@ main() {
     echo "export DOCKER_BIN=/usr/local/bin/docker" >"/home/dokku/.dokkurc/DOCKER_BIN"
   fi
 
+  if [[ -n "$DOKKU_HOST_ROOT" ]]; then
+    touch /etc/default/dokku
+    echo "export DOKKU_HOST_ROOT=$DOKKU_HOST_ROOT" >> /etc/default/dokku
+    chown dokku:dokku /etc/default/dokku
+  fi
+
   NGINX_ROOT="/etc/nginx"
   if [[ -x /usr/bin/openresty ]]; then
     NGINX_ROOT="/usr/local/openresty/nginx/conf"

--- a/docker/etc/my_init.d/10_dokku_init
+++ b/docker/etc/my_init.d/10_dokku_init
@@ -64,7 +64,7 @@ main() {
 
   if [[ -n "$DOKKU_HOST_ROOT" ]]; then
     touch /etc/default/dokku
-    echo "export DOKKU_HOST_ROOT=$DOKKU_HOST_ROOT" >> /etc/default/dokku
+    echo "export DOKKU_HOST_ROOT=$DOKKU_HOST_ROOT" >>/etc/default/dokku
     chown dokku:dokku /etc/default/dokku
   fi
 

--- a/docs/getting-started/install/docker.md
+++ b/docs/getting-started/install/docker.md
@@ -11,6 +11,7 @@ Next, run the image.
 ```shell
 docker container run \
   --env DOKKU_HOSTNAME=dokku.me \
+  --env DOKKU_HOST_ROOT=/var/lib/dokku/home/dokku \
   --name dokku \
   --publish 3022:22 \
   --publish 8080:80 \
@@ -28,7 +29,8 @@ Dokku is run in the following configuration:
 - Container HTTP port 80 is exposed on the host as 8080.
 - Container HTTPS port 443 is exposed on the host as 8443.
 - Data within the container is stored on the host within the `/var/lib/dokku` directory.
-- The docker socket is mounted into container
+- Image build cache is set to the data dir + `/home/dokku`.
+- The docker socket is mounted into container.
 
 Application repositories, plugin config, as well as plugin data are persisted to disk within the specified host directory for `/var/lib/dokku`.
 


### PR DESCRIPTION
Without this change, cache doesn't work when running in a docker container.

Closes #4788