### PR TITLE
Correct issue with detection of non-https port mapping as https port mapping

### DIFF
--- a/plugins/caddy-vhosts/docker-args-process-deploy
+++ b/plugins/caddy-vhosts/docker-args-process-deploy
@@ -72,6 +72,16 @@ trigger-caddy-vhosts-docker-args-process-deploy() {
     fi
   done
 
+  letsencrypt_email="$(fn-caddy-letsencrypt-email)"
+  if [[ -n "$letsencrypt_email" ]] && [[ -z "$proxy_container_https_port" ]]; then
+    proxy_container_https_port_candidate="$proxy_container_http_port_candidate"
+    proxy_host_https_port_candidate="$proxy_host_http_port_candidate"
+    if [[ -n "$proxy_container_http_port" ]]; then
+      proxy_container_https_port_candidate="$proxy_container_http_port"
+      proxy_host_http_port_candidate=443
+    fi
+  fi
+
   app_domains="$(plugn trigger domains-list "$APP")"
   if [[ -n "$app_domains" ]]; then
     caddy_domains="$(echo "$app_domains" | xargs)"
@@ -98,7 +108,6 @@ trigger-caddy-vhosts-docker-args-process-deploy() {
       fi
     fi
 
-    letsencrypt_email="$(fn-caddy-letsencrypt-email)"
     scheme="http"
     if [[ -n "$letsencrypt_email" ]] && [[ "$has_443_mapping" == "true" ]]; then
       output="--label 'caddy=${caddy_domains}'"

--- a/plugins/traefik-vhosts/docker-args-process-deploy
+++ b/plugins/traefik-vhosts/docker-args-process-deploy
@@ -8,7 +8,7 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
   declare desc="nginx-vhosts core-post-deploy plugin trigger"
   declare trigger="docker-args-process-deploy"
   declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3" PROC_TYPE="$4" CONTAINER_INDEX="$5"
-  local app_domains is_app_listening output proxy_container_port proxy_host_port port_map proxy_port_map priority proxy_scheme proxy_schemes traefik_domains
+  local app_domains is_app_listening letsencrypt_email output proxy_container_port proxy_host_port port_map proxy_port_map priority proxy_scheme proxy_schemes traefik_domains
   local proxy_container_http_port proxy_container_http_port_candidate proxy_host_http_port_candidate
   local proxy_container_https_port proxy_container_https_port_candidate proxy_host_https_port_candidate
   local app_urls_path="$DOKKU_ROOT/$APP/URLS"
@@ -71,6 +71,16 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
       fi
     fi
   done
+
+  letsencrypt_email="$(fn-traefik-letsencrypt-email)"
+  if [[ -n "$letsencrypt_email" ]] && [[ -z "$proxy_container_https_port" ]]; then
+    proxy_container_https_port_candidate="$proxy_container_http_port_candidate"
+    proxy_host_https_port_candidate="$proxy_host_http_port_candidate"
+    if [[ -n "$proxy_container_http_port" ]]; then
+      proxy_container_https_port_candidate="$proxy_container_http_port"
+      proxy_host_http_port_candidate=443
+    fi
+  fi
 
   # add the labels for traefik here
   # any `http:80` port mapping is treated as a `http` traefik entrypoint

--- a/tests/unit/caddy.bats
+++ b/tests/unit/caddy.bats
@@ -5,6 +5,8 @@ load test_helper
 setup() {
   global_setup
   dokku nginx:stop
+  dokku caddy:set --global letsencrypt-server https://acme-staging-v02.api.letsencrypt.org/directory
+  dokku caddy:set --global letsencrypt-email
   dokku caddy:start
   create_app
 }
@@ -80,4 +82,63 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output "python/http.server"
+}
+
+@test "(caddy) ssl" {
+  run /bin/bash -c "dokku builder-herokuish:set $TEST_APP allowed true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku proxy:set $TEST_APP caddy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "docker inspect $TEST_APP.web.1 --format '{{ index .Config.Labels \"caddy\" }}'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "$TEST_APP.dokku.me:80"
+
+  run /bin/bash -c "dokku caddy:set --global letsencrypt-email test@example.com"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku caddy:stop"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku caddy:start"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku ps:inspect $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "docker inspect $TEST_APP.web.1 --format '{{ index .Config.Labels \"caddy\" }}'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "$TEST_APP.dokku.me"
+
+  run /bin/bash -c "dokku proxy:report $TEST_APP --proxy-port-map"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "http:80:5000"
 }


### PR DESCRIPTION
This allows folks to _only_ set the letsencrypt-email in order to get https working as expected.

Closes #5410