### PR TITLE
Remove duplicate syntax for nginx.conf

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -62,8 +62,8 @@ server {
     root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
     internal;
   }
-{{ end }}
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
+{{ end }}
 }
 {{ else if eq $scheme "https"}}
 server {


### PR DESCRIPTION
Since 0.27.9 `include /home/dokku/nginx.conf.d/*.conf` is duplicate defined.

```
# nginx -t
nginx: [emerg] "client_max_body_size" directive is duplicate in /home/dokku/default/nginx.conf.d/upload.conf:1
```

```
# head -n 15 nginx.conf

server {
  listen      [::]:80;
  listen      80;
  server_name example.com;
  access_log  /var/log/nginx/default-access.log;
  error_log   /var/log/nginx/default-error.log;

  include /home/dokku/default/nginx.conf.d/*.conf;
  location / {
    return 301 https://$host:443$request_uri;
  }

  include /home/dokku/default/nginx.conf.d/*.conf;
}
```

Closes #5277