### PR TITLE
Use pack as default builder for arm64 servers

### DIFF
--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -62,11 +62,11 @@ git_trigger_build() {
     BUILDER="herokuish"
     local ARCHITECTURE="$(dpkg --print-architecture 2>/dev/null || true)"
     if [[ "$ARCHITECTURE" == "arm64" ]]; then
-      dokku_log_warn "Builder herokuish not supported on $ARCHITECTURE servers."
+      dokku_log_warn "Herokuish builder not supported on $ARCHITECTURE servers."
       dokku_log_warn "Switching to pack builder."
       BUILDER="pack"
     elif [[ "$ARCHITECTURE" == "armhf" ]]; then
-      dokku_log_warn "Builder herokuish not supported on $ARCHITECTURE servers."
+      dokku_log_warn "Herokuish builder not supported on $ARCHITECTURE servers."
       dokku_log_warn "Consider using a Dockerfile to build your app."
       return 1
     fi

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -58,7 +58,19 @@ git_trigger_build() {
   plugn trigger post-extract "$APP" "$TMP_WORK_DIR" "$REV"
 
   BUILDER="$(plugn trigger builder-detect "$APP" "$TMP_WORK_DIR" | head -n1 || true)"
-  [[ -z "$BUILDER" ]] && BUILDER="herokuish"
+  if [[ -z "$BUILDER" ]]; then
+    BUILDER="herokuish"
+    local ARCHITECTURE="$(dpkg --print-architecture 2>/dev/null || true)"
+    if [[ "$ARCHITECTURE" == "arm64" ]]; then
+      dokku_log_warn "Builder herokuish not supported on $ARCHITECTURE servers."
+      dokku_log_warn "Switching to pack builder."
+      BUILDER="pack"
+    elif [[ "$ARCHITECTURE" == "armhf" ]]; then
+      dokku_log_warn "Builder herokuish not supported on $ARCHITECTURE servers."
+      dokku_log_warn "Consider using a Dockerfile to build your app."
+      return 1
+    fi
+  fi
 
   plugn trigger pre-receive-app "$APP" "$BUILDER" "$TMP_WORK_DIR" "$REV"
   dokku_receive "$APP" "$BUILDER" "$TMP_WORK_DIR"


### PR DESCRIPTION
Herokuish is not and will never be supported on arm servers, so attempting to use it will only fail builds.

Also fail when trying to default to herokuish on armhf instances. We can't default to pack as it's just not built for armhf/arm (only arm64).

Closes #5113