### PR TITLE
Ensure we properly setup all data directories on app install and creation

### DIFF
--- a/plugins/app-json/Makefile
+++ b/plugins/app-json/Makefile
@@ -1,5 +1,5 @@
 SUBCOMMANDS = subcommands/report subcommands/set
-TRIGGERS = triggers/app-json-process-deploy-parallelism triggers/install triggers/post-app-clone-setup triggers/post-app-rename-setup triggers/post-delete triggers/post-deploy triggers/pre-deploy triggers/report
+TRIGGERS = triggers/app-json-process-deploy-parallelism triggers/install triggers/post-app-clone-setup triggers/post-app-rename triggers/post-app-rename-setup triggers/post-create triggers/post-delete triggers/post-deploy triggers/pre-deploy triggers/report
 BUILD = commands subcommands triggers
 PLUGIN_NAME = app-json
 

--- a/plugins/app-json/appjson.go
+++ b/plugins/app-json/appjson.go
@@ -45,7 +45,7 @@ type Formation struct {
 
 // GetAppjsonDirectory returns the directory containing a given app's extracted app.json file
 func GetAppjsonDirectory(appName string) string {
-	return filepath.Join(common.MustGetEnv("DOKKU_LIB_ROOT"), "data", "app-json", appName)
+	return common.GetAppDataDirectory("app-json", appName)
 }
 
 // GetAppjsonPath returns the path to a given app's extracted app.json file

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -455,12 +455,12 @@ func createdContainerID(appName string, dockerArgs []string, image string, comma
 }
 
 func refreshAppJSON(appName string, image string) error {
-	baseDirectory := filepath.Join(common.MustGetEnv("DOKKU_LIB_ROOT"), "data", "app-json")
+	baseDirectory := common.GetDataDirectory("app-json")
 	if !common.DirectoryExists(baseDirectory) {
 		return errors.New("Run 'dokku plugin:install' to ensure the correct directories exist")
 	}
 
-	directory := GetAppjsonDirectory(appName)
+	directory := common.GetAppDataDirectory("app-json", appName)
 	if !common.DirectoryExists(directory) {
 		if err := os.MkdirAll(directory, 0755); err != nil {
 			return err
@@ -514,7 +514,7 @@ func injectDokkuScale(appName string, image string) error {
 		return err
 	}
 
-	baseDirectory := filepath.Join(common.MustGetEnv("DOKKU_LIB_ROOT"), "data", "app-json")
+	baseDirectory := common.GetDataDirectory("app-json")
 	if !common.DirectoryExists(baseDirectory) {
 		return errors.New("Run 'dokku plugin:install' to ensure the correct directories exist")
 	}

--- a/plugins/app-json/src/triggers/triggers.go
+++ b/plugins/app-json/src/triggers/triggers.go
@@ -28,6 +28,10 @@ func main() {
 		oldAppName := flag.Arg(0)
 		newAppName := flag.Arg(1)
 		err = appjson.TriggerPostAppCloneSetup(oldAppName, newAppName)
+	case "post-app-rename":
+		oldAppName := flag.Arg(0)
+		newAppName := flag.Arg(1)
+		err = appjson.TriggerPostAppRename(oldAppName, newAppName)
 	case "post-app-rename-setup":
 		oldAppName := flag.Arg(0)
 		newAppName := flag.Arg(1)

--- a/plugins/common/data.go
+++ b/plugins/common/data.go
@@ -1,0 +1,82 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/otiai10/copy"
+)
+
+// CreateAppDataDirectory creates a data directory for the given plugin/app combination with the correct permissions
+func CreateAppDataDirectory(pluginName, appName string) error {
+	directory := GetAppDataDirectory(pluginName, appName)
+	if err := os.MkdirAll(directory, 0755); err != nil {
+		return err
+	}
+
+	if err := SetPermissions(directory, 0755); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateDataDirectory creates a data directory for the given plugin/app combination with the correct permissions
+func CreateDataDirectory(pluginName string) error {
+	directory := GetDataDirectory(pluginName)
+	if err := os.MkdirAll(directory, 0755); err != nil {
+		return err
+	}
+
+	if err := SetPermissions(directory, 0755); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetAppDataDirectory returns the path to the data directory for the given plugin/app combination
+func GetAppDataDirectory(pluginName string, appName string) string {
+	return filepath.Join(GetDataDirectory(pluginName), appName)
+}
+
+// GetDataDirectory returns the path to the data directory for the specified plugin
+func GetDataDirectory(pluginName string) string {
+	return filepath.Join(MustGetEnv("DOKKU_LIB_ROOT"), "data", pluginName)
+}
+
+// RemoveAppDataDirectory removes the path to the data directory for the given plugin/app combination
+func RemoveAppDataDirectory(pluginName, appName string) error {
+	return os.RemoveAll(GetAppDataDirectory(pluginName, appName))
+}
+
+func CloneAppData(pluginName string, oldAppName string, newAppName string) error {
+	oldDataDir := GetAppDataDirectory(pluginName, oldAppName)
+	newDataDir := GetAppDataDirectory(pluginName, newAppName)
+	if err := copy.Copy(oldDataDir, newDataDir); err != nil {
+		return fmt.Errorf("Unable to clone app data to new location: %v", err.Error())
+	}
+
+	return nil
+}
+
+// SetupAppData creates
+func SetupAppData(pluginName string) error {
+	if err := CreateDataDirectory(pluginName); err != nil {
+		return err
+	}
+
+	apps, err := UnfilteredDokkuApps()
+	if err != nil {
+		return nil
+	}
+
+	for _, appName := range apps {
+		if err := CreateAppDataDirectory(pluginName, appName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/plugins/logs/Makefile
+++ b/plugins/logs/Makefile
@@ -1,5 +1,5 @@
 SUBCOMMANDS = subcommands/failed subcommands/report subcommands/set subcommands/vector-logs subcommands/vector-start subcommands/vector-stop
-TRIGGERS = triggers/docker-args-process-deploy triggers/install triggers/logs-get-property triggers/post-app-clone-setup triggers/post-app-rename-setup triggers/post-delete triggers/report
+TRIGGERS = triggers/docker-args-process-deploy triggers/install triggers/logs-get-property triggers/post-app-clone-setup triggers/post-app-rename triggers/post-app-rename-setup triggers/post-create triggers/post-delete triggers/report
 BUILD = commands subcommands triggers
 PLUGIN_NAME = logs
 

--- a/plugins/logs/functions.go
+++ b/plugins/logs/functions.go
@@ -223,7 +223,7 @@ func writeVectorConfig() error {
 	b = bytes.Replace(b, []byte("\\u0026"), []byte("&"), -1)
 	b = bytes.Replace(b, []byte("\\u002B"), []byte("+"), -1)
 
-	vectorConfig := filepath.Join(common.MustGetEnv("DOKKU_LIB_ROOT"), "data", "logs", "vector.json")
+	vectorConfig := filepath.Join(common.GetDataDirectory("logs"), "vector.json")
 	if err := common.WriteSliceToFile(vectorConfig, []string{string(b)}); err != nil {
 		return err
 	}

--- a/plugins/logs/src/triggers/triggers.go
+++ b/plugins/logs/src/triggers/triggers.go
@@ -31,6 +31,10 @@ func main() {
 		oldAppName := flag.Arg(0)
 		newAppName := flag.Arg(1)
 		err = logs.TriggerPostAppCloneSetup(oldAppName, newAppName)
+	case "post-app-rename":
+		oldAppName := flag.Arg(0)
+		newAppName := flag.Arg(1)
+		err = logs.TriggerPostAppRename(oldAppName, newAppName)
 	case "post-app-rename-setup":
 		oldAppName := flag.Arg(0)
 		newAppName := flag.Arg(1)

--- a/plugins/logs/subcommands.go
+++ b/plugins/logs/subcommands.go
@@ -75,7 +75,7 @@ func CommandSet(appName string, property string, value string) error {
 
 	common.CommandPropertySet("logs", appName, property, value, DefaultProperties, GlobalProperties)
 	if property == "vector-sink" {
-		common.LogVerboseQuiet(fmt.Sprintf("Writing updated vector config to %s", filepath.Join(common.MustGetEnv("DOKKU_LIB_ROOT"), "data", "logs", "vector.json")))
+		common.LogVerboseQuiet(fmt.Sprintf("Writing updated vector config to %s", filepath.Join(common.GetDataDirectory("logs"), "vector.json")))
 		return writeVectorConfig()
 	}
 	return nil

--- a/plugins/ps/functions.go
+++ b/plugins/ps/functions.go
@@ -66,7 +66,7 @@ func getProcfileCommand(procfilePath string, processType string, port int) (stri
 }
 
 func getProcfilePath(appName string) string {
-	directory := filepath.Join(common.MustGetEnv("DOKKU_LIB_ROOT"), "data", "ps", appName)
+	directory := common.GetAppDataDirectory("ps", appName)
 	return filepath.Join(directory, "Procfile")
 }
 

--- a/plugins/ps/subcommands.go
+++ b/plugins/ps/subcommands.go
@@ -104,7 +104,7 @@ func CommandRestore(appName string, allApps bool, parallelCount int) error {
 
 // CommandRetire ensures old containers are retired
 func CommandRetire(appName string) error {
-	lockFile := filepath.Join(common.MustGetEnv("DOKKU_LIB_ROOT"), "data", "ps", "retire")
+	lockFile := filepath.Join(common.GetDataDirectory("ps"), "retire")
 	scheduler := ""
 	if appName == "" {
 		scheduler = common.GetGlobalScheduler()


### PR DESCRIPTION
Move all golang code for managing data directories to common plugin. This makes it easier for us to more or less copy-paste the underlying code.

Additionally, ensure the golang plugins handle setup/teardown of plugin and app-specific data directories during install, rename, and clone phases.

Refs #5568.