### PR TITLE
Correct issue where more complex docker args were not properly parsed when scheduling containers

### DIFF
--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -241,11 +241,11 @@ fn-scheduler-docker-local-start-app-container() {
   declare APP="$1"
   shift
 
-  local DOCKER_ARGS
+  declare -a DOCKER_ARGS
   for i in "$@"; do
-    DOCKER_ARGS="$DOCKER_ARGS \"$i\""
+    DOCKER_ARGS+=("$i")
   done
-  eval set -- $DOCKER_ARGS
+  set -- "${DOCKER_ARGS[@]}"
 
   eval "$(config_export app "$APP" --merged)"
   # shellcheck disable=SC2124

--- a/tests/unit/scheduler-docker-local.bats
+++ b/tests/unit/scheduler-docker-local.bats
@@ -30,3 +30,28 @@ teardown() {
   echo "status: $status"
   assert_success
 }
+
+@test "(scheduler-docker-local) complex labels" {
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # the run command is equivalent to the following line, except with backslashes due to the enclosing doublequotes
+  # dokku docker-options:add test deploy '--label "some.key=Host(\`$TEST_APP.dokku.me\`)"'
+  run /bin/bash -c "dokku docker-options:add $TEST_APP deploy '--label \"some.key=Host(\\\`$TEST_APP.dokku.me\\\`)\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "docker inspect --format '{{ index .Config.Labels \"some.key\"}}' $TEST_APP.web.1"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "Host(\`$TEST_APP.dokku.me\`)"
+  assert_success
+}


### PR DESCRIPTION
In cases where a docker arg uses backticks - which may happen with docker labels - scheduled containers would fail to support these due to performing a double-eval. This is particularly noticeable for traefik labels, where backticks and parenthesis are common. This fix properly handles docker args as an array instead of performing an extra eval when scheduling containers.