### PR TITLE
Clarify documentation for default site under nginx

### DIFF
--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -397,7 +397,11 @@ These are provided as an alternative to the generic Nginx error page, are shared
 
 ### Default site
 
-By default, Dokku will route any received request with an unknown HOST header value to the lexicographically first site in the nginx config stack. If this is not the desired behavior, you may want to add the following configuration to the global nginx configuration.
+By default, Dokku will route any received request with an unknown HOST header value to the lexicographically first site in the nginx config stack.
+
+> Note that some versions of Nginx may create a default site (a static page which says "Welcome to Nginx") when installed. If this default site is enabled, it will not route any requests with an unknown HOST header to Dokku. If you want Dokku to receive all requests, disable this default site by removing the `/etc/nginx/sites-enabled/default` file, and then restart nginx.
+
+If Dokku handling all requests is not the desired behavior, you may want to add the following configuration to the global nginx configuration.
 
 Create the file at `/etc/nginx/conf.d/00-default-vhost.conf`:
 

--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -399,7 +399,13 @@ These are provided as an alternative to the generic Nginx error page, are shared
 
 By default, Dokku will route any received request with an unknown HOST header value to the lexicographically first site in the nginx config stack.
 
-> Note that some versions of Nginx may create a default site when installed. This site is simply a static page which says "Welcome to Nginx", and if this default site is enabled, Nginx will not route any requests with an unknown HOST header to Dokku. If you want Dokku to receive all requests, disable this default site by removing the `/etc/nginx/sites-enabled/default` file, and then restart Nginx.
+> Warning: some versions of Nginx may create a default site when installed. This site is simply a static page which says "Welcome to Nginx", and if this default site is enabled, Nginx will not route any requests with an unknown HOST header to Dokku. If you want Dokku to receive all requests, run the following commands:
+>
+> ```
+> rm /etc/nginx/sites-enabled/default
+> dokku nginx:stop
+> dokku nginx:start
+> ```
 
 If Dokku handling all requests is not the desired behavior, you may want to add the following configuration to the global nginx configuration.
 

--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -399,7 +399,7 @@ These are provided as an alternative to the generic Nginx error page, are shared
 
 By default, Dokku will route any received request with an unknown HOST header value to the lexicographically first site in the nginx config stack.
 
-> Note that some versions of Nginx may create a default site (a static page which says "Welcome to Nginx") when installed. If this default site is enabled, it will not route any requests with an unknown HOST header to Dokku. If you want Dokku to receive all requests, disable this default site by removing the `/etc/nginx/sites-enabled/default` file, and then restart nginx.
+> Note that some versions of Nginx may create a default site when installed. This site is simply a static page which says "Welcome to Nginx", and if this default site is enabled, Nginx will not route any requests with an unknown HOST header to Dokku. If you want Dokku to receive all requests, disable this default site by removing the `/etc/nginx/sites-enabled/default` file, and then restart Nginx.
 
 If Dokku handling all requests is not the desired behavior, you may want to add the following configuration to the global nginx configuration.
 


### PR DESCRIPTION
Added some wording to the Nginx docs about the default site which Nginx creates on install. This default site being enabled prevents Dokku from receiving traffic unless the HOST header matches one of the domains assigned to an app.

Fixes #5562