### PR TITLE
Download all src files for go mod dependencies for use in vscode

### DIFF
--- a/.devcontainer/bin/download-go-mod
+++ b/.devcontainer/bin/download-go-mod
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+main() {
+  declare PLUGIN_NAME="$1"
+  local plugin_root="/root/go/src/github.com/dokku/dokku/plugins"
+
+  export GO111MODULE=off
+  echo "-----> Fetching onsi/gomega dependency for tests"
+  go get github.com/onsi/gomega || true
+
+  echo "-----> Fetching spf13/pflag dependency for subcommands"
+  go get github.com/spf13/pflag || true
+  pushd "$plugin_root" >/dev/null
+  find "$plugin_root/" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
+    pushd "$plugin_root/$plugin" >/dev/null
+    if [[ -f "go.mod" ]]; then
+      echo "-----> Fetching dependencies for $plugin plugin"
+      go get || true
+    fi
+    popd >/dev/null
+  done
+  popd >/dev/null
+}
+
+main "$@"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
     "source=${localWorkspaceFolder}/tmp/data/,target=/mnt/dokku/,type=bind"
   ],
   "overrideCommand": false,
-  "postCreateCommand": "make setup-deploy-tests",
+  "postCreateCommand": "download-go-mod && make setup-deploy-tests",
   "runArgs": ["--init"],
   "workspaceFolder": "/root/go/src/github.com/dokku/dokku",
   "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/root/go/src/github.com/dokku/dokku,consistency=cached"


### PR DESCRIPTION
Without this, the LSP within the container continually complains that the source for go files cannot be found. While this method isn't _exactly_ correct, it does help with development.