### PR TITLE
Reference blog on main domain

### DIFF
--- a/contrib/write-mkdocs
+++ b/contrib/write-mkdocs
@@ -106,7 +106,7 @@ def generate_nav(src, dest):
         data["nav"] = [
             {"Docs": navigation},
             {"Pro": "https://pro.dokku.com/docs/getting-started/"},
-            {"Blog": "https://dokku.github.io/"},
+            {"Blog": "https://dokku.com/blog/"},
             {"Purchase Dokku Pro": "https://dokku.dpdcart.com/cart/add?product_id=217344&method_id=236878"},
         ]
 

--- a/docs/home.html
+++ b/docs/home.html
@@ -53,7 +53,7 @@
                 <button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
                 <div class="collapse navbar-collapse" id="navbarResponsive">
                     <ul class="navbar-nav ms-auto my-2 my-lg-0">
-                        <li class="nav-item"><a class="nav-link mx-0 mx-md-2 underline" href="https://dokku.github.io/">Blog</a></li>
+                        <li class="nav-item"><a class="nav-link mx-0 mx-md-2 underline" href="https://dokku.com/blog/">Blog</a></li>
                         <li class="nav-item"><a class="nav-link mx-0 mx-md-2 underline" href="https://github.com/dokku/dokku/">Code</a></li>
                         <li class="nav-item"><a class="nav-link mx-0 mx-md-2 underline" href="/{{NAME}}/getting-started/installation/">Docs</a></li>
                         <li class="nav-item dropdown">

--- a/docs/template.html
+++ b/docs/template.html
@@ -66,7 +66,7 @@
                 <button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
                 <div class="collapse navbar-collapse" id="navbarResponsive">
                     <ul class="navbar-nav ms-auto my-2 my-lg-0">
-                        <li class="nav-item"><a class="nav-link mx-0 mx-md-2 underline" href="https://dokku.github.io/">Blog</a></li>
+                        <li class="nav-item"><a class="nav-link mx-0 mx-md-2 underline" href="https://dokku.com/blog/">Blog</a></li>
                         <li class="nav-item"><a class="nav-link mx-0 mx-md-2 underline" href="https://github.com/dokku/dokku/">Code</a></li>
                         <li class="nav-item"><a class="nav-link mx-0 mx-md-2 underline" href="/{{NAME}}/getting-started/installation/">Docs</a></li>
                         <li class="nav-item dropdown">


### PR DESCRIPTION
The blog is now backed by mkdocs and has been moved to a subdirectory of dokku.com.