### PR TITLE
Fix reference to scheduler name in nomad docs

### DIFF
--- a/docs/deployment/schedulers/nomad.md
+++ b/docs/deployment/schedulers/nomad.md
@@ -8,7 +8,7 @@ For users that require additional functionality, please refer to the [Sponsoring
 
 ## Scheduler Interface
 
-The following sections describe implemented scheduler functionality for the `docker-local` scheduler.
+The following sections describe implemented scheduler functionality for the `nomad` scheduler.
 
 ### Implemented Commands and Triggers
 


### PR DESCRIPTION
Closes dokku/dokku-scheduler-nomad#7