### PR TITLE
Add builder-type and image-stage labels to all images

### DIFF
--- a/plugins/builder-dockerfile/builder-build
+++ b/plugins/builder-dockerfile/builder-build
@@ -17,7 +17,7 @@ trigger-builder-dockerfile-builder-build() {
   dokku_log_info1 "Building $APP from Dockerfile"
 
   local IMAGE=$(get_app_image_name "$APP")
-  local DOCKER_BUILD_LABEL_ARGS=("--label=org.label-schema.schema-version=1.0" "--label=org.label-schema.vendor=dokku" "--label=com.dokku.app-name=$APP" "--label=com.dokku.image-stage=build")
+  local DOCKER_BUILD_LABEL_ARGS=("--label=dokku" "--label=org.label-schema.schema-version=1.0" "--label=org.label-schema.vendor=dokku" "--label=com.dokku.image-stage=build" "--label=com.dokku.builder-type=dockerfile" "--label=com.dokku.app-name=$APP")
 
   pushd "$SOURCECODE_WORK_DIR" &>/dev/null
 

--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -23,8 +23,8 @@ trigger-builder-herokuish-builder-build() {
   local IMAGE=$(get_app_image_name "$APP")
   local DOKKU_APP_CACHE_DIR="$DOKKU_ROOT/$APP/cache"
   local DOKKU_APP_HOST_CACHE_DIR="$DOKKU_HOST_ROOT/$APP/cache"
-  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP")
-  local DOCKER_RUN_LABEL_ARGS=("--label=com.dokku.image-stage=build" "--label=com.dokku.app-name=$APP")
+  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL dokku=" "--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.image-stage=build" "--change" "LABEL com.dokku.builder-type=herokuish" "--change" "LABEL com.dokku.app-name=$APP")
+  local DOCKER_RUN_LABEL_ARGS=("--label=dokku" "--label=org.label-schema.schema-version=1.0" "--label=org.label-schema.vendor=dokku" "--label=com.dokku.image-stage=build" "--label=com.dokku.builder-type=herokuish" "--label=com.dokku.app-name=$APP")
   local CID TAR_CID
 
   pushd "$SOURCECODE_WORK_DIR" &>/dev/null

--- a/plugins/builder-pack/builder-build
+++ b/plugins/builder-pack/builder-build
@@ -33,7 +33,7 @@ trigger-builder-pack-builder-build() {
 
   plugn trigger pre-build-pack "$APP" "$SOURCECODE_WORK_DIR"
   pack build "$IMAGE" --builder "$DOKKU_CNB_BUILDER" --path "$SOURCECODE_WORK_DIR" --default-process web "${ENV_ARGS[@]}"
-  docker-image-labeler --label=com.dokku.image-stage=build --label=com.dokku.app-name=$APP --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=dokku "$IMAGE"
+  docker-image-labeler --label=dokku --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.image-stage=build --label=com.dokku.builder-type=pack --label=com.dokku.app-name=$APP "$IMAGE"
 
   plugn trigger post-build-pack "$APP" "$SOURCECODE_WORK_DIR"
 }


### PR DESCRIPTION
This allows users to further introspect where an image came from, and therefore what - if any - custom logic to perform.