### PR TITLE
Drop bindutils as alternative dependency to bind-utils

### DIFF
--- a/rpm.mk
+++ b/rpm.mk
@@ -29,7 +29,7 @@ endif
 		--architecture $(RPM_ARCHITECTURE) \
 		--package "$(BUILD_DIRECTORY)/$(DOKKU_RPM_PACKAGE_NAME)" \
 		--depends '/usr/bin/docker' \
-		--depends 'bind-utils or bindutils' \
+		--depends 'bind-utils' \
 		--depends 'cpio' \
 		--depends 'curl' \
 		--depends 'dos2unix' \


### PR DESCRIPTION
Unfortunately, this breaks CentOS compatibility as they use an older version of yum in CentOS 7. Rather than inconvenience the larger user base, Photon users may wish to provide their own `bind-utils` metapackage that depends on `bindutils`.

Closes #4852