### PR TITLE
Document and enable alternative proxy implementations

### DIFF
--- a/docs/appendices/0.10.0-migration-guide.md
+++ b/docs/appendices/0.10.0-migration-guide.md
@@ -4,10 +4,10 @@
 
 By default, Dokku will ship a PCI Compliant nginx configuration. For developers whose users are on older browsers or mobile devices, you may need to ship a custom `nginx.conf.sigil` to enable ciphers for older browsers.
 
-See the [nginx customization](/docs/configuration/nginx/#customizing-the-nginx-configuration) docs for more details.
+See the [nginx customization](/docs/networking/proxies/nginx/#customizing-the-nginx-configuration) docs for more details.
 
 ## Nginx Error Pages
 
 We now ship with nicer error pages by default. You are free to customize your Dokku installation via a custom `nginx.conf.sigil` to change what error pages are displayed in different circumstances.
 
-See the [nginx customization](/docs/configuration/nginx/#customizing-the-nginx-configuration) docs for more details.
+See the [nginx customization](/docs/networking/proxies/nginx/#customizing-the-nginx-configuration) docs for more details.

--- a/docs/appendices/0.5.0-migration-guide.md
+++ b/docs/appendices/0.5.0-migration-guide.md
@@ -5,11 +5,11 @@
 - The nginx-vhosts template language is now [sigil](https://github.com/gliderlabs/sigil)
   - No need to escape literal `$` characters (or other "bash-isms")
   - Template variables are represented as {{ .VARIABLE_NAME }}
-  - A detailed list of template variables can be found [here](/docs/configuration/nginx.md#available-template-variables)
+  - A detailed list of template variables can be found [here](/docs/networking/proxies/nginx.md#available-template-variables)
 - A custom nginx-vhosts template must be named `nginx.conf.sigil`
   - The default path for this custom template is the root of your repo (i.e. `/app` in the container or `WORKDIR` if defined in a dockerfile app)
   - Dokku no longer looks for this file in `/home/dokku/node-js-app` on the Dokku server
-  - Check out an example template [here](/docs/configuration/nginx.md)
+  - Check out an example template [here](/docs/networking/proxies/nginx.md)
 - Support for server-wide SSL certs have been dropped in favor of using the `certs` plugin
   - `dokku certs:add node-js-app < certs.tar`
 - All domains for an SSL-enabled app will be redirected to https by default

--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -113,4 +113,4 @@ dokku domains:report node-js-app --domains-app-enabled
 
 ## Default site
 
-This is specific to your proxy plugin of choice. See the [nginx documentation](/docs/configuration/nginx.md#default-site) for more information on how to configure this for the default nginx proxy implementation.
+This is specific to your proxy plugin of choice. See the [nginx documentation](/docs/networking/proxies/nginx.md#default-site) for more information on how to configure this for the default nginx proxy implementation.

--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -43,7 +43,7 @@ cat yourdomain_com.crt yourdomain_com.ca-bundle > server.crt
 
 When an SSL certificate is associated to an application, the certificate will be associated with _all_ domains currently associated with said application. Your certificate _should_ be associated with all of those domains, otherwise accessing the application will result in SSL errors. If you wish to remove one of the domains from the application, refer to the [domain configuration documentation](/docs/configuration/domains.md).
 
-Note that with the default nginx template, requests will be redirected to the `https` version of the domain. If this is not the desired state of request resolution, you may customize the nginx template in use. For more details, see the [nginx documentation](/docs/configuration/nginx.md).
+Note that with the default nginx template, requests will be redirected to the `https` version of the domain. If this is not the desired state of request resolution, you may customize the nginx template in use. For more details, see the [nginx documentation](/docs/networking/proxies/nginx.md).
 
 ### Certificate generation
 
@@ -126,7 +126,7 @@ dokku certs:report node-js-app --ssl-enabled
 
 The [HSTS header](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) is an HTTP header that can inform browsers that all requests to a given site should be made via HTTPS. Dokku does enables this header by default for HTTPS requests.
 
-See the [NGINX HSTS documentation](/docs/configuration/nginx.md#hsts-header) for more information on how the HSTS configuration can be managed for your application.
+See the [NGINX HSTS documentation](/docs/networking/proxies/nginx.md#hsts-header) for more information on how the HSTS configuration can be managed for your application.
 
 ## HTTP/2 support
 

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1842,6 +1842,21 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 # TODO
 ```
 
+### `proxy-configure-ports`
+
+- Description: Configures the proxy port mapping
+- Invoked by: `internally triggered by proxy plugins`
+- Arguments: `$APP`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+# TODO
+```
+
 ### `proxy-disable`
 
 - Description: Disables the configured proxy implementation for an app

--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -8,6 +8,8 @@ nginx:error-logs <app> [-t]              # Show the nginx error logs for an appl
 nginx:report [<app>] [<flag>]            # Displays a nginx report for one or more apps
 nginx:set <app> <property> (<value>)     # Set or clear an nginx property for an app
 nginx:show-config <app>                  # Display app nginx config
+nginx:start                              # Starts the nginx server
+nginx:stop                               # Stops the nginx server
 nginx:validate-config [<app>] [--clean]  # Validates and optionally cleans up invalid nginx configurations
 ```
 
@@ -17,7 +19,23 @@ nginx:validate-config [<app>] [--clean]  # Validates and optionally cleans up in
 
 By default, the `web` process is the only process proxied by the nginx proxy implementation. Proxying to other process types may be handled by a custom `nginx.conf.sigil` file, as generally described [below](/docs/networking/proxies/nginx.md#customizing-the-nginx-configuration)
 
-Nginx will proxy the requests in a [round-robin balancing fashion](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream) to the different deployed (scaled) containers running the `web` proctype. This way, the host's resources can be fully leveraged for single-threaded applications (e.g. `dokku ps:scale node-js-app web=4` on a 4-core machine)
+Nginx will proxy the requests in a [round-robin balancing fashion](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream) to the different deployed (scaled) containers running the `web` proctype. This way, the host's resources can be fully leveraged for single-threaded applications (e.g. `dokku ps:scale node-js-app web=4` on a 4-core machine).
+
+### Starting nginx
+
+The nginx server can be started via `nginx:start`.
+
+```shell
+dokku nginx:start
+````
+
+### Stopping nginx
+
+The nginx server can be stopped via `nginx:stop`.
+
+```shell
+dokku nginx:stop
+````
 
 ### Binding to specific addresses
 

--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -15,7 +15,7 @@ nginx:validate-config [<app>] [--clean]  # Validates and optionally cleans up in
 
 ### Request Proxying
 
-By default, the `web` process is the only process proxied by the nginx proxy implementation. Proxying to other process types may be handled by a custom `nginx.conf.sigil` file, as generally described [below](/docs/configuration/nginx.md#customizing-the-nginx-configuration)
+By default, the `web` process is the only process proxied by the nginx proxy implementation. Proxying to other process types may be handled by a custom `nginx.conf.sigil` file, as generally described [below](/docs/networking/proxies/nginx.md#customizing-the-nginx-configuration)
 
 Nginx will proxy the requests in a [round-robin balancing fashion](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream) to the different deployed (scaled) containers running the `web` proctype. This way, the host's resources can be fully leveraged for single-threaded applications (e.g. `dokku ps:scale node-js-app web=4` on a 4-core machine)
 

--- a/docs/networking/proxy-management.md
+++ b/docs/networking/proxy-management.md
@@ -134,7 +134,7 @@ From Dokku versions `0.5.0` until `0.11.0`, enabling or disabling an application
 
 ## Implementing a Proxy
 
-Custom plugins names _must_ have the prefix `proxy-` or scheduler overriding via `proxy:set` may not function as expected.
+Custom plugins names _must_ have the suffix `-vhosts` or scheduler overriding via `proxy:set` may not function as expected.
 
 At this time, the following dokku commands are used to implement a complete proxy implementation. 
 

--- a/docs/networking/proxy-management.md
+++ b/docs/networking/proxy-management.md
@@ -131,3 +131,44 @@ See the [port management documentation](/docs/networking/port-management.md) for
 > Changed as of 0.11.0
 
 From Dokku versions `0.5.0` until `0.11.0`, enabling or disabling an application's proxy would **also** control whether or not the application was bound to all interfaces - e.g. `0.0.0.0`. As of `0.11.0`, this is now controlled by the network plugin. Please see the [network documentation](/docs/networking/network.md#container-network-interface-binding) for more information.
+
+## Implementing a Proxy
+
+Custom plugins names _must_ have the prefix `proxy-` or scheduler overriding via `proxy:set` may not function as expected.
+
+At this time, the following dokku commands are used to implement a complete proxy implementation. 
+
+- `domains:add`: Adds a given domain to an app.
+  - trigers: `post-domains-update`
+- `domains:clear`: Clears out an app's associated domains.
+  - trigers: `post-domains-update`
+- `domains:disable`: Disables domains for an app.
+  - trigers: `pre-disable-vhost`
+- `domains:enable`: Enables domains for an app.
+  - trigers: `pre-enable-vhost`
+- `domains:remove`: Removes a domain from an app.
+  - trigers: `post-domains-update`
+- `domains:set`: Sets all domains for a given app.
+  - trigers: `post-domains-update`
+- `proxy:build-config`: Builds - or rebuilds - external proxy configuration.
+  - triggers: `proxy-build-config`
+- `proxy:clear-config`: Clears out external proxy configuration.
+  - triggers: `proxy-clear-config`
+- `proxy:disable`: Disables the proxy configuration for an app.
+  - triggers: `proxy-disable`
+- `proxy:enable`: Enables the proxy configuration for an app.
+  - triggers: `proxy-enable`
+- `proxy:ports-add`: Adds one or more port mappings to an app
+  - triggers: `post-proxy-ports-update`
+- `proxy:ports-clear`: Clears out all port mappings for an app.
+  - triggers: `post-proxy-ports-update`
+- `proxy:ports-remove`: Removes one or more port mappings from an app.
+  - triggers: `post-proxy-ports-update`
+- `proxy:ports-set`: Sets all port mappings for an app.
+  - triggers: `post-proxy-ports-update`
+
+Proxy implementations may decide to omit some functionality here, or use plugin triggers to supplement config with information from other plugins.
+
+Individual proxy implementations _may_ trigger app rebuilds, depending on how proxy metadata is exposed for the proxy implementation.
+
+Finally, proxy implementations _may_ install extra software needed for the proxy itself in whatever manner deemed fit. Proxy software can run on the host itself or within a running Docker container with either exposed ports or host networking.

--- a/docs/processes/process-management.md
+++ b/docs/processes/process-management.md
@@ -164,7 +164,7 @@ There are also a few other exceptions for the `web` process.
 
 - Custom checks defined by a `CHECKS` file only apply to the `web` process type.
 - By default, the built-in nginx proxy implementation only proxies the `web` process (others may be handled via a custom `nginx.conf.sigil`).
-  - See the [nginx request proxying documentation](/docs/configuration/nginx.md#request-proxying) for more information on how nginx handles proxied requests.
+  - See the [nginx request proxying documentation](/docs/networking/proxies/nginx.md#request-proxying) for more information on how nginx handles proxied requests.
 - Only the `web` process may be bound to an external port.
 
 #### Changing the `Procfile` location

--- a/docs/template.html
+++ b/docs/template.html
@@ -157,7 +157,6 @@
 
             <a href="/{{NAME}}/configuration/environment-variables/" class="list-group-item">Environment Variables</a>
             <a href="/{{NAME}}/configuration/domains/" class="list-group-item">Domain Configuration</a>
-            <a href="/{{NAME}}/configuration/nginx/" class="list-group-item">Nginx Configuration</a>
             <a href="/{{NAME}}/configuration/ssl/" class="list-group-item">SSL Configuration</a>
 
             <a href="#" class="list-group-item disabled">Interacting with Processes</a>
@@ -172,7 +171,11 @@
             <a href="/{{NAME}}/networking/dns/" class="list-group-item">DNS Configuration</a>
             <a href="/{{NAME}}/networking/network/" class="list-group-item">Network Management</a>
             <a href="/{{NAME}}/networking/port-management/" class="list-group-item">Port Management</a>
+
+            <a href="#" class="list-group-item disabled">Proxy Configuration</a>
+
             <a href="/{{NAME}}/networking/proxy-management/" class="list-group-item">Proxy Management</a>
+            <a href="/{{NAME}}/networking/proxies/nginx/" class="list-group-item">Nginx Proxy</a>
 
             <a href="#" class="list-group-item disabled">Advanced Usage</a>
 

--- a/docs/viewdocs.json
+++ b/docs/viewdocs.json
@@ -4,49 +4,40 @@
     "advanced-installation": "getting-started/advanced-installation/",
     "troubleshooting": "getting-started/troubleshooting/",
     "upgrading": "getting-started/upgrading/",
-
     "application-deployment": "deployment/application-deployment/",
     "checks-examples": "deployment/zero-downtime-deploys/",
     "remote-commands": "deployment/remote-commands/",
-
     "process-management": "processes/process-management/",
     "deployment/process-management": "processes/process-management/",
     "deployment/one-off-processes": "processes/one-off-tasks/",
-
     "deployment/buildpacks": "deployment/builders/herokuish-buildpacks/",
     "deployment/methods/buildpacks": "deployment/builders/herokuish-buildpacks/",
     "deployment/dockerfiles": "deployment/builders/dockerfiles/",
-
     "deployment/methods/cloud-native-buildpacks": "deployment/builders/cloud-native-buildpacks/",
     "deployment/methods/dockerfiles": "deployment/builders/dockerfiles/",
     "deployment/methods/herokuish-buildpacks": "deployment/builders/herokuish-buildpacks/",
-
     "deployment/images": "deployment/methods/git/#initializing-an-app-repository-from-a-docker-image",
     "deployment/tar": "deployment/methods/git/#initializing-an-app-repository-from-an-archive-file",
     "deployment/methods/images": "deployment/methods/git/#initializing-an-app-repository-from-a-docker-image",
     "deployment/methods/tar": "deployment/methods/git/#initializing-an-app-repository-from-an-archive-file",
     "configuration-management": "configuration/environment-variables/",
     "deployment/ssl-configuration": "configuration/ssl/",
-    "nginx": "configuration/nginx/",
-
+    "configuration/nginx": "networking/proxies/nginx/",
+    "nginx": "networking/proxies/nginx/",
     "dns": "networking/dns/",
     "configuration/dns": "networking/dns/",
     "proxy": "networking/proxy-management/",
     "advanced-usage/proxy-management": "networking/proxy-management/",
-
     "backup-recovery": "advanced-usage/backup-recovery/",
     "deployment-tasks": "advanced-usage/deployment-tasks/",
     "deployment/deployment-tasks": "advanced-usage/deployment-tasks/",
     "docker-options": "advanced-usage/docker-options/",
     "dokku-events-logs": "advanced-usage/event-logs/",
     "dokku-storage": "advanced-usage/persistent-storage/",
-
     "advanced-usage/schedulers/alternate-schedulers": "deployment/schedulers/scheduler-management/",
     "advanced-usage/schedulers/docker-local": "deployment/schedulers/docker-local/",
     "deployment/schedulers/alternate-schedulers": "deployment/schedulers/scheduler-management/",
-
     "community/tutorials/deploying-with-gitlab-ci": "deployment/continuous-integration/gitlab-ci/",
-
     "plugins": "community/plugins/"
   }
 }

--- a/plugins/nginx-vhosts/command-functions
+++ b/plugins/nginx-vhosts/command-functions
@@ -107,6 +107,24 @@ cmd-nginx-show-config() {
   cat "$DOKKU_ROOT/$APP/nginx.conf"
 }
 
+cmd-nginx-stop() {
+  declare desc="stops the nginx server"
+  declare cmd="nginx:stop"
+  [[ "$1" == "$cmd" ]] && shift 1
+
+  touch "${DOKKU_LIB_ROOT}/data/nginx-vhosts/nginx.stopped"
+  fn-nginx-vhosts-nginx-init-cmd "stop"
+}
+
+cmd-nginx-start() {
+  declare desc="starts the nginx server"
+  declare cmd="nginx:start"
+  [[ "$1" == "$cmd" ]] && shift 1
+
+  rm -f "${DOKKU_LIB_ROOT}/data/nginx-vhosts/nginx.stopped"
+  fn-nginx-vhosts-nginx-init-cmd "start"
+}
+
 cmd-nginx-validate-config() {
   declare desc="validates and optionally cleans up invalid nginx configurations"
   declare cmd="nginx:validate-config"

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -155,62 +155,6 @@ nginx_logs() {
   tail "$NGINX_LOGS_ARGS" "$NGINX_LOGS_PATH"
 }
 
-configure_nginx_ports() {
-  declare desc="configure nginx listening ports"
-  local APP=$1
-  local RAW_TCP_PORTS="$(get_app_raw_tcp_ports "$APP")"
-  local DOKKU_PROXY_PORT=$(config_get "$APP" DOKKU_PROXY_PORT)
-  local DOKKU_PROXY_SSL_PORT=$(config_get "$APP" DOKKU_PROXY_SSL_PORT)
-  local DOKKU_PROXY_PORT_MAP=$(config_get "$APP" DOKKU_PROXY_PORT_MAP)
-  local IS_APP_VHOST_ENABLED=true
-  local UPSTREAM_PORT="5000"
-  plugn trigger domains-vhost-enabled "$APP" 2>/dev/null || IS_APP_VHOST_ENABLED=false
-
-  if [[ -z "$DOKKU_PROXY_PORT" ]] && [[ -z "$RAW_TCP_PORTS" ]]; then
-    if [[ "$IS_APP_VHOST_ENABLED" == "false" ]]; then
-      dokku_log_info1 "No proxy port set, setting to random open high port"
-      local PROXY_PORT=$(get_available_port)
-    else
-      local PROXY_PORT=$(config_get --global DOKKU_PROXY_PORT)
-      PROXY_PORT=${PROXY_PORT:=80}
-    fi
-    DOKKU_QUIET_OUTPUT=1 config_set --no-restart "$APP" DOKKU_PROXY_PORT="$PROXY_PORT"
-  fi
-  if [[ -z "$DOKKU_PROXY_SSL_PORT" ]]; then
-    if (is_ssl_enabled "$APP"); then
-      local PROXY_SSL_PORT=$(config_get --global DOKKU_PROXY_SSL_PORT)
-      PROXY_SSL_PORT=${PROXY_SSL_PORT:=443}
-      if [[ -z "$RAW_TCP_PORTS" ]] && [[ "$IS_APP_VHOST_ENABLED" == "false" ]]; then
-        dokku_log_info1 "No proxy ssl port set, setting to random open high port"
-        PROXY_SSL_PORT=$(get_available_port)
-      fi
-      DOKKU_QUIET_OUTPUT=1 config_set --no-restart "$APP" DOKKU_PROXY_SSL_PORT="$PROXY_SSL_PORT"
-    fi
-  fi
-  if [[ -z "$DOKKU_PROXY_PORT_MAP" ]]; then
-    if [[ -n "$RAW_TCP_PORTS" ]]; then
-      local RAW_TCP_PORT
-      for RAW_TCP_PORT in $RAW_TCP_PORTS; do
-        local PROXY_PORT_MAP+=" http:${RAW_TCP_PORT}:${RAW_TCP_PORT} "
-      done
-    else
-      local PROXY_PORT=${PROXY_PORT:-$DOKKU_PROXY_PORT}
-      local PROXY_SSL_PORT=${PROXY_SSL_PORT:-$DOKKU_PROXY_SSL_PORT}
-      [[ -f "$DOKKU_ROOT/$APP/PORT.web.1" ]] && local UPSTREAM_PORT="$(<"$DOKKU_ROOT/$APP/PORT.web.1")"
-      if [[ -n "$PROXY_PORT" ]] && [[ -n "$PROXY_SSL_PORT" ]]; then
-        local PROXY_PORT_MAP+=" http:${PROXY_PORT}:$UPSTREAM_PORT https:${PROXY_SSL_PORT}:$UPSTREAM_PORT "
-      elif [[ -n "$PROXY_PORT" ]]; then
-        local PROXY_PORT_MAP+=" http:${PROXY_PORT}:$UPSTREAM_PORT "
-      fi
-    fi
-    if [[ -n "$PROXY_PORT_MAP" ]]; then
-      local PROXY_PORT_MAP="$(echo "$PROXY_PORT_MAP" | xargs)"
-      local PROXY_PORT_MAP+=" $(merge_dedupe_list "$(remove_val_from_list "$PORT_MAP" "$DOKKU_PROXY_PORT_MAP" " ")" " ") "
-      DOKKU_QUIET_OUTPUT=1 config_set --no-restart "$APP" DOKKU_PROXY_PORT_MAP="$PROXY_PORT_MAP"
-    fi
-  fi
-}
-
 validate_ssl_domains() {
   declare desc="check configured domains against SSL cert contents and show warning if mismatched"
   local APP=$1
@@ -384,7 +328,7 @@ nginx_build_config() {
     fi
 
     # setup nginx listen ports
-    configure_nginx_ports "$APP"
+    plugn trigger proxy-configure-ports "$APP"
     local PROXY_PORT=$(config_get "$APP" DOKKU_PROXY_PORT)
     local PROXY_SSL_PORT=$(config_get "$APP" DOKKU_PROXY_SSL_PORT)
     local PROXY_PORT_MAP=$(config_get "$APP" DOKKU_PROXY_PORT_MAP)

--- a/plugins/nginx-vhosts/help-functions
+++ b/plugins/nginx-vhosts/help-functions
@@ -32,6 +32,8 @@ fn-help-content() {
     nginx:report [<app>] [<flag>], Displays an nginx report for one or more apps
     nginx:set <app> <property> (<value>), Set or clear an nginx property for an app
     nginx:show-config <app>, Display app nginx config
+    nginx:start, Starts the nginx server
+    nginx:stop, Stops the nginx server
     nginx:validate-config [<app>] [--clean], Validates and optionally cleans up invalid nginx configurations
 help_content
 }

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -27,19 +27,19 @@ trigger-nginx-vhosts-install() {
   local mode="0440"
   case "$DOKKU_DISTRO" in
     debian | raspbian)
-      echo "%dokku ALL=(ALL) NOPASSWD:/usr/sbin/invoke-rc.d $NGINX_INIT_NAME reload, $NGINX_BIN -t, ${NGINX_BIN} -t -c *" >"$NGINX_SUDOERS_FILE"
+      echo "%dokku ALL=(ALL) NOPASSWD:/usr/sbin/invoke-rc.d $NGINX_INIT_NAME reload, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME start, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME stop, $NGINX_BIN -t, ${NGINX_BIN} -t -c *" >"$NGINX_SUDOERS_FILE"
       ;;
 
     ubuntu)
       if [[ -x /usr/bin/sv ]]; then
-        echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/sv reload $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
+        echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/sv reload $NGINX_INIT_NAME, /usr/bin/sv start $NGINX_INIT_NAME, /usr/bin/sv stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       else
-        echo "%dokku ALL=(ALL) NOPASSWD:/etc/init.d/$NGINX_INIT_NAME reload, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
+        echo "%dokku ALL=(ALL) NOPASSWD:/etc/init.d/$NGINX_INIT_NAME reload, /etc/init.d/$NGINX_INIT_NAME start, /etc/init.d/$NGINX_INIT_NAME stop, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       fi
       ;;
 
     arch)
-      echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl reload $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
+      echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl reload $NGINX_INIT_NAME, /usr/bin/systemctl start $NGINX_INIT_NAME, /usr/bin/systemctl stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       ;;
   esac
 
@@ -76,6 +76,7 @@ trigger-nginx-vhosts-install() {
 
   # Create nginx error templates
   mkdir -p "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors"
+  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/nginx-vhosts"
   cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/400-error.html" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors/400-error.html"
   cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/404-error.html" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors/404-error.html"
   cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/500-error.html" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors/500-error.html"
@@ -108,7 +109,7 @@ trigger-nginx-vhosts-install() {
   # avoid failing runit init calls on install
   # the runit binaries are not yet available during dockerfile building
   # and therefore both these calls will fail
-  if [[ ! -x /usr/bin/sv ]]; then
+  if [[ ! -x /usr/bin/sv ]] && [[ ! -f "${DOKKU_LIB_ROOT}/data/nginx-vhosts/nginx.stopped" ]]; then
     fn-nginx-vhosts-nginx-init-cmd start || fn-nginx-vhosts-nginx-init-cmd reload
   fi
 }

--- a/plugins/nginx-vhosts/subcommands/start
+++ b/plugins/nginx-vhosts/subcommands/start
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/nginx-vhosts/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-nginx-start "$@"

--- a/plugins/nginx-vhosts/subcommands/stop
+++ b/plugins/nginx-vhosts/subcommands/stop
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/nginx-vhosts/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-nginx-stop "$@"

--- a/plugins/proxy/.gitignore
+++ b/plugins/proxy/.gitignore
@@ -6,3 +6,4 @@
 /install
 /post-*
 /report
+!/proxy-configure-ports

--- a/plugins/proxy/proxy-configure-ports
+++ b/plugins/proxy/proxy-configure-ports
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/certs/functions"
+source "$PLUGIN_AVAILABLE_PATH/config/functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-proxy-proxy-configure-ports() {
+  declare desc="proxy proxy-configure-ports plugin trigger"
+  declare trigger="proxy-configure-ports"
+  declare APP="$1"
+  local RAW_TCP_PORTS="$(get_app_raw_tcp_ports "$APP")"
+  local DOKKU_PROXY_PORT=$(config_get "$APP" DOKKU_PROXY_PORT)
+  local DOKKU_PROXY_SSL_PORT=$(config_get "$APP" DOKKU_PROXY_SSL_PORT)
+  local DOKKU_PROXY_PORT_MAP=$(config_get "$APP" DOKKU_PROXY_PORT_MAP)
+  local IS_APP_VHOST_ENABLED=true
+  local UPSTREAM_PORT="5000"
+
+  plugn trigger domains-vhost-enabled "$APP" 2>/dev/null || IS_APP_VHOST_ENABLED=false
+
+  if [[ -z "$DOKKU_PROXY_PORT" ]] && [[ -z "$RAW_TCP_PORTS" ]]; then
+    if [[ "$IS_APP_VHOST_ENABLED" == "false" ]]; then
+      dokku_log_info1 "No proxy port set, setting to random open high port"
+      local PROXY_PORT=$(get_available_port)
+    else
+      local PROXY_PORT=$(config_get --global DOKKU_PROXY_PORT)
+      PROXY_PORT=${PROXY_PORT:=80}
+    fi
+    DOKKU_QUIET_OUTPUT=1 config_set --no-restart "$APP" DOKKU_PROXY_PORT="$PROXY_PORT"
+  fi
+  if [[ -z "$DOKKU_PROXY_SSL_PORT" ]]; then
+    if (is_ssl_enabled "$APP"); then
+      local PROXY_SSL_PORT=$(config_get --global DOKKU_PROXY_SSL_PORT)
+      PROXY_SSL_PORT=${PROXY_SSL_PORT:=443}
+      if [[ -z "$RAW_TCP_PORTS" ]] && [[ "$IS_APP_VHOST_ENABLED" == "false" ]]; then
+        dokku_log_info1 "No proxy ssl port set, setting to random open high port"
+        PROXY_SSL_PORT=$(get_available_port)
+      fi
+      DOKKU_QUIET_OUTPUT=1 config_set --no-restart "$APP" DOKKU_PROXY_SSL_PORT="$PROXY_SSL_PORT"
+    fi
+  fi
+  if [[ -z "$DOKKU_PROXY_PORT_MAP" ]]; then
+    if [[ -n "$RAW_TCP_PORTS" ]]; then
+      local RAW_TCP_PORT
+      for RAW_TCP_PORT in $RAW_TCP_PORTS; do
+        local PROXY_PORT_MAP+=" http:${RAW_TCP_PORT}:${RAW_TCP_PORT} "
+      done
+    else
+      local PROXY_PORT=${PROXY_PORT:-$DOKKU_PROXY_PORT}
+      local PROXY_SSL_PORT=${PROXY_SSL_PORT:-$DOKKU_PROXY_SSL_PORT}
+      [[ -f "$DOKKU_ROOT/$APP/PORT.web.1" ]] && local UPSTREAM_PORT="$(<"$DOKKU_ROOT/$APP/PORT.web.1")"
+      if [[ -n "$PROXY_PORT" ]] && [[ -n "$PROXY_SSL_PORT" ]]; then
+        local PROXY_PORT_MAP+=" http:${PROXY_PORT}:$UPSTREAM_PORT https:${PROXY_SSL_PORT}:$UPSTREAM_PORT "
+      elif [[ -n "$PROXY_PORT" ]]; then
+        local PROXY_PORT_MAP+=" http:${PROXY_PORT}:$UPSTREAM_PORT "
+      fi
+    fi
+    if [[ -n "$PROXY_PORT_MAP" ]]; then
+      local PROXY_PORT_MAP="$(echo "$PROXY_PORT_MAP" | xargs)"
+      local PROXY_PORT_MAP+=" $(merge_dedupe_list "$(remove_val_from_list "$PORT_MAP" "$DOKKU_PROXY_PORT_MAP" " ")" " ") "
+      DOKKU_QUIET_OUTPUT=1 config_set --no-restart "$APP" DOKKU_PROXY_PORT_MAP="$PROXY_PORT_MAP"
+    fi
+  fi
+}
+trigger-proxy-proxy-configure-ports "$@"


### PR DESCRIPTION
This MR documents what is needed for an alternative proxy implementation. Plugins are not required to implement any triggers or commands, though it may make it easier to develop if they are.

This MR also pulls out some code necessary for configuring port mappings from the nginx plugin, as it is useful for all plugins.