### PR TITLE
Drop installation of nginx ppa

### DIFF
--- a/plugins/nginx-vhosts/dependencies
+++ b/plugins/nginx-vhosts/dependencies
@@ -2,27 +2,6 @@
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 
-nginx_needs_upgrade() {
-  declare desc="checks as to whether nginx needs to be installed or upgraded"
-  local MAJOR_VERSION MINOR_VERSION
-  local NEEDS_UPGRADE=true
-
-  if ! command -v nginx &>/dev/null; then
-    echo $NEEDS_UPGRADE
-    return
-  fi
-
-  MAJOR_VERSION=$(nginx -v 2>&1 | cut -d'/' -f 2 | awk '{split($0,a,"."); print a[1]}')
-  MINOR_VERSION=$(nginx -v 2>&1 | cut -d'/' -f 2 | awk '{split($0,a,"."); print a[2]}')
-  if [[ "$MAJOR_VERSION" -ge "2" ]]; then
-    NEEDS_UPGRADE=false
-  elif [[ "$MAJOR_VERSION" -ge "1" ]] && [[ "$MINOR_VERSION" -ge "8" ]]; then
-    NEEDS_UPGRADE=false
-  fi
-
-  echo $NEEDS_UPGRADE
-}
-
 nginx_install() {
   declare desc="install nginx and dnsutils"
   export DEBIAN_FRONTEND=noninteractive
@@ -39,26 +18,10 @@ trigger-nginx-vhosts-dependencies() {
       ;;
 
     ubuntu)
-      export DEBIAN_FRONTEND=noninteractive
-      local NEEDS_UPGRADE=$(nginx_needs_upgrade)
-      if [[ "$NEEDS_UPGRADE" == "false" ]]; then
+      if command -v nginx &>/dev/null; then
         return
       fi
 
-      if ! command -v nginx &>/dev/null; then
-        nginx_install
-        return
-      fi
-
-      ubuntu_year=$(lsb_release -d | cut -d ' ' -f 2 | awk '{split($0,a,"."); print a[1]}')
-      ubuntu_month=$(lsb_release -d | cut -d ' ' -f 2 | awk '{split($0,a,"."); print a[2]}')
-      [[ "$ubuntu_year" -ge "16" ]] && exit 0
-      [[ "$ubuntu_year" -eq "15" ]] && [[ "$ubuntu_month" -eq "10" ]] && exit 0
-
-      apt-get -qq -y --no-install-recommends install software-properties-common python-software-properties
-
-      add-apt-repository -y ppa:nginx/stable
-      apt-get update -qq >/dev/null
       nginx_install
       ;;
 

--- a/tests/ci/setup.sh
+++ b/tests/ci/setup.sh
@@ -56,7 +56,6 @@ install_dependencies() {
     curl -L "https://packagecloud.io/dokku/dokku/packages/ubuntu/bionic/procfile-util_${PROCFILE_VERSION}_amd64.deb/download.deb" -o "$ROOT_DIR/build/${PROCFILE_UTIL_PACKAGE_NAME}"
   fi
 
-  sudo add-apt-repository -y ppa:nginx/stable
   sudo apt-get update -qq
   sudo apt-get -qq -y --no-install-recommends install cgroupfs-mount dos2unix jq nginx debconf-utils
   sudo cp "${ROOT_DIR}/tests/dhparam.pem" /etc/nginx/dhparam.pem


### PR DESCRIPTION
We've been using OS nginx for quite a while now as it's been updated significantly, so there is no need to use the official ppa anymore.