### PR TITLE
Fix typo in kubernetes docs

### DIFF
--- a/docs/deployment/schedulers/kubernetes.md
+++ b/docs/deployment/schedulers/kubernetes.md
@@ -2,7 +2,7 @@
 
 > Warning: This scheduler is not in Dokku core and thus functionality may change over time as the API stabilizes.
 
-The [Nomad Scheduler Plugin](https://github.com/dokku/dokku-scheduler-kubernetes) is available free as an external plugin. Please see the plugin's [issue tracker](https://github.com/dokku/dokku-scheduler-kubernetes/issues) for more information on the status of the plugin.
+The [Kubernetes Scheduler Plugin](https://github.com/dokku/dokku-scheduler-kubernetes) is available free as an external plugin. Please see the plugin's [issue tracker](https://github.com/dokku/dokku-scheduler-kubernetes/issues) for more information on the status of the plugin.
 
 For users that require additional functionality, please refer to the [Sponsoring Documentation](https://github.com/dokku/.github/blob/master/SPONSORING.md).
 


### PR DESCRIPTION
**Why this PR exits:**
I've noticed that the "Kubernetes Scheduler" had a typo in the documentation

**Solution:**
Fix the typo