### PR TITLE
fix: do not validate global flag as an app name

### DIFF
--- a/plugins/network/subcommands.go
+++ b/plugins/network/subcommands.go
@@ -142,8 +142,10 @@ func CommandReport(appName string, format string, infoFlag string) error {
 
 // CommandSet set or clear a network property for an app
 func CommandSet(appName string, property string, value string) error {
-	if err := common.VerifyAppName(appName); err != nil {
-		return err
+	if appName != "--global" {
+		if err := common.VerifyAppName(appName); err != nil {
+			return err
+		}
 	}
 
 	if property == "bind-all-interfaces" && value == "" {


### PR DESCRIPTION
From slack:

> there appears to still be an issue `dokku network:set --global initial-network app-internal
 !     App name must begin with lowercase alphanumeric character, and cannot include uppercase characters, colons, or underscores` it thinks that app-internal is an app name, where it's actually a network name

The problem caused by `network.CommandSet` which validates the `appName` with `common.VerifyAppName`. Before calling this method from the subcommands the `appName` is replaced with `--global` which isn't a valid app name. I applied the logic I saw in `common.CommandPropertySet` to skip the verification when the `appName` parameter is `--global`.