### PR TITLE
Fix help flag for logs command

### DIFF
--- a/docs/deployment/logs.md
+++ b/docs/deployment/logs.md
@@ -1,7 +1,7 @@
 # Log Management
 
 ```
-logs <app> [-h] [-t|--tail] [-n|--num num] [-q|--quiet] [-p|--ps process]  # Display recent log output
+logs <app> [-h|--help] [-t|--tail] [-n|--num num] [-q|--quiet] [-p|--ps process]  # Display recent log output
 logs:failed [--all|<app>]                                                  # Shows the last failed deploy logs
 logs:report [<app>] [<flag>]                                               # Displays a logs report for one or more apps
 logs:set [--global|<app>] <key> <value>                                    # Set or clear a logs property for an app

--- a/plugins/logs/src/commands/commands.go
+++ b/plugins/logs/src/commands/commands.go
@@ -22,7 +22,7 @@ Manage log integration for an app
 Additional commands:`
 
 	helpContent = `
-    logs [-h] [-t|--tail] [-n|--num num] [-q|--quiet] [-p|--ps process] <app>, Display recent log output
+    logs [-h|--help] [-t|--tail] [-n|--num num] [-q|--quiet] [-p|--ps process] <app>, Display recent log output
     logs:failed [--all|<app>], Shows the last failed deploy logs
     logs:report [<app>] [<flag>], Displays a logs report for one or more apps
     logs:set [--global|<app>] <key> <value>, Set or clear a logs property for an app
@@ -40,7 +40,7 @@ func main() {
 	switch cmd {
 	case "logs":
 		args := flag.NewFlagSet("logs", flag.ExitOnError)
-		help := args.Bool("h", false, "-h: print help for the command")
+		help := args.BoolP("help", "h", false, "print help for the command")
 		num := args.Int64P("num", "n", 100, "the number of lines to display")
 		ps := args.StringP("ps", "p", "", "only display logs from the given process")
 		tail := args.BoolP("tail", "t", false, "continually stream logs")


### PR DESCRIPTION
## Description of problem

For log plugin `--h` flag is registered instead of `-h`/`--help`.

### How reproducible

Always

### Steps to Reproduce

Execute `dokku logs -h`

#### Actual Results

```
Usage of logs:
      --h           -h: print help for the command
  -n, --num int     the number of lines to display (default 100)
  -p, --ps string   only display logs from the given process
  -q, --quiet       display raw logs without colors, time and names
  -t, --tail        continually stream logs
pflag: help requested
```

#### Expected Results

```
Usage: dokku logs[:COMMAND]

Manage log integration for an app

Additional commands:
    logs [-h|--help] [-t|--tail] [-n|--num num] [-q|--quiet] [-p|--ps process] <app>  Display recent log output
    logs:failed [--all|<app>]                                                         Shows the last failed deploy logs
    logs:report [<app>] [<flag>]                                                      Displays a logs report for one or more apps
    logs:set [--global|<app>] <key> <value>                                           Set or clear a logs property for an app
    logs:vector-logs [--num num] [--tail]                                             Display vector log output
    logs:vector-start                                                                 Start the vector logging container
    logs:vector-stop                                                                  Stop the vector logging container
```
