### PR TITLE
Drop which in favor of command -v

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -160,7 +160,7 @@ main() {
   }
 }
 
-if [[ "$0" == "dokku" ]] || [[ "$0" == *dokku_client.sh ]] || [[ "$0" == $(which dokku) ]]; then
+if [[ "$0" == "dokku" ]] || [[ "$0" == *dokku_client.sh ]] || [[ "$0" == $(command -v dokku) ]]; then
   main "$@"
   exit $?
 fi

--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -6,7 +6,7 @@ if [[ ! -f "$DOKKU_ROOT/VHOST" ]]; then
   [[ $(dig +short "$(hostname -f)") ]] && hostname -f >"$DOKKU_ROOT/VHOST"
 fi
 
-dokku_path="$(which dokku)"
+dokku_path="$(command -v dokku)"
 
 # temporary hack for https://github.com/dokku/dokku/issues/82
 # redeploys all apps after a reboot

--- a/plugins/nginx-vhosts/dependencies
+++ b/plugins/nginx-vhosts/dependencies
@@ -7,7 +7,7 @@ nginx_needs_upgrade() {
   local MAJOR_VERSION MINOR_VERSION
   local NEEDS_UPGRADE=true
 
-  if ! which nginx >/dev/null 2>&1; then
+  if ! command -v nginx &>/dev/null; then
     echo $NEEDS_UPGRADE
     return
   fi
@@ -45,7 +45,7 @@ trigger-nginx-vhosts-dependencies() {
         return
       fi
 
-      if ! which nginx >/dev/null 2>&1; then
+      if ! command -v nginx &>/dev/null; then
         nginx_install
         return
       fi

--- a/plugins/nginx-vhosts/internal-functions
+++ b/plugins/nginx-vhosts/internal-functions
@@ -75,7 +75,7 @@ fn-nginx-vhosts-nginx-location() {
   declare desc="check that nginx is at the expected location and return it"
   local NGINX_LOCATION
 
-  NGINX_LOCATION=$(which nginx 2>/dev/null)
+  NGINX_LOCATION=$(command -v nginx 2>/dev/null)
   if [[ -z "$NGINX_LOCATION" ]]; then
     NGINX_LOCATION="/usr/sbin/nginx"
   fi

--- a/plugins/scheduler-docker-local/install
+++ b/plugins/scheduler-docker-local/install
@@ -14,7 +14,7 @@ trigger-scheduler-docker-local-install() {
 
   fn-plugin-property-setup "scheduler-docker-local"
 
-  DOKKU_PATH="$(which dokku)"
+  DOKKU_PATH="$(command -v dokku)"
 
   if [[ $(systemctl 2>/dev/null) =~ -\.mount ]]; then
     cat <<EOF >/etc/systemd/system/dokku-retire.service

--- a/tests/shellcheck-exclude
+++ b/tests/shellcheck-exclude
@@ -26,7 +26,6 @@
 # SC2207 - Prefer mapfile or read -a to split command output (or quote to avoid splitting) - https://github.com/koalaman/shellcheck/wiki/SC2207
 # SC2219 - Instead of 'let expr', prefer (( expr ))  - https://github.com/koalaman/shellcheck/wiki/SC2219
 # SC2220 - Invalid flags are not handled. Add a *) case - https://github.com/koalaman/shellcheck/wiki/SC2220
-# SC2230 - which is non-standard. Use builtin 'command -v' instead - https://github.com/koalaman/shellcheck/wiki/SC2230
 # SC2231 - Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt  - https://github.com/koalaman/shellcheck/wiki/SC2231
 # SC2235 - Use { ..; } instead of (..) to avoid subshell overhead - https://github.com/koalaman/shellcheck/wiki/SC2235
 # SC2267 - GNU xargs -i is deprecated in favor of -I{} - https://github.com/koalaman/shellcheck/wiki/SC2267

--- a/tests/test_deploy
+++ b/tests/test_deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xeo pipefail
 
-SELF=$(which "$0")
+SELF=$(command -v "$0")
 APP="$1"
 TARGET="$2"
 FORWARDED_PORT="$3"


### PR DESCRIPTION
`which` is non-standard and was recently almost pulled from Debian, so we should just avoid it as we have a good alternative.