### PR TITLE
Respect PLUGIN_PATH when checking if a plugin trigger exists

### DIFF
--- a/plugins/common/common_test.go
+++ b/plugins/common/common_test.go
@@ -21,6 +21,10 @@ var (
 )
 
 func setupTests() (err error) {
+	if err := os.Setenv("PLUGIN_PATH", "/var/lib/dokku/plugins"); err != nil {
+		return err
+	}
+
 	return os.Setenv("PLUGIN_ENABLED_PATH", "/var/lib/dokku/plugins/enabled")
 }
 

--- a/plugins/common/subprocess.go
+++ b/plugins/common/subprocess.go
@@ -132,12 +132,13 @@ func PlugnTriggerSetup(triggerName string, args ...string) *sh.Session {
 
 // PlugnTriggerExists returns whether a plugin trigger exists (ignoring the existence of any within the 20_events plugin)
 func PlugnTriggerExists(triggerName string) bool {
-	pluginPath := MustGetEnv("PLUGIN_ENABLED_PATH")
-	glob := filepath.Join(pluginPath, "*", triggerName)
+	pluginPath := MustGetEnv("PLUGIN_PATH")
+	pluginPathPrefix := filepath.Join(pluginPath, "enabled")
+	glob := filepath.Join(pluginPathPrefix, "*", triggerName)
 	exists := false
 	files, _ := filepath.Glob(glob)
 	for _, file := range files {
-		plugin := strings.Trim(strings.TrimPrefix(strings.TrimSuffix(file, "/"+triggerName), pluginPath), "/")
+		plugin := strings.Trim(strings.TrimPrefix(strings.TrimSuffix(file, "/"+triggerName), pluginPathPrefix), "/")
 		if plugin != "20_events" {
 			exists = true
 			break

--- a/plugins/config/config_test.go
+++ b/plugins/config/config_test.go
@@ -19,6 +19,10 @@ var (
 )
 
 func setupTests() (err error) {
+	if err := os.Setenv("PLUGIN_PATH", "/var/lib/dokku/plugins"); err != nil {
+		return err
+	}
+
 	return os.Setenv("PLUGIN_ENABLED_PATH", "/var/lib/dokku/plugins/enabled")
 }
 


### PR DESCRIPTION
Without this, upgrades may fail if the user has enabled a plugin which implements a trigger that is checked for during an upgrade.