### PR TITLE
Properly support the --global flag when detecting the scheduler

### DIFF
--- a/plugins/scheduler/src/triggers/triggers.go
+++ b/plugins/scheduler/src/triggers/triggers.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/dokku/dokku/plugins/common"
 	"github.com/dokku/dokku/plugins/scheduler"
@@ -14,6 +15,7 @@ import (
 func main() {
 	parts := strings.Split(os.Args[0], "/")
 	trigger := parts[len(parts)-1]
+	global := flag.Bool("global", false, "--global: use the global environment")
 	flag.Parse()
 
 	var err error
@@ -36,6 +38,9 @@ func main() {
 		err = scheduler.ReportSingleApp(appName, "", "")
 	case "scheduler-detect":
 		appName := flag.Arg(0)
+		if *global {
+			appName = "--global"
+		}
 		err = scheduler.TriggerSchedulerDetect(appName)
 	default:
 		err = fmt.Errorf("Invalid plugin trigger call: %s", trigger)

--- a/plugins/scheduler/triggers.go
+++ b/plugins/scheduler/triggers.go
@@ -9,9 +9,11 @@ import (
 
 // TriggerSchedulerDetect outputs a manually selected scheduler for the app
 func TriggerSchedulerDetect(appName string) error {
-	if scheduler := common.PropertyGet("scheduler", appName, "selected"); scheduler != "" {
-		fmt.Println(scheduler)
-		return nil
+	if appName != "--global" {
+		if scheduler := common.PropertyGet("scheduler", appName, "selected"); scheduler != "" {
+			fmt.Println(scheduler)
+			return nil
+		}
 	}
 
 	if scheduler := common.PropertyGet("scheduler", "--global", "selected"); scheduler != "" {


### PR DESCRIPTION
Previously this caused errors when fetching the global scheduler.