### PR TITLE
Start the vector logging container after Docker daemon restarts

### DIFF
--- a/plugins/logs/functions.go
+++ b/plugins/logs/functions.go
@@ -71,6 +71,7 @@ func startVectorContainer(vectorImage string) error {
 		common.DockerBin(),
 		"container",
 		"run", "--detach", "--name", vectorContainerName, common.MustGetEnv("DOKKU_GLOBAL_RUN_ARGS"),
+		"--restart", "unless-stopped",
 		"--volume", "/var/lib/dokku/data/logs/vector.json:/etc/vector/vector.json",
 		"--volume", "/var/run/docker.sock:/var/run/docker.sock",
 		"--volume", common.MustGetEnv("DOKKU_LOGS_HOST_DIR") + ":/var/logs/dokku/apps",

--- a/tests/unit/logs.bats
+++ b/tests/unit/logs.bats
@@ -533,6 +533,12 @@ teardown() {
   assert_success
   assert_output_contains "Vector container is running"
 
+  run /bin/bash -c "sudo docker inspect --format='{{.HostConfig.RestartPolicy.Name}}' vector"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "unless-stopped"
+
   run /bin/bash -c "dokku logs:vector-logs 2>&1"
   echo "output: $output"
   echo "status: $status"


### PR DESCRIPTION
Addresses the issue https://github.com/dokku/dokku/issues/5122.