### PR TITLE
Skip herokuish version in report output and disable the herokuish builder on armhf architectures

### DIFF
--- a/plugins/00_dokku-standard/subcommands/report
+++ b/plugins/00_dokku-standard/subcommands/report
@@ -23,7 +23,11 @@ cmd-report() {
   dokku_log_info1 "git version: $(git --version)"
   dokku_log_info1 "sigil version: $(sigil -v)"
   dokku_log_info1 "herokuish version: "
-  "$DOCKER_BIN" container run $DOKKU_GLOBAL_RUN_ARGS --rm "$DOKKU_IMAGE" herokuish version | sed "s/^/       /"
+  if [[ "$(dpkg --print-architecture 2>/dev/null || true)" == "armhf" ]]; then
+    dokku_log_warn "herokuish not supported on armhf architecture"
+  else
+    "$DOCKER_BIN" container run $DOKKU_GLOBAL_RUN_ARGS --rm "$DOKKU_IMAGE" herokuish version | sed "s/^/       /"
+  fi
   dokku_log_info1 "dokku version: $(dokku_version)"
   dokku_log_info1 "plugn version: $(plugn version)"
   dokku_log_info1 "dokku plugins: "

--- a/plugins/builder-herokuish/builder-detect
+++ b/plugins/builder-herokuish/builder-detect
@@ -8,6 +8,10 @@ trigger-builder-herokuish-builder-detect() {
   declare trigger="builder-detect"
   declare APP="$1" SOURCECODE_WORK_DIR="$2"
 
+  if [[ "$(dpkg --print-architecture 2>/dev/null || true)" == "armhf" ]]; then
+    return
+  fi
+
   if fn-has-buildpacks-file "$SOURCECODE_WORK_DIR"; then
     echo "herokuish"
     return


### PR DESCRIPTION
We don't skip pack as in theory they may be able to support arm in the future. Dockerfile builds should work fine, as long as all images in the FROM directives have arm versions.

Finally, the null builder _should_ always work, but of course YMMV :D