### PR TITLE
Fix reference to scheduler name in kubernetes docs

### DIFF
--- a/docs/deployment/schedulers/kubernetes.md
+++ b/docs/deployment/schedulers/kubernetes.md
@@ -8,7 +8,7 @@ For users that require additional functionality, please refer to the [Sponsoring
 
 ## Scheduler Interface
 
-The following sections describe implemented scheduler functionality for the `docker-local` scheduler.
+The following sections describe implemented scheduler functionality for the `kubernetes` scheduler.
 
 ### Implemented Commands and Triggers
 


### PR DESCRIPTION
Closes dokku/dokku-scheduler-kubernetes#40