### PR TITLE
Document that the community registry plugin should be uninstalled before upgrading past 0.24.x

### DIFF
--- a/docs/appendices/0.25.0-migration-guide.md
+++ b/docs/appendices/0.25.0-migration-guide.md
@@ -9,6 +9,8 @@ The [dokku-registry](https://github.com/dokku/dokku-registry) plugin is now buil
 - At this time, remote docker repositories are not automatically created for AWS, and users must create those repositories for their applications as necessary. This may be implemented in the future.
 - Docker images are only pushed when configured to do so. See the [registry management documentation](/docs/deployment/registry-management.md) for more details.
 
+Before upgrading, uninstall the registry plugin via `dokku plugin:uninstall registry`. Not doing so will cause issues with Dokku.
+
 ## Other
 
 ### Changes


### PR DESCRIPTION
Without this, it's unknown what will happen.

Refs #5223