### PR TITLE
Add support for --global as app name when calling config-get trigger

### DIFF
--- a/plugins/common/docker.go
+++ b/plugins/common/docker.go
@@ -172,7 +172,14 @@ func DockerCleanup(appName string, forceCleanup bool) error {
 	if !forceCleanup {
 		skipCleanup := false
 		if appName != "" {
-			b, _ := PlugnTriggerOutput("config-get", []string{appName, "DOKKU_SKIP_CLEANUP"}...)
+			triggerName := "config-get"
+			triggerArgs := []string{appName, "DOKKU_SKIP_CLEANUP"}
+			if appName == "--global" {
+				triggerName = "config-get-global"
+				triggerArgs = []string{"DOKKU_SKIP_CLEANUP"}
+			}
+
+			b, _ := PlugnTriggerOutput(triggerName, triggerArgs...)
 			output := strings.TrimSpace(string(b[:]))
 			if output == "true" {
 				skipCleanup = true

--- a/plugins/config/src/triggers/triggers.go
+++ b/plugins/config/src/triggers/triggers.go
@@ -14,6 +14,7 @@ import (
 func main() {
 	parts := strings.Split(os.Args[0], "/")
 	trigger := parts[len(parts)-1]
+	global := flag.Bool("global", false, "--global: Whether global or app-specific")
 	flag.Parse()
 
 	var err error
@@ -27,6 +28,10 @@ func main() {
 	case "config-get":
 		appName := flag.Arg(0)
 		key := flag.Arg(1)
+		if *global {
+			appName = "--global"
+			key = flag.Arg(0)
+		}
 		err = config.TriggerConfigGet(appName, key)
 	case "config-get-global":
 		key := flag.Arg(0)


### PR DESCRIPTION
The trigger in use _should_ be config-get-global, but some calling code does not check, so adding support here will ensure the calling code gets what it expects.

Additionally, switch to correct trigger when getting a global argument. While both will now work, using the correct trigger will skip some extra logic.

Closes #5269