### PR TITLE
Drop SPDY support from nginx plugin

### DIFF
--- a/docs/appendices/0.30.0-migration-guide.md
+++ b/docs/appendices/0.30.0-migration-guide.md
@@ -1,0 +1,5 @@
+# 0.30.0 Migration Guide
+
+## Removals
+
+- Support for [SPDY](https://en.wikipedia.org/wiki/SPDY) has been removed. No major browser supports it as of 2021. Custom `nginx.conf.sigil` templates referencing spdy-related variables will continue to build until the 1.0.0 release.

--- a/docs/getting-started/upgrading/index.md
+++ b/docs/getting-started/upgrading/index.md
@@ -18,6 +18,7 @@ Docker releases updates periodically to their engine. We recommend reading their
 
 Before upgrading, check the migration guides to get comfortable with new features and prepare your deployment to be upgraded.
 
+- [Upgrading to 0.30](/docs/appendices/0.30.0-migration-guide.md)
 - [Upgrading to 0.29](/docs/appendices/0.29.0-migration-guide.md)
 - [Upgrading to 0.28](/docs/appendices/0.28.0-migration-guide.md)
 - [Upgrading to 0.27](/docs/appendices/0.27.0-migration-guide.md)

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -219,28 +219,6 @@ is_tls13_available() {
   echo $HAS_SUPPORT
 }
 
-is_spdy_enabled() {
-  declare desc="detects whether the installed nginx version has spdy support"
-  local NGINX_VERSION="$1"
-  local MAJOR_VERSION MINOR_VERSION PATCH_VERSION
-  local HAS_SUPPORT=true
-
-  MAJOR_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[1]}')
-  MINOR_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[2]}')
-  PATCH_VERSION=$(echo "$NGINX_VERSION" | awk '{split($0,a,"."); print a[3]}')
-  if [[ "$MAJOR_VERSION" -ge "2" ]]; then
-    HAS_SUPPORT=false
-  elif [[ "$MAJOR_VERSION" -eq "1" ]]; then
-    if [[ "$MINOR_VERSION" -ge "10" ]]; then
-      HAS_SUPPORT=false
-    elif [[ "$MINOR_VERSION" -ge "9" ]] && [[ "$PATCH_VERSION" -ge "5" ]]; then
-      HAS_SUPPORT=false
-    fi
-  fi
-
-  echo $HAS_SUPPORT
-}
-
 is_http2_push_enabled() {
   declare desc="detects whether the installed nginx version has http2 push support"
   local NGINX_VERSION="$1"
@@ -394,7 +372,8 @@ nginx_build_config() {
       exit 1
     fi
     NGINX_VERSION="$("$NGINX_LOCATION" -v 2>&1 | cut -d'/' -f 2)"
-    SPDY_SUPPORTED="$(is_spdy_enabled "$NGINX_VERSION")"
+    # DEPRECATED: Remove me at 1.0.0
+    SPDY_SUPPORTED="false"
     TLS13_SUPPORTED="$(is_tls13_available "$NGINX_VERSION")"
     HTTP2_SUPPORTED="$(is_http2_enabled "$NGINX_VERSION")"
     HTTP2_PUSH_SUPPORTED="$(is_http2_push_enabled "$NGINX_VERSION")"

--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -67,8 +67,8 @@ server {
 }
 {{ else if eq $scheme "https"}}
 server {
-  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ else if eq $.SPDY_SUPPORTED "true" }}spdy{{ end }};
-  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ else if eq $.SPDY_SUPPORTED "true" }}spdy{{ end }};
+  listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ end }};
+  listen      {{ if $.NGINX_BIND_ADDRESS_IP4 }}{{ $.NGINX_BIND_ADDRESS_IP4 }}:{{end}}{{ $listen_port }} ssl {{ if eq $.HTTP2_SUPPORTED "true" }}http2{{ end }};
   {{ if $.SSL_SERVER_NAME }}server_name {{ $.SSL_SERVER_NAME }}; {{ end }}
   {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }}; {{ end }}
   access_log  {{ $.NGINX_ACCESS_LOG_PATH }}{{ if and ($.NGINX_ACCESS_LOG_FORMAT) (ne $.NGINX_ACCESS_LOG_PATH "off") }} {{ $.NGINX_ACCESS_LOG_FORMAT }}{{ end }};
@@ -80,7 +80,6 @@ server {
   ssl_prefer_server_ciphers off;
 
   keepalive_timeout   70;
-  {{ if and (eq $.SPDY_SUPPORTED "true") (ne $.HTTP2_SUPPORTED "true") }}add_header          Alternate-Protocol  {{ $.PROXY_SSL_PORT }}:npn-spdy/2;{{ end }}
 
   location    / {
 

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -399,15 +399,14 @@ server {
 }
 {{ else if eq \$scheme "https"}}
 server {
-  listen      [::]:{{ $.PROXY_SSL_PORT }} ssl spdy;
-  listen      {{ $.PROXY_SSL_PORT }} ssl spdy;
+  listen      [::]:{{ $.PROXY_SSL_PORT }} ssl;
+  listen      {{ $.PROXY_SSL_PORT }} ssl;
   {{ if $.SSL_SERVER_NAME }}server_name {{ $.SSL_SERVER_NAME }} $CUSTOM_TEMPLATE_SSL_DOMAIN; {{ end }}
   {{ if $.NOSSL_SERVER_NAME }}server_name {{ $.NOSSL_SERVER_NAME }} $CUSTOM_TEMPLATE_SSL_DOMAIN; {{ end }}
   ssl_certificate     {{ $.APP_SSL_PATH }}/server.crt;
   ssl_certificate_key {{ $.APP_SSL_PATH }}/server.key;
 
   keepalive_timeout   70;
-  add_header          Alternate-Protocol  {{ \$listen_port }}:npn-spdy/2;
   location    / {
     proxy_pass  http://{{ $.APP }}-{{ \$upstream_port }};
     proxy_http_version 1.1;


### PR DESCRIPTION
This hasn't been supported by browsers in quite a while and nginx will set a warning as of Ubuntu 20.04 when the header is referenced.