### PR TITLE
Typo for deploying using image SHA

### DIFF
--- a/docs/deployment/methods/git.md
+++ b/docs/deployment/methods/git.md
@@ -145,7 +145,7 @@ The resulting `git:from-image` call would then be:
 
 ```shell
 # where the image sha is: sha256:9d187c3025d03c033dcc71e3a284fee53be88cc4c0356a19242758bc80cab673
-dokku git:from-image node-js-app dokku/node-js-getting-started:@sha256:9d187c3025d03c033dcc71e3a284fee53be88cc4c0356a19242758bc80cab673
+dokku git:from-image node-js-app dokku/node-js-getting-started@sha256:9d187c3025d03c033dcc71e3a284fee53be88cc4c0356a19242758bc80cab673
 ```
 
 The `git:from-image` command can optionally take a git `user.name` and `user.email` argument (in that order) to customize the author. If the arguments are left empty, they will fallback to `Dokku` and `automated@dokku.sh`, respectively.


### PR DESCRIPTION
The command for using an image doesn't include a colon before the `@sha`. Just wanted to help out others because this was tripping me up for like an hour!