### PR TITLE
export DOKKU_COMMAND for use in authentication systems

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -743,6 +743,7 @@ dokku_auth() {
   declare desc="calls user-auth plugin trigger"
   export SSH_USER=${SSH_USER:=$USER}
   export SSH_NAME=${NAME:="default"}
+  export DOKKU_COMMAND="$1"
 
   local user_auth_count=$(find "$PLUGIN_PATH"/enabled/*/user-auth 2>/dev/null | wc -l)
 


### PR DESCRIPTION
Some auth systems may decide that an app is not available for use by a particular command vs making them wholly available or not. Exporting the variable here allows such systems to function correctly.