### PR TITLE
Ensure pack is run as root user when building apps in docker

### DIFF
--- a/docker/etc/sudoers.d/dokku-docker
+++ b/docker/etc/sudoers.d/dokku-docker
@@ -1,1 +1,1 @@
-dokku    ALL=NOPASSWD:SETENV:/usr/bin/docker,/usr/bin/docker-image-labeler
+dokku    ALL=NOPASSWD:SETENV:/usr/bin/docker,/usr/bin/docker-image-labeler,/usr/bin/pack

--- a/docker/usr/local/bin/pack
+++ b/docker/usr/local/bin/pack
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $TRACE ]] && set -x
+
+main() {
+  declare desc="re-runs pack commands as sudo"
+  local PACK_BIN=""
+  if [[ -x "/usr/bin/pack" ]]; then
+    PACK_BIN="/usr/bin/pack"
+  fi
+
+  if [[ -z "$PACK_BIN" ]]; then
+    echo "!   No pack binary found" 1>&2
+    exit 1
+  fi
+
+  sudo -E "$PACK_BIN" "$@"
+}
+
+main "$@"


### PR DESCRIPTION
Without this, using the pack builder fails since it cannot communicate with a root-mounted docker socket.