### PR TITLE
Confirm installation of universe packages when installing on ubuntu

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -63,7 +63,7 @@ install-requirements() {
         apt-get -qq -y --no-install-recommends install software-properties-common
       fi
 
-      add-apt-repository universe >/dev/null
+      add-apt-repository -y universe >/dev/null
       apt-get update -qq >/dev/null
       ;;
   esac


### PR DESCRIPTION
This fixes installs stalling on Ubuntu 22.04 because of necessary confirmation of the addition.

Closes #5191