### PR TITLE
Avoid popd errors when dokku is run as root

### DIFF
--- a/plugins/builder-dockerfile/core-post-extract
+++ b/plugins/builder-dockerfile/core-post-extract
@@ -26,7 +26,7 @@ trigger-builder-dockerfile-core-post-extract() {
   fi
 
   mv "$NEW_DOCKERFILE" Dockerfile
-  popd &>/dev/null
+  popd &>/dev/null || pushd "/tmp" >/dev/null
 }
 
 trigger-builder-dockerfile-core-post-extract "$@"

--- a/plugins/builder-pack/core-post-extract
+++ b/plugins/builder-pack/core-post-extract
@@ -24,7 +24,7 @@ trigger-builder-pack-core-post-extract() {
   if [[ "$NEW_PROJECT_TOML" != "project.toml" ]]; then
     mv "$NEW_PROJECT_TOML" project.toml
   fi
-  popd &>/dev/null
+  popd &>/dev/null || pushd "/tmp" >/dev/null
 }
 
 trigger-builder-pack-core-post-extract "$@"


### PR DESCRIPTION
When running the dokku command in a directory that the dokku user does not have access to - such as /root - popd will fail loudly (starting in Ubuntu 16.04). This change ignores those errors and changes the working dir in the bin to /tmp.

Closes #5012