### PR TITLE
Set default process list in test cnb buildpacks

### DIFF
--- a/tests/apps/python/cnb/1/bin/build
+++ b/tests/apps/python/cnb/1/bin/build
@@ -15,3 +15,9 @@ echo "TESTENV_1" >$bp_env_dir/TESTENV
   echo "build = true"
   echo "cache = true"
 } >"${bp_layer}.toml"
+
+cat >"$layers_dir/launch.toml" <<EOL
+[[processes]]
+type = "web"
+command = "true"
+EOL

--- a/tests/apps/python/cnb/2/bin/build
+++ b/tests/apps/python/cnb/2/bin/build
@@ -21,3 +21,9 @@ echo "TESTENV_2" >$bp_env_dir/TESTENV
   echo "build = true"
   echo "cache = true"
 } >"${bp_layer}.toml"
+
+cat >"$layers_dir/launch.toml" <<EOL
+[[processes]]
+type = "web"
+command = "true"
+EOL

--- a/tests/apps/python/project2.toml
+++ b/tests/apps/python/project2.toml
@@ -8,3 +8,7 @@ uri = "./cnb/1"
 
 [[build.buildpacks]]
 uri = "./cnb/1"
+
+
+[[order.group]]
+uri = "gcr.io/paketo-buildpacks/procfile"


### PR DESCRIPTION
Also include the packeto-buildpacks/procfile buildpack to ensure the Procfile is interpolated for a process list.