### PR TITLE
Switch from base64-encoding to base36-encoding of cron task IDs

### DIFF
--- a/docs/appendices/0.29.0-migration-guide.md
+++ b/docs/appendices/0.29.0-migration-guide.md
@@ -2,4 +2,5 @@
 
 ## Changes
 
-The output of `run:detached` now uses the container name - eg. `node-js-app.run.1` - vs the container id.
+- The output of `run:detached` now uses the container name - eg. `node-js-app.run.1` - vs the container id.
+- The ID of `cron` tasks is now base36-encoded instead of base64-encoded.

--- a/plugins/cron/functions.go
+++ b/plugins/cron/functions.go
@@ -1,7 +1,6 @@
 package cron
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -13,6 +12,7 @@ import (
 	appjson "github.com/dokku/dokku/plugins/app-json"
 	"github.com/dokku/dokku/plugins/common"
 
+	base36 "github.com/multiformats/go-base36"
 	cronparser "github.com/robfig/cron/v3"
 )
 
@@ -126,7 +126,7 @@ func writeCronEntries() error {
 			return fmt.Errorf("Invalid injected cron task: %v", line)
 		}
 
-		id := base64.StdEncoding.EncodeToString([]byte(strings.Join(parts, ";;;")))
+		id := base36.EncodeToStringLc([]byte(strings.Join(parts, ";;;")))
 		command := templateCommand{
 			ID:         id,
 			Schedule:   parts[0],
@@ -189,5 +189,5 @@ func getCronTemplate() (*template.Template, error) {
 }
 
 func generateCommandID(appName string, c appjson.CronCommand) string {
-	return base64.StdEncoding.EncodeToString([]byte(appName + "===" + c.Command + "===" + c.Schedule))
+	return base36.EncodeToStringLc([]byte(appName + "===" + c.Command + "===" + c.Schedule))
 }

--- a/plugins/cron/go.mod
+++ b/plugins/cron/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/ryanuber/columnize v1.1.2-0.20190319233515-9e6335e58db3
 	github.com/spf13/pflag v1.0.5
+	github.com/multiformats/go-base36 v0.1.1-0.20220823151017-f5af2eed4d9c
 )
 
 require (

--- a/plugins/cron/go.sum
+++ b/plugins/cron/go.sum
@@ -4,6 +4,10 @@ github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 h1:HHUr4P/aKh4qu
 github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27/go.mod h1:VQx0hjo2oUeQkQUET7wRwradO6f+fN5jzXgB/zROxxE=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/multiformats/go-base36 v0.1.0 h1:JR6TyF7JjGd3m6FbLU2cOxhC0Li8z8dLNGQ89tUg4F4=
+github.com/multiformats/go-base36 v0.1.0/go.mod h1:kFGE83c6s80PklsHO9sRn2NCoffoRdUUOENyW/Vv6sM=
+github.com/multiformats/go-base36 v0.1.1-0.20220823151017-f5af2eed4d9c h1:3eLctj5+2JpWf0E8PICebevkyD0KcZUhye8ggScrnEQ=
+github.com/multiformats/go-base36 v0.1.1-0.20220823151017-f5af2eed4d9c/go.mod h1:qvnKE++v+2MWCfePClUEjE78Z7P2a1UV0xHgWc0hkp4=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=


### PR DESCRIPTION
This allows the IDs to be used as DNS labels, meaning they can be used as is for external scheduler task names.

Closes #4903