### PR TITLE
Traefik attempts to obtain certificate for api even if it's disabled.

### DIFF
--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -24,10 +24,13 @@ services:
       {{ end }}
 
     labels:
+      {{ if $.TRAEFIK_API_ENABLED }}
       # Dashboard
       - "traefik.http.routers.api.rule=Host(`{{ $.TRAEFIK_API_VHOST }}`)"
       - "traefik.http.routers.api.service=api@internal"
       - "traefik.http.routers.api.entrypoints={{ if $.TRAEFIK_LETSENCRYPT_EMAIL }}https{{ else }}http{{ end }}"
+      {{ end }}
+      
       - "traefik.http.routers.middlewares=auth"
       {{ if $.TRAEFIK_BASIC_AUTH }}
       - "traefik.http.middlewares.auth.basicauth.users={{ $.TRAEFIK_BASIC_AUTH }}"


### PR DESCRIPTION
If you have letsencrypt setup and have not enabled the dashboard you may not even think about routing to a possible dashboard url (by default lb.dokku.me) but if you don't then your Traefik container logs complain about being unable to get a certificate for the url in question. 

This PR wraps that stanza in a check that makes sure the API is desired before trying to get a certificate for it.