### PR TITLE
Update deprecated apt-key command

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -212,7 +212,7 @@ install-dokku-from-deb-package() {
   fi
 
   echo "--> Installing dokku"
-  wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -
+  wget -qO- https://packagecloud.io/dokku/dokku/gpgkey | sudo tee /etc/apt/trusted.gpg.d/dokku.asc
   echo "deb https://packagecloud.io/dokku/dokku/$DOKKU_DISTRO/ $OS_ID main" | tee /etc/apt/sources.list.d/dokku.list
   apt-get update -qq >/dev/null
 

--- a/deb.mk
+++ b/deb.mk
@@ -19,7 +19,7 @@ install-from-deb:
 	wget -nv -O - https://get.docker.com/ | sh
 
 	@echo "--> Installing dokku"
-	wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -
+	wget -qO- https://packagecloud.io/dokku/dokku/gpgkey | sudo tee /etc/apt/trusted.gpg.d/dokku.asc
 	@echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ $(shell lsb_release -cs 2>/dev/null || echo "bionic") main" | sudo tee /etc/apt/sources.list.d/dokku.list
 	sudo apt-get update -qq >/dev/null
 	sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get -qq -y --no-install-recommends install dokku

--- a/docs/getting-started/install/debian.md
+++ b/docs/getting-started/install/debian.md
@@ -11,7 +11,7 @@ sudo apt-get -qq -y --no-install-recommends install apt-transport-https
 wget -nv -O - https://get.docker.com/ | sh
 
 # install dokku
-wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -
+wget -qO- https://packagecloud.io/dokku/dokku/gpgkey | sudo tee /etc/apt/trusted.gpg.d/dokku.asc
 OS_ID="$(lsb_release -cs 2>/dev/null || echo "bionic")"
 echo "bionic focal jammy" | grep -q "$OS_ID" || OS_ID="bionic"
 echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ ${OS_ID} main" | sudo tee /etc/apt/sources.list.d/dokku.list

--- a/docs/home.html
+++ b/docs/home.html
@@ -128,7 +128,7 @@
           <p class="line">
             <span class="path"></span>
             <span class="prompt">$</span>
-            <span class="command">wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -</span>
+            <span class="command">wget -qO- https://packagecloud.io/dokku/dokku/gpgkey | sudo tee /etc/apt/trusted.gpg.d/dokku.asc</span>
           </p>
           <p class="line">
             <span class="path"></span>


### PR DESCRIPTION
Upon running the provided `apt-key` command, I get a deprecation warning:

```sh
root@pop-os:/home/alex# wget -nv -O - https://packagecloud.io/dokku/dokku/gpgkey | apt-key add -
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
2022-07-24 11:01:36 URL:https://d28dx6y1hfq314.cloudfront.net/505/623/gpg/dokku-dokku-FB2B6AA421CD193F.pub.gpg?t=1658678796_f906c69452735f2338f96cd23ea0bcf3ba2b60b1 [3937/3937] -> "-" [1]
OK
```

Furthermore in `apt update`:

```sh
root@pop-os:/home/alex# apt update
...
W: https://packagecloud.io/dokku/dokku/ubuntu/dists/jammy/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```

Checking the docs for `man apt-key`:

```sh
DEPRECATION
       Except for using apt-key del in maintainer scripts, the use of apt-key is deprecated. This section shows how to replace existing use of apt-key.

       If your existing use of apt-key add looks like this:

       wget -qO- https://myrepo.example/myrepo.asc | sudo apt-key add -

       Then you can directly replace this with (though note the recommendation below):

       wget -qO- https://myrepo.example/myrepo.asc | sudo tee /etc/apt/trusted.gpg.d/myrepo.asc

       Make sure to use the "asc" extension for ASCII armored keys and the "gpg" extension for the binary OpenPGP format (also known as "GPG key public ring"). The binary OpenPGP format
       works for all apt versions, while the ASCII armored format works for apt version >= 1.4.

       Recommended: Instead of placing keys into the /etc/apt/trusted.gpg.d directory, you can place them anywhere on your filesystem by using the Signed-By option in your sources.list
       and pointing to the filename of the key. See sources.list(5) for details. Since APT 2.4, /etc/apt/keyrings is provided as the recommended location for keys not managed by
       packages. When using a deb822-style sources.list, and with apt version >= 2.4, the Signed-By option can also be used to include the full ASCII armored keyring directly in the
       sources.list without an additional file.
```

I was able to remove the old key with:

```sh
apt-key del 288B3315
```

Then reinstall install it the new way:

```sh
wget -qO- https://packagecloud.io/dokku/dokku/gpgkey | sudo tee /etc/apt/trusted.gpg.d/dokku.asc
```