### PR TITLE
fix: define devcontainer platform

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM dokku/dokku:latest
+FROM --platform=linux/amd64 dokku/dokku:latest
 
 RUN apt-get update
 RUN apt-get install --no-install-recommends -y build-essential file nano && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,14 +1,17 @@
-FROM --platform=linux/amd64 dokku/dokku:latest
+FROM dokku/dokku:latest
 
-RUN apt-get update
+ARG TARGETARCH
+
+RUN apt-get update && \
+  apt-get install -y apt-transport-https ca-certificates
 RUN apt-get install --no-install-recommends -y build-essential file nano && \
   apt-get install --no-install-recommends -y help2man shellcheck uuid-runtime wget xmlstarlet && \
   apt-get clean autoclean && \
   apt-get autoremove --yes && \
   rm -rf /var/lib/apt/lists/*
 
-RUN wget https://dl.google.com/go/go1.17.9.linux-amd64.tar.gz && \
-  tar -xvf go1.17.9.linux-amd64.tar.gz && \
+RUN wget https://dl.google.com/go/go1.17.9.linux-${TARGETARCH}.tar.gz && \
+  tar -xvf go1.17.9.linux-${TARGETARCH}.tar.gz && \
   mv go /usr/local
 
 RUN GOROOT=/usr/local/go /usr/local/go/bin/go install golang.org/x/tools/gopls@latest 2>&1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:focal-1.1.0
+FROM phusion/baseimage:focal-1.2.0
 
 CMD ["/sbin/my_init"]
 


### PR DESCRIPTION
AMD64 version of Go is installed inside the devcontainer but the platform of dokku image is not defined. The platform of the image has to be defined for ARM devices because on these machines ARM version of dokku image is used by default.