### PR TITLE
Add an official caddy proxy implementation

### DIFF
--- a/docs/appendices/0.28.0-migration-guide.md
+++ b/docs/appendices/0.28.0-migration-guide.md
@@ -16,3 +16,10 @@ All users are encouraged to install Dokku via the [Docker-based installation met
 ## Deprecations
 
 Ubuntu 18.04 is now a deprecated installation target. The operating system will be considered EOL by Canonical in April 2023. Users are encouraged to upgrade to Ubuntu 22.04 or consider switching their instllation method to the [Docker-based installation method](/docs/getting-started/install/docker.md) to avoid any disruption in usage.
+
+## Additions
+
+New in 0.28.0 are the Caddy and Traefik plugins. As community plugins wrapping these proxies exist, users should:
+
+- Recommended: Uninstall the community plugin in question and switch all config to the new plugins.
+- Upgrade the community plugin to a version that does not use the `proxy:set` value of `caddy` or `traefik`.

--- a/docs/networking/proxies/caddy.md
+++ b/docs/networking/proxies/caddy.md
@@ -1,5 +1,7 @@
 # Caddy Proxy
 
+> New as of 0.28.0
+
 Dokku provides integration with the [Caddy](https://caddyserver.com/) proxy service by utilizing the Docker label-based integration implemented by Caddy.
 
 ```

--- a/docs/networking/proxies/caddy.md
+++ b/docs/networking/proxies/caddy.md
@@ -1,0 +1,196 @@
+# Caddy Proxy
+
+Dokku provides integration with the [Caddy](https://caddyserver.com/) proxy service by utilizing the Docker label-based integration implemented by Caddy.
+
+```
+caddy:report [<app>] [<flag>]            # Displays a caddy report for one or more apps
+caddy:logs [--num num] [--tail]          # Display caddy log output
+caddy:set <app> <property> (<value>)     # Set or clear an caddy property for an app
+caddy:show-config <app>                  # Display caddy compose config
+caddy:start                              # Starts the caddy server
+caddy:stop                               # Stops the caddy server
+```
+
+## Usage
+
+> Warning: As using multiple proxy plugins on a single Dokku installation can lead to issues routing requests to apps, doing so should be avoided. As the default proxy implementation is nginx, users are encouraged to stop the nginx service before switching to Caddy.
+
+The Caddy plugin has specific rules for routing requests:
+
+- Caddy integration is exposed via docker labels attached to containers. Changes in labels require either app deploys or rebuilds.
+- While Caddy will respect labels associated with other containers, only `web` containers have Caddy labels injected by the plugin.
+- Only `http:80` and `https:443` port mappings are supported.
+- Caddy will automatically enable SSL if the letsencrypt email property is set. SSL will be disabled otherwise.
+- If no `http:80` mapping is found, the first `http` port mapping is used for http requests.
+- If no `https:443` mapping is found, the first `https` port mapping is used for https requests.
+- If no `https` mapping is found, the container port from `http:80` will be used for https requests.
+- Requests are routed as soon as the container is running and passing healthchecks.
+
+### Switching to Caddy
+
+To use the Caddy plugin, use the `proxy:set` command for the app in question:
+
+```shell
+dokku proxy:set node-js-app caddy
+```
+
+This will enable the docker label-based Caddy integration. All future deploys will inject the correct labels for Caddy to read and route requests to containers. Due to the docker label-based integration used by Caddy, a single deploy or rebuild will be required before requests will route successfully.
+
+```shell
+dokku ps:rebuild node-js-app
+```
+
+Any changes to domains or port mappings will also require either a deploy or rebuild.
+
+### Starting Caddy container
+
+Caddy can be started via the `caddy:start` command. This will start a Caddy container via the `docker compose up` command.
+
+```shell
+dokku caddy:start
+```
+
+### Stopping the Caddy container
+
+Caddy may be stopped via the `caddy:stop` command.
+
+```shell
+dokku caddy:stop
+```
+
+The Caddy container will be stopped and removed from the system. If the container is not running, this command will do nothing.
+
+### Showing the Caddy compose config
+
+For debugging purposes, it may be useful to show the Caddy compose config. This can be achieved via the `caddy:show-config` command.
+
+```shell
+dokku caddy:show-config
+```
+
+### Customizing the Caddy container image
+
+While the default Caddy image is hardcoded, users may specify an alternative by setting the `image` property with the `--global` flag:
+
+```shell
+dokku caddy:set --global image lucaslorentz/caddy-docker-proxy:2.7
+```
+
+#### Checking the Caddy container's logs
+
+It may be necessary to check the Caddy container's logs to ensure that Caddy is operating as expected. This can be performed with the `caddy:logs` command.
+
+```shell
+dokku caddy:logs
+```
+
+This command also supports the following modifiers:
+
+```shell
+--num NUM        # the number of lines to display
+--tail           # continually stream logs
+```
+
+You can use these modifiers as follows:
+
+```shell
+dokku caddy:logs --tail --num 10
+```
+
+The above command will show logs continually from the vector container, with an initial history of 10 log lines
+
+### Changing the Caddy log level
+
+Caddy log output is set to `ERROR` by default. It may be changed by setting the `log-level` property with the `--global` flag:
+
+```shell
+dokku caddy:set --global log-level DEBUG
+```
+
+After modifying,  the Caddy container will need to be restarted.
+
+### SSL Configuration
+
+The caddy plugin only supports automatic ssl certificates from it's letsencrypt integration. Managed certificates provided by the `certs` plugin are ignored.
+
+#### Enabling letsencrypt integration
+
+By default, letsencrypt is disabled and https port mappings are ignored. To enable, set the `letsencrypt-email` property with the `--global` flag:
+
+```shell
+dokku caddy:set --global letsencrypt-email automated@dokku.sh
+```
+
+After enabling, the Caddy container will need to be restarted and apps will need to be rebuilt. All http requests will then be redirected to https.
+
+#### Customizing the letsencrypt server
+
+The letsencrypt integration is set to the production letsencrypt server by default. To change this, set the `letsencrypt-server` property with the `--global` flag:
+
+```shell
+dokku caddy:set --global letsencrypt-server https://acme-staging-v02.api.letsencrypt.org/directory
+```
+
+After enabling, the Caddy container will need to be restarted and apps will need to be rebuilt to retrieve certificates from the new server.
+
+### Using Caddy's Internal TLS server
+
+To switch to Caddy's internal TLS server for certificate provisioning, set the `tls-internal` property. This can only be set on a per-app basis.
+
+```shell
+dokku caddy:set node-js-app tls-internal true
+```
+
+## Displaying Caddy reports for an app
+
+You can get a report about the app's Caddy config using the `caddy:report` command:
+
+```shell
+dokku caddy:report
+```
+
+```
+=====> node-js-app caddy information
+       Caddy image:                   lucaslorentz/caddy-docker-proxy:2.7
+       Caddy letsencrypt email:
+       Caddy letsencrypt server:
+       Caddy log level:               ERROR
+       Caddy polling interval:        5s
+       Caddy tls internal:            false
+=====> python-app caddy information
+       Caddy image:                   lucaslorentz/caddy-docker-proxy:2.7
+       Caddy letsencrypt email:
+       Caddy letsencrypt server:
+       Caddy log level:               ERROR
+       Caddy polling interval:        5s
+       Caddy tls internal:            false
+=====> ruby-app caddy information
+       Caddy image:                   lucaslorentz/caddy-docker-proxy:2.7
+       Caddy letsencrypt email:
+       Caddy letsencrypt server:
+       Caddy log level:               ERROR
+       Caddy polling interval:        5s
+       Caddy tls internal:            false
+```
+
+You can run the command for a specific app also.
+
+```shell
+dokku caddy:report node-js-app
+```
+
+```
+=====> node-js-app caddy information
+       Caddy image:                   lucaslorentz/caddy-docker-proxy:2.7
+       Caddy letsencrypt email:
+       Caddy letsencrypt server:
+       Caddy log level:               ERROR
+       Caddy polling interval:        5s
+       Caddy tls internal:            false
+```
+
+You can pass flags which will output only the value of the specific information you want. For example:
+
+```shell
+dokku caddy:report node-js-app --caddy-image
+```

--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -1,4 +1,4 @@
-# Nginx Configuration
+# Nginx Proxy
 
 Dokku uses nginx as its server for routing requests to specific applications. By default, access and error logs are written for each app to `/var/log/nginx/${APP}-access.log` and `/var/log/nginx/${APP}-error.log` respectively
 

--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -15,6 +15,8 @@ nginx:validate-config [<app>] [--clean]  # Validates and optionally cleans up in
 
 ## Usage
 
+> Warning: As using multiple proxy plugins on a single Dokku installation can lead to issues routing requests to apps, doing so should be avoided.
+
 ### Request Proxying
 
 By default, the `web` process is the only process proxied by the nginx proxy implementation. Proxying to other process types may be handled by a custom `nginx.conf.sigil` file, as generally described [below](/docs/networking/proxies/nginx.md#customizing-the-nginx-configuration)

--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -25,6 +25,8 @@ Nginx will proxy the requests in a [round-robin balancing fashion](http://nginx.
 
 ### Starting nginx
 
+> New as of 0.28.0
+
 The nginx server can be started via `nginx:start`.
 
 ```shell
@@ -32,6 +34,8 @@ dokku nginx:start
 ````
 
 ### Stopping nginx
+
+> New as of 0.28.0
 
 The nginx server can be stopped via `nginx:stop`.
 

--- a/docs/networking/proxies/traefik.md
+++ b/docs/networking/proxies/traefik.md
@@ -1,4 +1,4 @@
-# Traefik Configuration
+# Traefik Proxy
 
 Dokku provides integration with the [Traefik](https://traefik.io/) proxy service by utilizing the Docker label-based integration implemented by Traefik.
 

--- a/docs/networking/proxies/traefik.md
+++ b/docs/networking/proxies/traefik.md
@@ -1,5 +1,7 @@
 # Traefik Proxy
 
+> New as of 0.28.0
+
 Dokku provides integration with the [Traefik](https://traefik.io/) proxy service by utilizing the Docker label-based integration implemented by Traefik.
 
 ```

--- a/docs/networking/proxies/traefik.md
+++ b/docs/networking/proxies/traefik.md
@@ -21,7 +21,7 @@ The Traefik plugin has specific rules for routing requests:
 - While Traefik will respect labels associated with other containers, only `web` containers have Traefik labels injected by the plugin.
 - Only `http:80` and `https:443` port mappings are supported.
 - If no `http:80` mapping is found, the first `http` port mapping is used for http requests.
-- If no `https:443` mapping is found, the first `https` port mapping is used for http requests.
+- If no `https:443` mapping is found, the first `https` port mapping is used for https requests.
 - If no `https` mapping is found, the container port from `http:80` will be used for https requests.
 - Requests are routed as soon as the container is running and passing healthchecks.
 
@@ -108,7 +108,11 @@ dokku traefik:set --global log-level DEBUG
 
 After modifying,  the Traefik container will need to be restarted.
 
-### Enabling letsencrypt integration
+### SSL Configuration
+
+The traefik plugin only supports automatic ssl certificates from it's letsencrypt integration. Managed certificates provided by the `certs` plugin are ignored.
+
+#### Enabling letsencrypt integration
 
 By default, letsencrypt is disabled and https port mappings are ignored. To enable, set the `letsencrypt-email` property with the `--global` flag:
 
@@ -117,6 +121,16 @@ dokku traefik:set --global letsencrypt-email automated@dokku.sh
 ```
 
 After enabling, apps will need to be rebuilt and the Traefik container will need to be restarted. All http requests will then be redirected to https.
+
+#### Customizing the letsencrypt server
+
+The letsencrypt integration is set to the production letsencrypt server by default. To change this, set the `letsencrypt-server` property with the `--global` flag:
+
+```shell
+dokku traefik:set --global letsencrypt-server https://acme-staging-v02.api.letsencrypt.org/directory
+```
+
+After enabling, the Traefik container will need to be restarted and apps will need to be rebuilt to retrieve certificates from the new server.
 
 ### API Access
 
@@ -184,6 +198,7 @@ dokku traefik:report
        Traefik dashboard enabled:     false
        Traefik image:                 traefik:v2.8
        Traefik letsencrypt email:
+       Traefik letsencrypt server:
        Traefik log level:             ERROR
 =====> python-app traefik information
        Traefik api enabled:           false
@@ -193,6 +208,7 @@ dokku traefik:report
        Traefik dashboard enabled:     false
        Traefik image:                 traefik:v2.8
        Traefik letsencrypt email:
+       Traefik letsencrypt server:
        Traefik log level:             ERROR
 =====> ruby-app traefik information
        Traefik api enabled:           false
@@ -202,6 +218,7 @@ dokku traefik:report
        Traefik dashboard enabled:     false
        Traefik image:                 traefik:v2.8
        Traefik letsencrypt email:
+       Traefik letsencrypt server:
        Traefik log level:             ERROR
 ```
 
@@ -220,6 +237,7 @@ dokku traefik:report node-js-app
        Traefik dashboard enabled:     false
        Traefik image:                 traefik:v2.8
        Traefik letsencrypt email:
+       Traefik letsencrypt server:
        Traefik log level:             ERROR
 ```
 

--- a/docs/template.html
+++ b/docs/template.html
@@ -47,7 +47,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&display=swap" rel="stylesheet">
-    
+
     <link href="https://cdn.jsdelivr.net/gh/dokku/dokku@v0.27.10/docs/assets/style.css" rel="stylesheet">
     <!-- <link href="./assets/style.css" rel="stylesheet"> -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet">
@@ -175,6 +175,7 @@
             <a href="#" class="list-group-item disabled">Proxy Configuration</a>
 
             <a href="/{{NAME}}/networking/proxy-management/" class="list-group-item">Proxy Management</a>
+            <a href="/{{NAME}}/networking/proxies/caddy/" class="list-group-item">Caddy Proxy</a>
             <a href="/{{NAME}}/networking/proxies/nginx/" class="list-group-item">Nginx Proxy</a>
             <a href="/{{NAME}}/networking/proxies/traefik/" class="list-group-item">Traefik Proxy</a>
 

--- a/dokku
+++ b/dokku
@@ -138,6 +138,9 @@ execute_dokku_cmd() {
     events | events:*)
       local PLUGIN_NAME=${PLUGIN_NAME/events/20_events}
       ;;
+    caddy | caddy:*)
+      local PLUGIN_NAME=${PLUGIN_NAME/caddy/caddy-vhosts}
+      ;;
     nginx | nginx:*)
       local PLUGIN_NAME=${PLUGIN_NAME/nginx/nginx-vhosts}
       ;;

--- a/plugins/caddy-vhosts/command-functions
+++ b/plugins/caddy-vhosts/command-functions
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/internal-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-caddy-report() {
+  declare desc="displays a caddy report for one or more apps"
+  declare cmd="caddy:report"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1" INFO_FLAG="$2"
+
+  if [[ -n "$APP" ]] && [[ "$APP" == --* ]]; then
+    INFO_FLAG="$APP"
+    APP=""
+  fi
+
+  if [[ -z "$APP" ]] && [[ -z "$INFO_FLAG" ]]; then
+    INFO_FLAG="true"
+  fi
+
+  if [[ -z "$APP" ]]; then
+    for app in $(dokku_apps); do
+      cmd-caddy-report-single "$app" "$INFO_FLAG" | tee || true
+    done
+  else
+    cmd-caddy-report-single "$APP" "$INFO_FLAG"
+  fi
+}
+
+cmd-caddy-report-single() {
+  declare APP="$1" INFO_FLAG="$2"
+  if [[ "$INFO_FLAG" == "true" ]]; then
+    INFO_FLAG=""
+  fi
+  verify_app_name "$APP"
+  local flag_map=(
+    "--caddy-image: $(fn-caddy-image)"
+    "--caddy-letsencrypt-email: $(fn-caddy-letsencrypt-email)"
+    "--caddy-letsencrypt-server: $(fn-caddy-letsencrypt-email)"
+    "--caddy-log-level: $(fn-caddy-log-level)"
+    "--caddy-polling-interval: $(fn-caddy-polling-interval)"
+    "--caddy-tls-internal: $(fn-caddy-tls-internal "$APP")"
+  )
+
+  if [[ -z "$INFO_FLAG" ]]; then
+    dokku_log_info2_quiet "${APP} caddy information"
+    for flag in "${flag_map[@]}"; do
+      key="$(echo "${flag#--}" | cut -f1 -d' ' | tr - ' ')"
+      dokku_log_verbose "$(printf "%-30s %-25s" "${key^}" "${flag#*: }")"
+    done
+  else
+    local match=false
+    local value_exists=false
+    for flag in "${flag_map[@]}"; do
+      valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
+      if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
+        value=${flag#*: }
+        size="${#value}"
+        if [[ "$size" -ne 0 ]]; then
+          echo "$value" && match=true && value_exists=true
+        else
+          match=true
+        fi
+      fi
+    done
+    [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
+  fi
+}
+
+cmd-caddy-logs() {
+  declare desc="display caddy logs from command line"
+  declare cmd="caddy:logs"
+  [[ "$1" == "$cmd" ]] && shift 1
+  local NUM="100" TAIL=false
+
+  local TEMP=$(getopt -o htn: --long help,tail,num: -n 'dokku caddy:logs' -- "$@")
+  local EXIT_CODE="$?"
+  if [[ "$EXIT_CODE" != 0 ]]; then
+    fn-caddy-logs-usage >&2
+    exit 1
+  fi
+  eval set -- "$TEMP"
+
+  while true; do
+    case "$1" in
+      -t | --tail)
+        local TAIL=true
+        shift
+        ;;
+      -n | --num)
+        local NUM="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *) dokku_log_fail "Internal error" ;;
+    esac
+  done
+
+  fn-caddy-logs "$TAIL" "$NUM"
+}
+
+cmd-caddy-show-config() {
+  declare desc="display caddy config"
+  declare cmd="caddy:show-config"
+  [[ "$1" == "$cmd" ]] && shift 1
+
+  local TMP_COMPOSE_FILE=$(mktemp "/tmp/dokku-${DOKKU_PID}-${FUNCNAME[0]}.XXXXXX")
+  trap "rm -rf '$TMP_COMPOSE_FILE' >/dev/null" RETURN INT TERM EXIT
+
+  fn-caddy-template-compose-file "$TMP_COMPOSE_FILE"
+  cat "$TMP_COMPOSE_FILE"
+}
+
+cmd-caddy-start() {
+  declare desc="Starts the caddy server"
+  declare cmd="caddy:start"
+  [[ "$1" == "$cmd" ]] && shift 1
+
+  local TMP_COMPOSE_FILE=$(mktemp "/tmp/dokku-${DOKKU_PID}-${FUNCNAME[0]}.XXXXXX")
+  trap "rm -rf '$TMP_COMPOSE_FILE' >/dev/null" RETURN INT TERM EXIT
+
+  fn-caddy-template-compose-file "$TMP_COMPOSE_FILE"
+  "$DOCKER_BIN" compose -f "$TMP_COMPOSE_FILE" -p caddy up -d --quiet-pull
+}
+
+cmd-caddy-stop() {
+  declare desc="Starts the caddy server"
+  declare cmd="caddy:start"
+  [[ "$1" == "$cmd" ]] && shift 1
+
+  local TMP_COMPOSE_FILE=$(mktemp "/tmp/dokku-${DOKKU_PID}-${FUNCNAME[0]}.XXXXXX")
+  trap "rm -rf '$TMP_COMPOSE_FILE' >/dev/null" RETURN INT TERM EXIT
+
+  fn-caddy-template-compose-file "$TMP_COMPOSE_FILE"
+  "$DOCKER_BIN" compose -f "$TMP_COMPOSE_FILE" -p caddy down --remove-orphans
+}

--- a/plugins/caddy-vhosts/commands
+++ b/plugins/caddy-vhosts/commands
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+[[ " caddy:help help " == *" $1 "* ]] || exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/help-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+case "$1" in
+  help | caddy:help)
+    cmd-caddy-help "$@"
+    ;;
+
+  *)
+    exit "$DOKKU_NOT_IMPLEMENTED_EXIT"
+    ;;
+esac

--- a/plugins/caddy-vhosts/core-post-deploy
+++ b/plugins/caddy-vhosts/core-post-deploy
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/internal-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-caddy-vhosts-core-post-deploy() {
+  declare desc="caddy-vhosts core-post-deploy plugin trigger"
+  declare trigger="core-post-deploy"
+  declare APP="$1"
+  local tls_internal
+
+  if [[ "$(plugn trigger proxy-type "$APP")" != "caddy" ]]; then
+    return
+  fi
+
+  tls_internal="$(fn-caddy-tls-internal)"
+  dokku_log_info1 "Routing app via caddy"
+  if [[ "$tls_internal" == "true" ]]; then
+    dokku_log_warn "Warning: using caddy's internal, locally-trusted CA to produce certificates for this site"
+  fi
+}
+
+trigger-caddy-vhosts-core-post-deploy "$@"

--- a/plugins/caddy-vhosts/docker-args-process-deploy
+++ b/plugins/caddy-vhosts/docker-args-process-deploy
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/internal-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-caddy-vhosts-docker-args-process-deploy() {
+  declare desc="nginx-vhosts core-post-deploy plugin trigger"
+  declare trigger="docker-args-process-deploy"
+  declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3" PROC_TYPE="$4" CONTAINER_INDEX="$5"
+  local app_domains caddy_domains is_app_listening letsencrypt_email output proxy_container_port proxy_host_port port_map proxy_port_map proxy_scheme proxy_schemes scheme tls_internal
+  local proxy_container_http_port proxy_container_http_port_candidate proxy_host_http_port_candidate
+  local proxy_container_https_port proxy_container_https_port_candidate proxy_host_https_port_candidate
+  local app_urls_path="$DOKKU_ROOT/$APP/URLS"
+  local STDIN=$(cat)
+
+  if [[ "$PROC_TYPE" != "web" ]]; then
+    return
+  fi
+
+  if [[ "$(plugn trigger proxy-type "$APP")" != "caddy" ]]; then
+    return
+  fi
+
+  if [[ "$(plugn trigger proxy-is-enabled "$APP")" != "true" ]]; then
+    return
+  fi
+
+  if ! plugn trigger domains-vhost-enabled "$APP" 2>/dev/null; then
+    return
+  fi
+
+  # run this silently or the output will be set as a label
+  plugn trigger domains-setup "$APP" >/dev/null
+
+  # ensure we have a port mapping
+  plugn trigger proxy-configure-ports "$APP"
+
+  # gather port mapping information
+  # we only support proxying a single port for http and https listeners
+  # so this block parses the port mappings and tries to find the correct
+  # mapping to expose
+  is_app_listening="false"
+  proxy_port_map="$(plugn trigger config-get "$APP" DOKKU_PROXY_PORT_MAP)"
+  for port_map in $proxy_port_map; do
+    proxy_scheme="$(awk -F ':' '{ print $1 }' <<<"$port_map")"
+    proxy_host_port="$(awk -F ':' '{ print $2 }' <<<"$port_map")"
+    proxy_container_port="$(awk -F ':' '{ print $3 }' <<<"$port_map")"
+
+    if [[ "$proxy_scheme" == "http" ]]; then
+      is_app_listening="true"
+      if [[ -z "$proxy_container_http_port_candidate" ]]; then
+        proxy_container_http_port_candidate="$proxy_container_port"
+        proxy_host_http_port_candidate="$proxy_host_port"
+      fi
+
+      if [[ "$proxy_host_port" == "80" ]] && [[ -z "$proxy_container_http_port" ]]; then
+        proxy_container_http_port="$proxy_container_port"
+      fi
+    fi
+
+    if [[ "$proxy_scheme" == "https" ]]; then
+      is_app_listening="true"
+      if [[ -z "$proxy_container_https_port_candidate" ]]; then
+        proxy_container_https_port_candidate="$proxy_container_port"
+        proxy_host_https_port_candidate="$proxy_host_port"
+      fi
+
+      if [[ "$proxy_host_port" == "443" ]] && [[ -z "$proxy_container_https_port" ]]; then
+        proxy_container_https_port="$proxy_container_port"
+      fi
+    fi
+  done
+
+  app_domains="$(plugn trigger domains-list "$APP")"
+  if [[ -n "$app_domains" ]]; then
+    caddy_domains="$(echo "$app_domains" | xargs)"
+  fi
+
+  # add the labels for caddy here
+  # prefer the https:443 mapping to http:80 mapping
+  if [[ -n "$is_app_listening" ]] && [[ -n "$caddy_domains" ]]; then
+    has_443_mapping=false
+    tls_internal="$(fn-caddy-tls-internal)"
+    if [[ -n "$proxy_container_https_port" ]] || [[ -n "$proxy_container_https_port_candidate" ]]; then
+      has_443_mapping=true
+    fi
+
+    ssl_warning_mapping="https:443"
+    if [[ "$tls_internal" == "true" ]]; then
+      output="--label caddy.tls=internal"
+      if [[ "$has_443_mapping" == "false" ]]; then
+        ssl_warning_mapping="http:80"
+        proxy_host_https_port_candidate="$proxy_host_http_port_candidate"
+        proxy_container_https_port_candidate="$proxy_container_http_port_candidate"
+        proxy_container_https_port="$proxy_container_http_port"
+      fi
+    fi
+
+    letsencrypt_email="$(fn-caddy-letsencrypt-email)"
+    scheme="http"
+    if [[ -n "$letsencrypt_email" ]] && [[ "$has_443_mapping" == "true" ]]; then
+      output="--label caddy=${caddy_domains}"
+      scheme="https"
+      if [[ -z "$proxy_container_https_port" ]]; then
+        warning_scheme="$(awk -F ':' '{ print $1 }' <<<"$ssl_warning_mapping")"
+        dokku_log_warn "Warning: $ssl_warning_mapping port mapping not found"
+        dokku_log_warn "Utilizing first warning_scheme port mapping, http:$proxy_host_https_port_candidate:$proxy_container_https_port_candidate"
+        proxy_container_https_port="$proxy_container_https_port_candidate"
+      fi
+
+      output="$output --label \"caddy.reverse_proxy={{ upstreams $proxy_container_https_port }}\""
+    elif [[ -n "$proxy_container_http_port" ]] || [[ -n "$proxy_container_http_port_candidate" ]]; then
+      caddy_domains="${caddy_domains// /:80 }"
+      output="--label caddy=${caddy_domains}:80"
+      if [[ -z "$proxy_container_http_port" ]]; then
+        dokku_log_warn "Warning: http:80 port mapping not found"
+        dokku_log_warn "Utilizing first http port mapping, http:$proxy_host_http_port_candidate:$proxy_container_http_port_candidate"
+        proxy_container_http_port="$proxy_container_http_port_candidate"
+      fi
+
+      output="$output --label \"caddy.reverse_proxy={{ upstreams $proxy_container_http_port }}\""
+    fi
+
+    echo "# THIS FILE IS GENERATED BY DOKKU - DO NOT EDIT, YOUR CHANGES WILL BE OVERWRITTEN" >"$app_urls_path"
+    xargs -I{} echo "$scheme://{}" <<<"$(echo "${app_domains}" | tr ' ' '\n' | sort -u)" >>"$app_urls_path"
+  fi
+
+  echo -n "$STDIN$output"
+}
+
+trigger-caddy-vhosts-docker-args-process-deploy "$@"

--- a/plugins/caddy-vhosts/help-functions
+++ b/plugins/caddy-vhosts/help-functions
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-caddy-help() {
+  declare desc="help command"
+  declare CMD="$1"
+  local plugin_name="caddy"
+  local plugin_description="Manage mounted volumes"
+
+  if [[ "$CMD" == "${plugin_name}:help" ]]; then
+    echo -e "Usage: dokku ${plugin_name}[:COMMAND]"
+    echo ''
+    echo "$plugin_description"
+    echo ''
+    echo 'Additional commands:'
+    fn-help-content | sort | column -c2 -t -s,
+  elif [[ $(ps -o command= $PPID) == *"--all"* ]]; then
+    fn-help-content
+  else
+    cat <<help_desc
+    $plugin_name, $plugin_description
+help_desc
+  fi
+}
+
+fn-help-content() {
+  declare desc="return help content"
+  cat <<help_content
+    caddy:report [<app>] [<flag>], Displays an caddy report for one or more apps
+    caddy:set <app> <property> (<value>), Set or clear an caddy property for an app
+    caddy:show-config <app>, Display caddy compose config
+    caddy:start, Starts the caddy server
+    caddy:stop, Stops the caddy server
+help_content
+}

--- a/plugins/caddy-vhosts/install
+++ b/plugins/caddy-vhosts/install
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-caddy-install() {
+  declare desc="installs the caddy plugin"
+  declare trigger="install"
+
+  mkdir -p "${DOKKU_LIB_ROOT}/data/caddy"
+  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/caddy"
+
+  fn-plugin-property-setup "caddy"
+}
+
+trigger-caddy-install "$@"

--- a/plugins/caddy-vhosts/internal-functions
+++ b/plugins/caddy-vhosts/internal-functions
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+fn-caddy-logs() {
+  declare desc="shows the logs for the caddy container"
+  declare TAIL="$1" NUM="$2"
+  local dokku_logs_args=("--tail" "$NUM")
+
+  if [[ "$TAIL" == "true" ]]; then
+    dokku_logs_args+=("--follow")
+  fi
+
+  "$DOCKER_BIN" logs caddy-caddy-1 "${dokku_logs_args[@]}"
+}
+
+fn-caddy-logs-usage() {
+  declare desc="logs specific usage"
+  echo "Usage: dokku caddy:logs"
+  echo " display recent caddy log output"
+  echo ""
+  echo " -n, --num NUM        # the number of lines to display"
+  echo " -t, --tail           # continually stream logs"
+}
+
+fn-caddy-template-compose-file() {
+  declare desc="templates out the compose file"
+  declare OUTPUT_PATH="$1"
+  local COMPOSE_TEMPLATE="$PLUGIN_AVAILABLE_PATH/caddy-vhosts/templates/compose.yml.sigil"
+
+  CUSTOM_COMPOSE_TEMPLATE="$(plugn trigger caddy-template-source "$APP")"
+  if [[ -n "$CUSTOM_COMPOSE_TEMPLATE" ]]; then
+    COMPOSE_TEMPLATE="$CUSTOM_COMPOSE_TEMPLATE"
+  fi
+
+  local SIGIL_PARAMS=(CADDY_DATA_DIR="${DOKKU_LIB_ROOT}/data/caddy"
+    CADDY_IMAGE="$(fn-caddy-image)"
+    CADDY_LETSENCRYPT_EMAIL="$(fn-caddy-letsencrypt-email)"
+    CADDY_LETSENCRYPT_SERVER="$(fn-caddy-letsencrypt-server)"
+    CADDY_LOG_LEVEL="$(fn-caddy-log-level)"
+    CADDY_POLLING_INTERVAL="$(fn-caddy-polling-interval)")
+
+  sigil -f "$COMPOSE_TEMPLATE" "${SIGIL_PARAMS[@]}" | cat -s >"$OUTPUT_PATH"
+}
+
+fn-caddy-image() {
+  fn-plugin-property-get-default "caddy" "--global" "image" "lucaslorentz/caddy-docker-proxy:2.7"
+}
+
+fn-caddy-letsencrypt-email() {
+  fn-plugin-property-get-default "caddy" "--global" "letsencrypt-email" ""
+}
+
+fn-caddy-letsencrypt-server() {
+  fn-plugin-property-get-default "caddy" "--global" "letsencrypt-server" "https://acme-v02.api.letsencrypt.org/directory"
+}
+
+fn-caddy-log-level() {
+  local log_level
+  log_level="$(fn-plugin-property-get-default "caddy" "--global" "log-level" "ERROR")"
+  echo "${log_level^^}"
+}
+
+fn-caddy-polling-interval() {
+  fn-plugin-property-get-default "caddy" "--global" "polling-interval" "5s"
+}
+
+fn-caddy-tls-internal() {
+  declare APP="$1"
+  fn-plugin-property-get-default "caddy" "$APP" "tls-internal" "false"
+}

--- a/plugins/caddy-vhosts/plugin.toml
+++ b/plugins/caddy-vhosts/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "dokku core caddy-vhosts plugin"
+version = "0.27.10"
+[plugin.config]

--- a/plugins/caddy-vhosts/subcommands/default
+++ b/plugins/caddy-vhosts/subcommands/default
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/help-functions"
+
+cmd-caddy-help "caddy:help"

--- a/plugins/caddy-vhosts/subcommands/logs
+++ b/plugins/caddy-vhosts/subcommands/logs
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-caddy-logs "$@"

--- a/plugins/caddy-vhosts/subcommands/report
+++ b/plugins/caddy-vhosts/subcommands/report
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-caddy-report "$@"

--- a/plugins/caddy-vhosts/subcommands/set
+++ b/plugins/caddy-vhosts/subcommands/set
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-caddy-set() {
+  declare desc="set or clear an caddy property for an app"
+  declare cmd="caddy:set"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1" KEY="$2" VALUE="$3"
+  local VALID_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval" "tls-internal")
+  local GLOBAL_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval")
+
+  [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
+
+  if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then
+    dokku_log_fail "Invalid key specified, valid keys include: image letsencrypt-email letsencrypt-server log-level polling-interval tls-internal"
+  fi
+
+  if ! fn-in-array "$KEY" "${GLOBAL_KEYS[@]}"; then
+    if [[ "$APP" == "--global" ]]; then
+      dokku_log_fail "The key '$KEY' cannot be set globally"
+    fi
+    verify_app_name "$APP"
+  fi
+
+  if [[ -n "$VALUE" ]]; then
+    dokku_log_info2_quiet "Setting ${KEY} to ${VALUE}"
+    fn-plugin-property-write "caddy" "$APP" "$KEY" "$VALUE"
+  else
+    dokku_log_info2_quiet "Unsetting ${KEY}"
+    fn-plugin-property-delete "caddy" "$APP" "$KEY"
+  fi
+}
+
+cmd-caddy-set "$@"

--- a/plugins/caddy-vhosts/subcommands/show-config
+++ b/plugins/caddy-vhosts/subcommands/show-config
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/command-functions"
+
+cmd-caddy-show-config "$@"

--- a/plugins/caddy-vhosts/subcommands/start
+++ b/plugins/caddy-vhosts/subcommands/start
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/command-functions"
+
+cmd-caddy-start "$@"

--- a/plugins/caddy-vhosts/subcommands/stop
+++ b/plugins/caddy-vhosts/subcommands/stop
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/command-functions"
+
+cmd-caddy-stop "$@"

--- a/plugins/caddy-vhosts/templates/compose.yml.sigil
+++ b/plugins/caddy-vhosts/templates/compose.yml.sigil
@@ -1,0 +1,34 @@
+---
+version: "3.7"
+
+services:
+  caddy:
+    image: "{{ $.CADDY_IMAGE }}"
+
+    environment:
+      - CADDY_INGRESS_NETWORKS=bridge
+      - CADDY_DOCKER_POLLING_INTERVAL={{ $.CADDY_POLLING_INTERVAL }}
+
+    labels: # Global options
+      - caddy.log.format=json
+      - caddy.log.level={{ $.CADDY_LOG_LEVEL }}
+      {{ if $.CADDY_LETSENCRYPT_EMAIL }}
+      - "caddy.email={{ $.CADDY_LETSENCRYPT_EMAIL }}"
+      - "caddy.acme_ca={{ $.CADDY_LETSENCRYPT_SERVER }}"
+      {{ else }}
+      - "caddy.auto_https=off"
+      {{ end }}
+
+    network_mode: bridge
+
+    ports:
+      - "80:80"
+      {{ if $.CADDY_LETSENCRYPT_EMAIL }}
+      - "443:443"
+      {{ end }}
+
+    restart: unless-stopped
+
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "{{ $.CADDY_DATA_DIR }}:/data"

--- a/plugins/traefik-vhosts/command-functions
+++ b/plugins/traefik-vhosts/command-functions
@@ -42,6 +42,7 @@ cmd-traefik-report-single() {
     "--traefik-dashboard-enabled: $(fn-traefik-dashboard-enabled)"
     "--traefik-image: $(fn-traefik-image)"
     "--traefik-letsencrypt-email: $(fn-traefik-letsencrypt-email)"
+    "--traefik-letsencrypt-server: $(fn-traefik-letsencrypt-server)"
     "--traefik-log-level: $(fn-traefik-log-level)"
   )
 

--- a/plugins/traefik-vhosts/internal-functions
+++ b/plugins/traefik-vhosts/internal-functions
@@ -49,6 +49,7 @@ fn-traefik-template-compose-file() {
   TRAEFIK_DATA_DIR="${DOKKU_LIB_ROOT}/data/traefik"
   TRAEFIK_IMAGE="$(fn-traefik-image)"
   TRAEFIK_LETSENCRYPT_EMAIL="$(fn-traefik-letsencrypt-email)"
+  TRAEFIK_LETSENCRYPT_SERVER="$(fn-traefik-letsencrypt-server)"
   TRAEFIK_LOG_LEVEL="$(fn-traefik-log-level)")
 
   sigil -f "$COMPOSE_TEMPLATE" "${SIGIL_PARAMS[@]}" | cat -s >"$OUTPUT_PATH"
@@ -80,6 +81,10 @@ fn-traefik-image() {
 
 fn-traefik-letsencrypt-email() {
   fn-plugin-property-get-default "traefik" "--global" "letsencrypt-email" ""
+}
+
+fn-traefik-letsencrypt-server() {
+  fn-plugin-property-get-default "traefik" "--global" "letsencrypt-server" "https://acme-v02.api.letsencrypt.org/directory"
 }
 
 fn-traefik-log-level() {

--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -17,7 +17,7 @@ services:
       - --log.format=json
 
       {{ if $.TRAEFIK_LETSENCRYPT_EMAIL }}
-      - --certificatesresolvers.leresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
+      - --certificatesresolvers.leresolver.acme.caserver={{ $.TRAEFIK_LETSENCRYPT_SERVER }}"
       - --certificatesresolvers.leresolver.acme.email={{ $.TRAEFIK_LETSENCRYPT_EMAIL }}
       - --certificatesresolvers.leresolver.acme.storage=/acme.json
       - --certificatesresolvers.leresolver.acme.tlschallenge=true

--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -1,5 +1,5 @@
 ---
-version: "3.3"
+version: "3.7"
 
 services:
   traefik:

--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -49,7 +49,9 @@ services:
 
     ports:
       - "80:80"
+      {{ if $.TRAEFIK_LETSENCRYPT_EMAIL }}
       - "443:443"
+      {{ end }}
 
     restart: unless-stopped
 


### PR DESCRIPTION
This plugin uses a docker-compose based Caddy installation in conjunction with injected container labels to route requests. It only exposes the minimal necessary for routing traffic to docker containers. Users wishing to customize further labels may explore using the docker-options plugin to attach additional labels during the 'deploy' phase.

Requests are routed as soon as the container is running and passing [healthchecks](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#active-health-checks).