### PR TITLE
Ensure we respect quotes and dollar signs in config vars

### DIFF
--- a/plugins/config/docker-args-deploy
+++ b/plugins/config/docker-args-deploy
@@ -7,25 +7,13 @@ source "$PLUGIN_AVAILABLE_PATH/config/functions"
 trigger-config-docker-args() {
   declare desc="config docker-args plugin trigger"
   declare trigger="docker-args"
-  declare APP="$1" IMAGE_TAG="$2"
-  local ENV_ARGS IMAGE STDIN trigger
+  declare APP="$1"
+  local ENV_ARGS STDIN
 
-  IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
   STDIN=$(cat)
-  trigger="$0 config_docker_args"
 
-  if is_image_cnb_based "$IMAGE"; then
-    ENV_ARGS="$(config_export app "$APP" --format docker-args-keys --merged)"
-    echo -n "$STDIN $ENV_ARGS"
-    return
-  fi
-
-  if ! is_image_herokuish_based "$IMAGE" "$APP"; then
-    ENV_ARGS="$(config_export app "$APP" --format docker-args --merged)"
-    echo -n "$STDIN $ENV_ARGS"
-  else
-    echo -n "$STDIN"
-  fi
+  ENV_ARGS="$(config_export app "$APP" --format docker-args-keys --merged)"
+  echo -n "$STDIN $ENV_ARGS"
 }
 
 trigger-config-docker-args "$@"

--- a/tests/unit/config.bats
+++ b/tests/unit/config.bats
@@ -179,17 +179,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run dokku trace:on
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
   run deploy_app
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run dokku trace:off
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/config.bats
+++ b/tests/unit/config.bats
@@ -169,7 +169,43 @@ teardown() {
 }
 
 @test "(config) global config (herokuish)" {
-  deploy_app
+  run /bin/bash -c "dokku config:set --global HASURA_GRAPHQL_JWT_SECRET='{ \"type\": \"HS256\", \"key\": \"347a4efd2dbb6b91aebf38db5dcf2c4e\" }'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku config:set --global VAR='\$123*&456$'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run dokku trace:on
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run dokku trace:off
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku run $TEST_APP env | grep -E '^HASURA_GRAPHQL_JWT_SECRET='"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains '{ "type": "HS256", "key": "347a4efd2dbb6b91aebf38db5dcf2c4e" }'
+
+  run /bin/bash -c "dokku run $TEST_APP env | grep -E '^VAR='"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains '123*&456$'
+
   run /bin/bash -c "dokku run $TEST_APP env | grep -E '^global_test=true'"
   echo "output: $output"
   echo "status: $status"
@@ -177,7 +213,7 @@ teardown() {
 }
 
 @test "(config) global config (dockerfile)" {
-  deploy_app dockerfile
+  run deploy_app dockerfile
   run /bin/bash -c "dokku run $TEST_APP env | grep -E '^global_test=true'"
   echo "output: $output"
   echo "status: $status"


### PR DESCRIPTION
Due to various changes in how containers are started, these keys were set incorrectly for apps. Since we can use the short-hand --env=ENV format for setting env vars on docker containers, lets do so.

Closes #4895
Closes #4896