### PR TITLE
Upgrade default Vagrantfile box to bento/ubuntu-20.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-BOX_NAME = ENV["BOX_NAME"] || "bento/ubuntu-18.04"
+BOX_NAME = ENV["BOX_NAME"] || "bento/ubuntu-20.04"
 BOX_CPUS = ENV["BOX_CPUS"] || "1"
 BOX_MEMORY = ENV["BOX_MEMORY"] || "1024"
 DOKKU_DOMAIN = ENV["DOKKU_DOMAIN"] || "dokku.me"


### PR DESCRIPTION
20.04 is the default Ubuntu LTS version on most cloud providers. Personally I've been using this image for months without any issues.