### PR TITLE
fix: Vector fails to start container due to --watch-config flag

### DIFF
--- a/plugins/logs/functions.go
+++ b/plugins/logs/functions.go
@@ -77,7 +77,7 @@ func startVectorContainer(vectorImage string) error {
 		"--volume", common.MustGetEnv("DOKKU_LOGS_HOST_DIR") + ":/var/logs/dokku/apps",
 		"--volume", common.MustGetEnv("DOKKU_LOGS_HOST_DIR") + "/apps:/var/log/dokku/apps",
 		vectorImage,
-		"--config", "/etc/vector/vector.json", "--watch-config", "1"}, " "))
+		"--config", "/etc/vector/vector.json", "--watch-config"}, " "))
 	cmd.ShowOutput = false
 
 	if !cmd.Execute() {


### PR DESCRIPTION
Vector doesn't accept an argument after the `--watch-config` flag anymore, so executing `dokku logs:vector-start` fails to start the container.

The output of `dokku logs:vector-logs`:

```
-----> Vector container logs
 !     USAGE:
 !         vector [OPTIONS] [SUBCOMMAND]
 !     For more information try --help
 !     error: Found argument '1' which wasn't expected, or isn't valid in this context
 ``` 

The output of `docker ps --no-trunc`:
```
CONTAINER ID                                                       IMAGE                           COMMAND                                                                              CREATED          STATUS                          PORTS      NAMES
f3bb3fae0464081c3c8c39cfb7f777ed920a8bd4f89392bc922d949e9e721886   timberio/vector:latest-debian   "/usr/bin/vector --config /etc/vector/vector.json --watch-config 1"                  35 minutes ago   Restarting (2) 30 seconds ago              vector
```