### PR TITLE
Add the ability to disable the init process 

### DIFF
--- a/docs/deployment/schedulers/docker-local.md
+++ b/docs/deployment/schedulers/docker-local.md
@@ -37,6 +37,20 @@ Once set, you may re-enable it by setting a blank value for `disable-chown`:
 dokku scheduler-docker-local:set node-js-app disable-chown
 ```
 
+### Disabling the init process
+
+The `scheduler-docker-local` injects an init process by default via the `--init`. For some apps - such as those where the built docker image uses S6 as the init - this may be undesirable and cause issues with process starts. You may disable this by running the following `scheduler-docker-local:set` command for your application:
+
+```shell
+dokku scheduler-docker-local:set node-js-app init-process false
+```
+
+Once set, you may re-enable it by setting a blank value for `init-process`:
+
+```shell
+dokku scheduler-docker-local:set node-js-app init-process
+```
+
 ### Deploying Process Types in Parallel
 
 > New as of 0.25.5

--- a/docs/deployment/schedulers/docker-local.md
+++ b/docs/deployment/schedulers/docker-local.md
@@ -51,6 +51,8 @@ Once set, you may re-enable it by setting a blank value for `init-process`:
 dokku scheduler-docker-local:set node-js-app init-process
 ```
 
+All image containers with the label `org.opencontainers.image.vendor=linuxserver.io` will have the automatic init process injection force-disabled without further intervention.
+
 ### Deploying Process Types in Parallel
 
 > New as of 0.25.5

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process
@@ -39,7 +39,7 @@ main() {
 
   INJECT_INIT_FLAG="$(fn-plugin-property-get "scheduler-docker-local" "$APP" "init-process" "")"
   if [[ -z "$INJECT_INIT_FLAG" ]]; then
-  # special-case linuxserver.io images as those always use an s6-overlay
+    # special-case linuxserver.io images as those always use an s6-overlay
     image_vendor="$("$DOCKER_BIN" image inspect --format '{{ index .Config.Labels "org.opencontainers.image.vendor" }}' "$IMAGE")"
     if [[ "$image_vendor" == "linuxserver.io" ]]; then
       INJECT_INIT_FLAG="false"

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process
@@ -7,6 +7,7 @@ source "$PLUGIN_AVAILABLE_PATH/checks/functions"
 main() {
   declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE="$3" IMAGE_TAG="$4" PROC_TYPE="$5" PROC_COUNT="$6"
   local CONTAINER_INDEX=1
+  local image_vendor
 
   dokku_log_info1 "Deploying $PROC_TYPE (count=$PROC_COUNT)"
   DOKKU_CHECKS_DISABLED="$(is_app_proctype_checks_disabled "$APP" "$PROC_TYPE")"
@@ -36,6 +37,12 @@ main() {
   done
 
   INJECT_INIT_FLAG="$(fn-plugin-property-get "scheduler-docker-local" "$APP" "init-process" "true")"
+  # special-case linuxserver.io images as those always use an s6-overlay
+  image_vendor="$("$DOCKER_BIN" image inspect --format '{{ index .Config.Labels "org.opencontainers.image.vendor" }}' "$IMAGE")"
+  if [[ "$image_vendor" == "linuxserver.io" ]]; then
+    INJECT_INIT_FLAG="false"
+  fi
+
   PARALLEL_DEPLOY_COUNT="$(plugn trigger "app-json-process-deploy-parallelism" "$APP" "$PROC_TYPE")"
   DOKKU_CHECKS_DISABLED="$DOKKU_CHECKS_DISABLED" parallel --will-cite --halt soon,fail=1 --jobs "$PARALLEL_DEPLOY_COUNT" --ungroup <"$PROCESS_TMP_FILE"
 

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process
@@ -49,7 +49,7 @@ main() {
   fi
 
   PARALLEL_DEPLOY_COUNT="$(plugn trigger "app-json-process-deploy-parallelism" "$APP" "$PROC_TYPE")"
-  DOKKU_CHECKS_DISABLED="$DOKKU_CHECKS_DISABLED" parallel --will-cite --halt soon,fail=1 --jobs "$PARALLEL_DEPLOY_COUNT" --ungroup <"$PROCESS_TMP_FILE"
+  DOKKU_CHECKS_DISABLED="$DOKKU_CHECKS_DISABLED" INJECT_INIT_FLAG="$INJECT_INIT_FLAG" parallel --will-cite --halt soon,fail=1 --jobs "$PARALLEL_DEPLOY_COUNT" --ungroup <"$PROCESS_TMP_FILE"
 
   # cleanup when we scale down
   if [[ "$PROC_COUNT" == 0 ]]; then

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process
@@ -35,6 +35,7 @@ main() {
     CONTAINER_INDEX=$((CONTAINER_INDEX + 1))
   done
 
+  INJECT_INIT_FLAG="$(fn-plugin-property-get "scheduler-docker-local" "$APP" "init-process" "true")"
   PARALLEL_DEPLOY_COUNT="$(plugn trigger "app-json-process-deploy-parallelism" "$APP" "$PROC_TYPE")"
   DOKKU_CHECKS_DISABLED="$DOKKU_CHECKS_DISABLED" parallel --will-cite --halt soon,fail=1 --jobs "$PARALLEL_DEPLOY_COUNT" --ungroup <"$PROCESS_TMP_FILE"
 

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process
@@ -2,6 +2,7 @@
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/checks/functions"
 
 main() {
@@ -36,11 +37,15 @@ main() {
     CONTAINER_INDEX=$((CONTAINER_INDEX + 1))
   done
 
-  INJECT_INIT_FLAG="$(fn-plugin-property-get "scheduler-docker-local" "$APP" "init-process" "true")"
+  INJECT_INIT_FLAG="$(fn-plugin-property-get "scheduler-docker-local" "$APP" "init-process" "")"
+  if [[ -z "$INJECT_INIT_FLAG" ]]; then
   # special-case linuxserver.io images as those always use an s6-overlay
-  image_vendor="$("$DOCKER_BIN" image inspect --format '{{ index .Config.Labels "org.opencontainers.image.vendor" }}' "$IMAGE")"
-  if [[ "$image_vendor" == "linuxserver.io" ]]; then
-    INJECT_INIT_FLAG="false"
+    image_vendor="$("$DOCKER_BIN" image inspect --format '{{ index .Config.Labels "org.opencontainers.image.vendor" }}' "$IMAGE")"
+    if [[ "$image_vendor" == "linuxserver.io" ]]; then
+      INJECT_INIT_FLAG="false"
+    else
+      INJECT_INIT_FLAG="true"
+    fi
   fi
 
   PARALLEL_DEPLOY_COUNT="$(plugn trigger "app-json-process-deploy-parallelism" "$APP" "$PROC_TYPE")"

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process-container
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process-container
@@ -19,7 +19,7 @@ main() {
   DOCKER_ARGS+=" --label=com.dokku.process-type=$PROC_TYPE --label=com.dokku.dyno=$DYNO"
   DOCKER_ARGS+=" --env=DYNO=$DYNO"
   DOCKER_ARGS+=" --name=$APP.$DYNO.upcoming-$RANDOM"
-  if [[ "$INJECT_INIT_FLAG" == "false" ]]; then
+  if [[ "$INJECT_INIT_FLAG" == "true" ]]; then
     DOCKER_ARGS+=" --init"
   fi
   DOCKER_ARGS+=" $DOCKER_RUN_LABEL_ARGS $DOKKU_GLOBAL_RUN_ARGS "

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process-container
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process-container
@@ -19,7 +19,9 @@ main() {
   DOCKER_ARGS+=" --label=com.dokku.process-type=$PROC_TYPE --label=com.dokku.dyno=$DYNO"
   DOCKER_ARGS+=" --env=DYNO=$DYNO"
   DOCKER_ARGS+=" --name=$APP.$DYNO.upcoming-$RANDOM"
-  DOCKER_ARGS+=" --init"
+  if [[ "$INJECT_INIT_FLAG" == "false" ]]; then
+    DOCKER_ARGS+=" --init"
+  fi
   DOCKER_ARGS+=" $DOCKER_RUN_LABEL_ARGS $DOKKU_GLOBAL_RUN_ARGS "
   DOCKER_ARGS+=$(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")
   [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" --env=TRACE=true"

--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -37,6 +37,7 @@ cmd-scheduler-docker-local-report-single() {
   verify_app_name "$APP"
   local flag_map=(
     "--scheduler-docker-local-disable-chown: $(fn-plugin-property-get "scheduler-docker-local" "$APP" "disable-chown" "")"
+    "--scheduler-docker-local-init-process: $(fn-plugin-property-get "scheduler-docker-local" "$APP" "init-process" "true")"
     "--scheduler-docker-local-parallel-schedule-count: $(fn-plugin-property-get "scheduler-docker-local" "$APP" "parallel-schedule-count" "")"
   )
 

--- a/plugins/scheduler-docker-local/subcommands/set
+++ b/plugins/scheduler-docker-local/subcommands/set
@@ -9,13 +9,13 @@ cmd-scheduler-docker-local-set() {
   declare cmd="scheduler-docker-local:set"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("disable-chown" "parallel-schedule-count")
+  local VALID_KEYS=("disable-chown" "init-process" "parallel-schedule-count")
   verify_app_name "$APP"
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then
-    dokku_log_fail "Invalid key specified, valid keys include: disable-chown, parallel-schedule-count"
+    dokku_log_fail "Invalid key specified, valid keys include: disable-chown, init-process, parallel-schedule-count"
   fi
 
   if [[ -n "$VALUE" ]]; then


### PR DESCRIPTION
This allows projects using s6 overlay - in particular linxserver images - the ability to disable --init flag injection.

Additionally, force-disable --init flag usage for all linuxserver images. Linuxserver images uses S6, and there are enough of them that this makes sense to autodetect on behalf of users.

Closes #5287