### PR TITLE
Enable vertical scrolling on the version selector

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -540,7 +540,9 @@ ul.fas li .fa-large:before, ul.fas li .fa-large:before {
   bottom: 20px;
   display: block;
   left: auto;
+  max-height: 600px;
   max-width: 300px;
+  overflow: scroll;
   right: 20px;
   width: auto;
 }


### PR DESCRIPTION
We now have too many versions for it to show up on a modern-ish laptop screen, so enabling scrolling will allow folks to choose older versions more easily.