### PR TITLE
Always respect app.json formations in scale settings

### DIFF
--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -497,7 +497,7 @@ func setScale(appName string, image string) error {
 	}
 
 	skipDeploy := true
-	clearExisting := false
+	clearExisting := true
 	args := []string{appName, strconv.FormatBool(skipDeploy), strconv.FormatBool(clearExisting)}
 	for processType, formation := range appJSON.Formation {
 		if formation.Quantity != nil {

--- a/tests/apps/python/app-5205a.json
+++ b/tests/apps/python/app-5205a.json
@@ -1,0 +1,10 @@
+{
+  "formation": {
+    "web": {
+      "quantity": 1
+    },
+    "worker": {
+      "quantity": 1
+    }
+  }
+}

--- a/tests/apps/python/app-5205b.json
+++ b/tests/apps/python/app-5205b.json
@@ -1,0 +1,10 @@
+{
+  "formation": {
+    "web": {
+      "quantity": 1
+    },
+    "cron": {
+      "quantity": 1
+    }
+  }
+}

--- a/tests/unit/app-json-3.bats
+++ b/tests/unit/app-json-3.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+load test_helper
+
+setup() {
+  global_setup
+  create_app
+}
+
+teardown() {
+  destroy_app
+  global_teardown
+}
+
+@test "(app-json) persist scale" {
+  local CUSTOM_TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
+
+  CUSTOM_TMP="$CUSTOM_TMP" run deploy_app python dokku@dokku.me:$TEST_APP persist_scale_callback_a
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku --quiet ps:scale $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "web:  1"
+  assert_output_contains "worker: 1"
+  assert_output_contains "cron: 0" 0
+
+  run persist_scale_callback_b "$TEST_APP" "$CUSTOM_TMP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run git -C "$CUSTOM_TMP" add app.json Procfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run git -C "$CUSTOM_TMP" commit -m 'Update scaling parameters'
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run git -C "$CUSTOM_TMP" push target master:master
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku --quiet ps:scale $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "web:  1"
+  assert_output_contains "worker: 1" 0
+  assert_output_contains "worker: 0" 0
+  assert_output_contains "cron: 1" 1
+}
+
+persist_scale_callback_a() {
+  local APP="$1"
+  local APP_REPO_DIR="$2"
+  [[ -z "$APP" ]] && local APP="$TEST_APP"
+
+  rm  "$APP_REPO_DIR/Procfile"
+  touch "$APP_REPO_DIR/Procfile"
+  echo "web: python3 web.py" >>"$APP_REPO_DIR/Procfile"
+  echo "worker: python3 worker.py" >>"$APP_REPO_DIR/Procfile"
+  mv "$APP_REPO_DIR/app-5205a.json" "$APP_REPO_DIR/app.json"
+}
+
+
+persist_scale_callback_b() {
+  local APP="$1"
+  local APP_REPO_DIR="$2"
+  [[ -z "$APP" ]] && local APP="$TEST_APP"
+
+  rm  "$APP_REPO_DIR/Procfile"
+  touch "$APP_REPO_DIR/Procfile"
+  echo "web: python3 web.py" >>"$APP_REPO_DIR/Procfile"
+  echo "cron: python3 worker.py" >>"$APP_REPO_DIR/Procfile"
+  mv "$APP_REPO_DIR/app-5205b.json" "$APP_REPO_DIR/app.json"
+}


### PR DESCRIPTION
Without this change, it was possible would end up in a state where we might still try to scale processes up that no longer exists.

Closes #5205