### PR TITLE
docs: update herokuish upgrade instructions

### DIFF
--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -118,6 +118,5 @@ To upgrade Herokuish from source, upgrade with:
 cd /tmp
 git clone https://github.com/gliderlabs/herokuish.git
 cd herokuish
-git pull origin master
-IMAGE_NAME=gliderlabs/herokuish BUILD_TAG=latest VERSION=master make -e build-in-docker
+CIRCLECI=true IMAGE_NAME=gliderlabs/herokuish BUILD_TAG=latest make build/docker
 ```


### PR DESCRIPTION
Closes #4944. Needs https://github.com/gliderlabs/herokuish/pull/726 to be merged first.

I am not proud of using `CIRCLECI=true` hack, but I didn't find a simple way to do it otherwise. I surely wouldn't want to go with the build system refactoring of a project I have never worked with just to fix the broken documentation :)