### PR TITLE
Remove errant semicolon from wget command

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -38,7 +38,7 @@ To install the latest stable version of Dokku, you can run the following shell c
 
 ```shell
 # for debian systems, installs Dokku via apt-get
-wget https://raw.githubusercontent.com/dokku/dokku/v0.28.1/bootstrap.sh;
+wget https://raw.githubusercontent.com/dokku/dokku/v0.28.1/bootstrap.sh
 sudo DOKKU_TAG=v0.28.1 bash bootstrap.sh
 ```
 


### PR DESCRIPTION
Running the command with the semicolon results in a 404 Not Found.