### PR TITLE
Set the default memory unit type to megabytes

### DIFF
--- a/docs/deployment/schedulers/docker-local.md
+++ b/docs/deployment/schedulers/docker-local.md
@@ -113,7 +113,7 @@ The `docker-local` scheduler supports a minimal list of resource _limits_ and _r
 
 - cpu: (docker option: `--cpus`), is specified in number of CPUs a process can access.
   - See the ["CPU" section](https://docs.docker.com/config/containers/resource_constraints/#cpu) of the Docker Runtime Options documentation for more information.
-- memory: (docker option: `--memory`) should be specified with a suffix of `b` (bytes), `k` (kilobytes), `m` (megabytes), `g` (gigabytes).
+- memory: (docker option: `--memory`) should be specified with a suffix of `b` (bytes), `k` (kilobytes), `m` (megabytes), `g` (gigabytes). Default unit is `m` (megabytes).
   - See the ["Memory" section](https://docs.docker.com/config/containers/resource_constraints/#memory) of the Docker Runtime Options documentation for more information.
 - memory-swap: (docker option: `--memory-swap`) should be specified with a suffix of `b` (bytes), `k` (kilobytes), `m` (megabytes), `g` (gigabytes)
   - See the ["Memory" section](https://docs.docker.com/config/containers/resource_constraints/#memory) of the Docker Runtime Options documentation for more information.
@@ -122,5 +122,5 @@ The `docker-local` scheduler supports a minimal list of resource _limits_ and _r
 
 ### Resource Reservations
 
-- memory: (docker option: `--memory-reservation`) should be specified with a suffix of `b` (bytes), `k` (kilobytes), `m` (megabytes), `g` (gigabytes)
+- memory: (docker option: `--memory-reservation`) should be specified with a suffix of `b` (bytes), `k` (kilobytes), `m` (megabytes), `g` (gigabytes). Default unit is `m` (megabytes).
   - See the ["Memory" section](https://docs.docker.com/config/containers/resource_constraints/#memory) of the Docker Runtime Options documentation for more information.

--- a/plugins/resource/functions.go
+++ b/plugins/resource/functions.go
@@ -10,7 +10,7 @@ import (
 func addMemorySuffixForDocker(key string, value string) string {
 	if key == "memory" {
 		hasSuffix := false
-		suffixes := []string{"b", "k", "m", "g"}
+		suffixes := []string{"b", "k", "m", "g", "KB", "MB", "GB"}
 		for _, suffix := range suffixes {
 			if strings.HasSuffix(value, suffix) {
 				hasSuffix = true

--- a/plugins/resource/functions.go
+++ b/plugins/resource/functions.go
@@ -2,9 +2,26 @@ package resource
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 )
+
+func addMemorySuffixForDocker(key string, value string) string {
+	if key == "memory" {
+		hasSuffix := false
+		suffixes := []string{"b", "k", "m", "g"}
+		for _, suffix := range suffixes {
+			if strings.HasSuffix(value, suffix) {
+				hasSuffix = true
+			}
+		}
+		if !hasSuffix {
+			value = value + "m"
+		}
+	}
+	return value
+}
 
 func clearByResourceType(appName string, processType string, resourceType string) {
 	noun := "limits"

--- a/plugins/resource/triggers.go
+++ b/plugins/resource/triggers.go
@@ -75,6 +75,7 @@ func TriggerDockerArgsProcessDeploy(appName string, processType string) error {
 		if value == "" {
 			continue
 		}
+		value = addMemorySuffixForDocker(key, value)
 		fmt.Printf(" --%s=%s ", key, value)
 	}
 
@@ -82,6 +83,7 @@ func TriggerDockerArgsProcessDeploy(appName string, processType string) error {
 		if value == "" {
 			continue
 		}
+		value = addMemorySuffixForDocker(key, value)
 		fmt.Printf(" --%s-reservation=%s ", key, value)
 	}
 

--- a/tests/unit/resource_1.bats
+++ b/tests/unit/resource_1.bats
@@ -51,6 +51,18 @@ teardown() {
   echo "status: $status"
   assert_output "536870912"
 
+  run /bin/bash -c "dokku resource:limit --memory 512 $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  dokku ps:rebuild "$TEST_APP"
+  CID=$(< $DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
+  run /bin/bash -c "docker inspect --format '{{.HostConfig.Memory}}' $CID"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "536870912"
+
   run /bin/bash -c "dokku resource:limit --memory 1024MB --process-type worker $TEST_APP"
   echo "output: $output"
   echo "status: $status"


### PR DESCRIPTION
This makes it easier to support all schedulers out of the box - all other schedulers assume megabytes when no unit is specified.