### PR TITLE
Call out git remote change when renaming an app

### DIFF
--- a/docs/deployment/application-management.md
+++ b/docs/deployment/application-management.md
@@ -150,6 +150,12 @@ By default, Dokku will deploy the renamed app, though you can skip the deploy by
 dokku apps:rename --skip-deploy node-js-app io-js-app
 ```
 
+Remember to also change your git remote on your local machine in order to make `git push dokku main:master` work again. For this you can use `git remote set-url`.
+
+```shell
+git remote set-url dokku dokku@dokku.me:io-js-app
+```
+
 ### Cloning an existing app
 
 > New as of 0.11.5


### PR DESCRIPTION
In order to make `git push` work after renaming an app the hint was added to update the remote url