### PR TITLE
Drop debugging code from ps plugin

### DIFF
--- a/plugins/ps/functions.go
+++ b/plugins/ps/functions.go
@@ -308,10 +308,6 @@ func updateScale(appName string, clearExisting bool, formationUpdates FormationS
 		}
 	}
 
-	if common.FileExists(getProcessSpecificProcfile(appName)) {
-		common.CatFile(getProcessSpecificProcfile(appName))
-	}
-
 	foundProcessTypes := map[string]bool{}
 	updatedFormation := FormationSlice{}
 	for _, formation := range formationUpdates {


### PR DESCRIPTION
This was accidentally added in a refactor of how processes are managed.