### PR TITLE
Always set app created-at via property instead of introspecting on folder creation time

### DIFF
--- a/plugins/apps/functions.go
+++ b/plugins/apps/functions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/dokku/dokku/plugins/common"
 )
@@ -34,6 +35,10 @@ func createApp(appName string) error {
 
 	common.LogInfo1Quiet(fmt.Sprintf("Creating %s...", appName))
 	os.MkdirAll(common.AppRoot(appName), 0755)
+
+	if err := common.PropertyWrite("apps", appName, "created-at", fmt.Sprintf("%d", time.Now().Unix())); err != nil {
+		return err
+	}
 
 	if err := common.PlugnTrigger("post-create", []string{appName}...); err != nil {
 		return err

--- a/plugins/apps/report.go
+++ b/plugins/apps/report.go
@@ -2,7 +2,7 @@ package apps
 
 import (
 	"fmt"
-	"os"
+	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 )
@@ -33,12 +33,11 @@ func ReportSingleApp(appName string, format string, infoFlag string) error {
 }
 
 func reportCreatedAt(appName string) string {
-	fi, err := os.Stat(common.AppRoot(appName))
+	createdAt, err := common.PropertyListGet("apps", appName, "created-at")
 	if err != nil {
 		return ""
 	}
-
-	return fmt.Sprint(fi.ModTime().Unix())
+	return fmt.Sprint(strings.Join(createdAt, ","))
 }
 
 func reportDeploySource(appName string) string {


### PR DESCRIPTION
Finishes https://github.com/dokku/dokku/issues/5343

Fixes a bug where `apps:report` returned when the `AppRoot` folder was updated instead of when the app was created. 