### PR TITLE
Clarify log shipping stance

### DIFF
--- a/docs/deployment/logs.md
+++ b/docs/deployment/logs.md
@@ -20,6 +20,8 @@ You can easily get logs of an app using the `logs` command:
 dokku logs node-js-app
 ```
 
+Logs are pulled via integration with the scheduler for the specified application via "live tailing". As such, logs from previously running deployments are usually not available. Users that desire to see logs from previous deployments for debugging purposes should persist those logs to external services. Please see Dokku's [vector integration](deployment/logs.md#vector-logging-shipping) for more information on how to persist logs across deployments to ship logs to another service or a third-party platform.
+
 #### Behavioral modifiers
 
 Dokku also supports certain command-line arguments that augment the `log` command's behavior.

--- a/docs/deployment/schedulers/docker-local.md
+++ b/docs/deployment/schedulers/docker-local.md
@@ -91,7 +91,11 @@ Omitting or removing the entry will result in parallelism for that process type 
 
 Note that increasing the value of `max_parallel` may significantly impact CPU utilization on your host as your app containers - and their respective processes - start up. Setting a value higher than the number of available CPUs is discouraged. It is recommended that users carefully set this value so as not to overburden their server.
 
-## Implemented Triggers
+## Scheduler Interface
+
+The following sections describe implemented scheduler functionality for the `docker-local` scheduler.
+
+### Implemented Commands and Triggers
 
 This plugin implements various functionality through `plugn` triggers to integrate with Docker for running apps on a single server. The following functionality is supported by the `scheduler-docker-local` plugin.
 
@@ -105,11 +109,16 @@ This plugin implements various functionality through `plugn` triggers to integra
 - `ps:stop`
 - `run`
 
-## Supported Resource Management Properties
+
+### Logging support
+
+App logs for the `logs` command are fetched from running containers via the `docker` cli. To persist logs across deployments, consider using Dokku's [vector integration](deployment/logs.md#vector-logging-shipping) to ship logs to another service or a third-party platform.
+
+### Supported Resource Management Properties
 
 The `docker-local` scheduler supports a minimal list of resource _limits_ and _reservations_. The following properties are supported:
 
-### Resource Limits
+#### Resource Limits
 
 - cpu: (docker option: `--cpus`), is specified in number of CPUs a process can access.
   - See the ["CPU" section](https://docs.docker.com/config/containers/resource_constraints/#cpu) of the Docker Runtime Options documentation for more information.
@@ -120,7 +129,7 @@ The `docker-local` scheduler supports a minimal list of resource _limits_ and _r
 - nvidia-gpus: (docker option: `--gpus`), is specified in number of Nvidia GPUs a process can access.
   - See the ["GPU" section](https://docs.docker.com/config/containers/resource_constraints/#gpu) of the Docker Runtime Options documentation for more information.
 
-### Resource Reservations
+#### Resource Reservations
 
 - memory: (docker option: `--memory-reservation`) should be specified with a suffix of `b` (bytes), `k` (kilobytes), `m` (megabytes), `g` (gigabytes). Default unit is `m` (megabytes).
   - See the ["Memory" section](https://docs.docker.com/config/containers/resource_constraints/#memory) of the Docker Runtime Options documentation for more information.

--- a/docs/deployment/schedulers/kubernetes.md
+++ b/docs/deployment/schedulers/kubernetes.md
@@ -2,13 +2,23 @@
 
 > Warning: This scheduler is not in Dokku core and thus functionality may change over time as the API stabilizes.
 
-The [Kubernetes Scheduler Plugin](https://github.com/dokku/dokku-scheduler-kubernetes) implements the following functionality:
+The [Nomad Scheduler Plugin](https://github.com/dokku/dokku-scheduler-kubernetes) is available free as an external plugin. Please see the plugin's [issue tracker](https://github.com/dokku/dokku-scheduler-kubernetes/issues) for more information on the status of the plugin.
+
+For users that require additional functionality, please refer to the [Sponsoring Documentation](https://github.com/dokku/.github/blob/master/SPONSORING.md).
+
+## Scheduler Interface
+
+The following sections describe implemented scheduler functionality for the `docker-local` scheduler.
+
+### Implemented Commands and Triggers
+
+This plugin implements various functionality through `plugn` triggers to integrate with `kubectl` for running apps on a Kubernetes cluster. The following functionality is supported by the `scheduler-kubernetes` plugin.
 
 - `apps:destroy`
 - `deploy`: partial, does not implement failed deploy log capture
 - `logs`: partial, does not implement failure logs
 - `ps:stop`
 
-Please see the plugin's [issue tracker](https://github.com/dokku/dokku-scheduler-kubernetes/issues) for more information on the status of the plugin.
+### Logging support
 
-For users that require additional functionality, please refer to the [Sponsoring Documentation](https://github.com/dokku/.github/blob/master/SPONSORING.md).
+App logs for the `logs` command are fetched from running pods via the `kubectl` cli. To persist logs across deployments, consider using [Vector](https://vector.dev/docs/setup/installation/platforms/kubernetes/) or a similar tool to ship logs to another service or a third-party platform.

--- a/docs/deployment/schedulers/nomad.md
+++ b/docs/deployment/schedulers/nomad.md
@@ -2,12 +2,22 @@
 
 > Warning: This scheduler is not in Dokku core and thus functionality may change over time as the API stabilizes.
 
-The [Nomad Scheduler Plugin](https://github.com/dokku/dokku-scheduler-nomad) implements the following functionality:
+The [Nomad Scheduler Plugin](https://github.com/dokku/dokku-scheduler-nomad) is available free as an external plugin. Please see the plugin's [issue tracker](https://github.com/dokku/dokku-scheduler-nomad/issues) for more information on the status of the plugin.
+
+For users that require additional functionality, please refer to the [Sponsoring Documentation](https://github.com/dokku/.github/blob/master/SPONSORING.md).
+
+## Scheduler Interface
+
+The following sections describe implemented scheduler functionality for the `docker-local` scheduler.
+
+### Implemented Commands and Triggers
+
+This plugin implements various functionality through `plugn` triggers to integrate with the `nomad` cli for running apps on a Nomad cluster. The following functionality is supported by the `scheduler-nomad` plugin.
 
 - `apps:destroy`
 - `deploy`
 - `ps:stop`
 
-Please see the plugin's [issue tracker](https://github.com/dokku/dokku-scheduler-nomad/issues) for more information on the status of the plugin.
+### Logging support
 
-For users that require additional functionality, please refer to the [Sponsoring Documentation](https://github.com/dokku/.github/blob/master/SPONSORING.md).
+> Warning: Fetching app logs for the `logs` command is currently not implemented. Please consider using [Vector](https://vector.dev/docs/setup/installation/platforms/kubernetes/) or a similar tool to ship logs to another service or a third-party platform.


### PR DESCRIPTION
While it is unfortunate that we don't store logs locally, doing so is actually a fairly difficult ask. Rather than pretending the problem doesn't exist, we'll clarify how logs are currently fetched, as well as point users to integrations/tools that may make their lives easier.

Refs #5234