### PR TITLE
Add log message when running state is false

### DIFF
--- a/plugins/ps/ps.go
+++ b/plugins/ps/ps.go
@@ -135,6 +135,8 @@ func Start(appName string) error {
 
 	if runningState == "mixed" {
 		common.LogWarn("App is running in mixed mode, releasing")
+	} else if runningState == "false" {
+		common.LogWarn("App has been detected as not running, releasing")
 	}
 
 	if runningState != "true" {


### PR DESCRIPTION
Without this, its not clear why we are releasing an app when calling `ps:start` or `ps:restore`.