### PR TITLE
Disable herokuish usage on both armhf and arm64 platforms

### DIFF
--- a/plugins/00_dokku-standard/subcommands/report
+++ b/plugins/00_dokku-standard/subcommands/report
@@ -8,6 +8,7 @@ cmd-report() {
   declare cmd="report"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"
+  local ARCHITECTURE="$(dpkg --print-architecture 2>/dev/null || true)"
 
   if [[ "$APP" == "--format" ]]; then
     dokku_log_fail "--format flag not supported on global report"
@@ -23,8 +24,8 @@ cmd-report() {
   dokku_log_info1 "git version: $(git --version)"
   dokku_log_info1 "sigil version: $(sigil -v)"
   dokku_log_info1 "herokuish version: "
-  if [[ "$(dpkg --print-architecture 2>/dev/null || true)" == "armhf" ]]; then
-    dokku_log_warn "herokuish not supported on armhf architecture"
+  if [[ "$ARCHITECTURE" == "armhf" ]] || [[ "$ARCHITECTURE" == "arm64" ]]; then
+    dokku_log_warn "herokuish not supported on $ARCHITECTURE architecture"
   else
     "$DOCKER_BIN" container run $DOKKU_GLOBAL_RUN_ARGS --rm "$DOKKU_IMAGE" herokuish version | sed "s/^/       /"
   fi

--- a/plugins/builder-herokuish/builder-detect
+++ b/plugins/builder-herokuish/builder-detect
@@ -7,8 +7,9 @@ trigger-builder-herokuish-builder-detect() {
   declare desc="builder-herokuish builder-detect plugin trigger"
   declare trigger="builder-detect"
   declare APP="$1" SOURCECODE_WORK_DIR="$2"
+  local ARCHITECTURE="$(dpkg --print-architecture 2>/dev/null || true)"
 
-  if [[ "$(dpkg --print-architecture 2>/dev/null || true)" == "armhf" ]]; then
+  if [[ "$ARCHITECTURE" == "armhf" ]] || [[ "$ARCHITECTURE" == "arm64" ]]; then
     return
   fi
 


### PR DESCRIPTION
We will not provide support for herokuish on either as herokuish is meant to be Heroku-compatible, and the Heroku stack does not support arm. Use 'pack' or Dockerfiles for app building instead.