### PR TITLE
Force-set correct permissions on env files

### DIFF
--- a/plugins/config/config.go
+++ b/plugins/config/config.go
@@ -52,6 +52,7 @@ func SetMany(appName string, entries map[string]string, restart bool) (err error
 			fmt.Println(prettyPrintEnvEntries("       ", entries))
 		}
 		env.Write()
+		common.SetPermissions(env.Filename(), 0600)
 		triggerUpdate(appName, "set", keys)
 	}
 	if !global && restart && env.GetBoolDefault("DOKKU_APP_RESTORE", true) {
@@ -84,6 +85,7 @@ func UnsetMany(appName string, keys []string, restart bool) (err error) {
 	}
 	if changed {
 		env.Write()
+		common.SetPermissions(env.Filename(), 0600)
 		triggerUpdate(appName, "unset", keys)
 	}
 	if !global && restart && env.GetBoolDefault("DOKKU_APP_RESTORE", true) {
@@ -107,6 +109,7 @@ func UnsetAll(appName string, restart bool) (err error) {
 	}
 	if changed {
 		env.Write()
+		common.SetPermissions(env.Filename(), 0600)
 		triggerUpdate(appName, "clear", []string{})
 	}
 	if !global && restart && env.GetBoolDefault("DOKKU_APP_RESTORE", true) {

--- a/plugins/config/environment.go
+++ b/plugins/config/environment.go
@@ -92,6 +92,11 @@ func LoadGlobalEnv() (*Env, error) {
 	return loadFromFile("<global>", getGlobalFile())
 }
 
+// Filename returns the full path on disk to the file holding the env vars
+func (e *Env) Filename() string {
+	return e.filename
+}
+
 //Get an environment variable
 func (e *Env) Get(key string) (value string, ok bool) {
 	value, ok = e.env[key]


### PR DESCRIPTION
If an env file is written as a root user - for example, during plugin install - the permissions on the file may change to root. This forces those permissions back to what they should be so that the dokku user can edit the files later on.

Closes #5190