### PR TITLE
Fix deploy branch setting

### DIFF
--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -81,7 +81,7 @@ cmd-git-hook() {
 
   DOKKU_DEPLOY_BRANCH="$(fn-git-deploy-branch "$APP")"
   if ! git check-ref-format --branch "$DOKKU_DEPLOY_BRANCH" >/dev/null 2>&1; then
-    echo $'\e[1G\e[K'"-----> WARNING: Invalid branch name '$DOKKU_DEPLOY_BRANCH' specified via DOKKU_DEPLOY_BRANCH."
+    echo $'\e[1G\e[K'"-----> WARNING: Invalid branch name '$DOKKU_DEPLOY_BRANCH' specified via deploy-branch setting."
     echo $'\e[1G\e[K'"-----> For more details, please see the man page for 'git-check-ref-format.'"
     return
   fi

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -101,7 +101,7 @@ cmd-git-hook() {
         plugn trigger deploy-source-set "$APP" "git-push" "$newrev"
       elif [[ -z "$(fn-git-deploy-branch "$APP" "")" ]]; then
         echo $'\e[1G\e[K'"-----> Set ${refname/refs\/heads\//} to DOKKU_DEPLOY_BRANCH."
-        fn-plugin-property-write "git" "$app" "deploy-branch" "${refname/refs\/heads\//}"
+        fn-plugin-property-write "git" "$APP" "deploy-branch" "${refname/refs\/heads\//}"
         git_receive_app "$APP" "$newrev"
         plugn trigger deploy-source-set "$APP" "git-push" "$newrev"
       else

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -409,7 +409,7 @@ fn-git-last-updated-at() {
   declare desc="retrieve the deploy branch for a given application"
   declare APP="$1"
   local DOKKU_DEPLOY_BRANCH="$(fn-git-deploy-branch "$APP")"
-  local HEAD_FILE="/home/dokku/$APP/refs/heads/$DOKKU_DEPLOY_BRANCH"
+  local HEAD_FILE="$DOKKU_ROOT/$APP/refs/heads/$DOKKU_DEPLOY_BRANCH"
 
   if [[ -f "$HEAD_FILE" ]]; then
     stat -c %Y "$HEAD_FILE"

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -388,7 +388,7 @@ fn-git-fetch() {
 
   DOKKU_DEPLOY_BRANCH="$(fn-git-deploy-branch "$APP")"
   if ! fn-git-cmd "$APP_ROOT" check-ref-format --branch "$DOKKU_DEPLOY_BRANCH" >/dev/null 2>&1; then
-    dokku_log_warn "Invalid branch name '$DOKKU_DEPLOY_BRANCH' specified via DOKKU_DEPLOY_BRANCH."
+    dokku_log_warn "Invalid branch name '$DOKKU_DEPLOY_BRANCH' specified via deploy-branch setting."
     dokku_log_warn "For more details, please see the man page for 'git-check-ref-format.'"
     return
   fi


### PR DESCRIPTION
Previously, we weren't actually setting it when a deploy occurred due to using a bad variable.

Also update the log output to better match what property sets this.