### PR TITLE
Ensure we default SSH_NAME to NAME when filtering apps

### DIFF
--- a/plugins/common/functions.go
+++ b/plugins/common/functions.go
@@ -18,6 +18,9 @@ func filterApps(apps []string) ([]string, error) {
 
 	sshName := os.Getenv("SSH_NAME")
 	if sshName == "" {
+		sshName = os.Getenv("NAME")
+	}
+	if sshName == "" {
 		sshName = "default"
 	}
 


### PR DESCRIPTION
This mirrors how SSH_NAME is populated for the user-auth trigger.