### PR TITLE
Use short url for installation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.29.4/bootstrap.sh
+wget https://dokku.com/install/v0.29.4/bootstrap.sh
 sudo DOKKU_TAG=v0.29.4 bash bootstrap.sh
 ```
 
@@ -35,7 +35,7 @@ sudo DOKKU_TAG=v0.29.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.29.3/bootstrap.sh
+wget https://dokku.com/install/v0.29.3/bootstrap.sh
 sudo DOKKU_TAG=v0.29.3 bash bootstrap.sh
 ```
 
@@ -59,7 +59,7 @@ sudo DOKKU_TAG=v0.29.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.29.2/bootstrap.sh
+wget https://dokku.com/install/v0.29.2/bootstrap.sh
 sudo DOKKU_TAG=v0.29.2 bash bootstrap.sh
 ```
 
@@ -72,7 +72,7 @@ sudo DOKKU_TAG=v0.29.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.29.1/bootstrap.sh
+wget https://dokku.com/install/v0.29.1/bootstrap.sh
 sudo DOKKU_TAG=v0.29.1 bash bootstrap.sh
 ```
 
@@ -108,7 +108,7 @@ sudo DOKKU_TAG=v0.29.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.29.0/bootstrap.sh
+wget https://dokku.com/install/v0.29.0/bootstrap.sh
 sudo DOKKU_TAG=v0.29.0 bash bootstrap.sh
 ```
 
@@ -195,7 +195,7 @@ See the [0.29.0 migration guide](/docs/appendices/0.29.0-migration-guide.md) for
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.28.4/bootstrap.sh
+wget https://dokku.com/install/v0.28.4/bootstrap.sh
 sudo DOKKU_TAG=v0.28.4 bash bootstrap.sh
 ```
 
@@ -230,7 +230,7 @@ sudo DOKKU_TAG=v0.28.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.28.3/bootstrap.sh
+wget https://dokku.com/install/v0.28.3/bootstrap.sh
 sudo DOKKU_TAG=v0.28.3 bash bootstrap.sh
 ```
 
@@ -259,7 +259,7 @@ sudo DOKKU_TAG=v0.28.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.28.2/bootstrap.sh
+wget https://dokku.com/install/v0.28.2/bootstrap.sh
 sudo DOKKU_TAG=v0.28.2 bash bootstrap.sh
 ```
 
@@ -300,7 +300,7 @@ sudo DOKKU_TAG=v0.28.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.28.1/bootstrap.sh
+wget https://dokku.com/install/v0.28.1/bootstrap.sh
 sudo DOKKU_TAG=v0.28.1 bash bootstrap.sh
 ```
 
@@ -313,7 +313,7 @@ sudo DOKKU_TAG=v0.28.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.28.0/bootstrap.sh
+wget https://dokku.com/install/v0.28.0/bootstrap.sh
 sudo DOKKU_TAG=v0.28.0 bash bootstrap.sh
 ```
 
@@ -356,7 +356,7 @@ See the [0.28.0 migration guide](/docs/appendices/0.28.0-migration-guide.md) for
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.10/bootstrap.sh
+wget https://dokku.com/install/v0.27.10/bootstrap.sh
 sudo DOKKU_TAG=v0.27.10 bash bootstrap.sh
 ```
 
@@ -373,7 +373,7 @@ sudo DOKKU_TAG=v0.27.10 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.9/bootstrap.sh
+wget https://dokku.com/install/v0.27.9/bootstrap.sh
 sudo DOKKU_TAG=v0.27.9 bash bootstrap.sh
 ```
 
@@ -402,7 +402,7 @@ sudo DOKKU_TAG=v0.27.9 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.8/bootstrap.sh
+wget https://dokku.com/install/v0.27.8/bootstrap.sh
 sudo DOKKU_TAG=v0.27.8 bash bootstrap.sh
 ```
 
@@ -425,7 +425,7 @@ sudo DOKKU_TAG=v0.27.8 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.7/bootstrap.sh
+wget https://dokku.com/install/v0.27.7/bootstrap.sh
 sudo DOKKU_TAG=v0.27.7 bash bootstrap.sh
 ```
 
@@ -451,7 +451,7 @@ sudo DOKKU_TAG=v0.27.7 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.6/bootstrap.sh
+wget https://dokku.com/install/v0.27.6/bootstrap.sh
 sudo DOKKU_TAG=v0.27.6 bash bootstrap.sh
 ```
 
@@ -482,7 +482,7 @@ sudo DOKKU_TAG=v0.27.6 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.5/bootstrap.sh
+wget https://dokku.com/install/v0.27.5/bootstrap.sh
 sudo DOKKU_TAG=v0.27.5 bash bootstrap.sh
 ```
 
@@ -511,7 +511,7 @@ sudo DOKKU_TAG=v0.27.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.4/bootstrap.sh
+wget https://dokku.com/install/v0.27.4/bootstrap.sh
 sudo DOKKU_TAG=v0.27.4 bash bootstrap.sh
 ```
 
@@ -524,7 +524,7 @@ sudo DOKKU_TAG=v0.27.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.3/bootstrap.sh
+wget https://dokku.com/install/v0.27.3/bootstrap.sh
 sudo DOKKU_TAG=v0.27.3 bash bootstrap.sh
 ```
 
@@ -545,7 +545,7 @@ sudo DOKKU_TAG=v0.27.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.2/bootstrap.sh
+wget https://dokku.com/install/v0.27.2/bootstrap.sh
 sudo DOKKU_TAG=v0.27.2 bash bootstrap.sh
 ```
 
@@ -594,7 +594,7 @@ sudo DOKKU_TAG=v0.27.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.1/bootstrap.sh
+wget https://dokku.com/install/v0.27.1/bootstrap.sh
 sudo DOKKU_TAG=v0.27.1 bash bootstrap.sh
 ```
 
@@ -643,7 +643,7 @@ sudo DOKKU_TAG=v0.27.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.27.0/bootstrap.sh
+wget https://dokku.com/install/v0.27.0/bootstrap.sh
 sudo DOKKU_TAG=v0.27.0 bash bootstrap.sh
 ```
 
@@ -696,7 +696,7 @@ See the [0.27.0 migration guide](/docs/appendices/0.27.0-migration-guide.md) for
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.26.8/bootstrap.sh
+wget https://dokku.com/install/v0.26.8/bootstrap.sh
 sudo DOKKU_TAG=v0.26.8 bash bootstrap.sh
 ```
 
@@ -720,7 +720,7 @@ sudo DOKKU_TAG=v0.26.8 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.26.7/bootstrap.sh
+wget https://dokku.com/install/v0.26.7/bootstrap.sh
 sudo DOKKU_TAG=v0.26.7 bash bootstrap.sh
 ```
 
@@ -760,7 +760,7 @@ sudo DOKKU_TAG=v0.26.7 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.26.6/bootstrap.sh
+wget https://dokku.com/install/v0.26.6/bootstrap.sh
 sudo DOKKU_TAG=v0.26.6 bash bootstrap.sh
 ```
 
@@ -774,7 +774,7 @@ sudo DOKKU_TAG=v0.26.6 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.26.5/bootstrap.sh
+wget https://dokku.com/install/v0.26.5/bootstrap.sh
 sudo DOKKU_TAG=v0.26.5 bash bootstrap.sh
 ```
 
@@ -802,7 +802,7 @@ sudo DOKKU_TAG=v0.26.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.26.4/bootstrap.sh
+wget https://dokku.com/install/v0.26.4/bootstrap.sh
 sudo DOKKU_TAG=v0.26.4 bash bootstrap.sh
 ```
 
@@ -821,7 +821,7 @@ sudo DOKKU_TAG=v0.26.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.26.3/bootstrap.sh
+wget https://dokku.com/install/v0.26.3/bootstrap.sh
 sudo DOKKU_TAG=v0.26.3 bash bootstrap.sh
 ```
 
@@ -834,7 +834,7 @@ sudo DOKKU_TAG=v0.26.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.26.2/bootstrap.sh
+wget https://dokku.com/install/v0.26.2/bootstrap.sh
 sudo DOKKU_TAG=v0.26.2 bash bootstrap.sh
 ```
 
@@ -852,7 +852,7 @@ sudo DOKKU_TAG=v0.26.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.26.1/bootstrap.sh
+wget https://dokku.com/install/v0.26.1/bootstrap.sh
 sudo DOKKU_TAG=v0.26.1 bash bootstrap.sh
 ```
 
@@ -869,7 +869,7 @@ sudo DOKKU_TAG=v0.26.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.26.0/bootstrap.sh
+wget https://dokku.com/install/v0.26.0/bootstrap.sh
 sudo DOKKU_TAG=v0.26.0 bash bootstrap.sh
 ```
 
@@ -912,7 +912,7 @@ See the [0.26.0 migration guide](/docs/appendices/0.26.0-migration-guide.md) for
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.25.7/bootstrap.sh
+wget https://dokku.com/install/v0.25.7/bootstrap.sh
 sudo DOKKU_TAG=v0.25.7 bash bootstrap.sh
 ```
 
@@ -938,7 +938,7 @@ sudo DOKKU_TAG=v0.25.7 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.25.6/bootstrap.sh
+wget https://dokku.com/install/v0.25.6/bootstrap.sh
 sudo DOKKU_TAG=v0.25.6 bash bootstrap.sh
 ```
 
@@ -972,7 +972,7 @@ sudo DOKKU_TAG=v0.25.6 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.25.5/bootstrap.sh
+wget https://dokku.com/install/v0.25.5/bootstrap.sh
 sudo DOKKU_TAG=v0.25.5 bash bootstrap.sh
 ```
 
@@ -1019,7 +1019,7 @@ sudo DOKKU_TAG=v0.25.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.25.4/bootstrap.sh
+wget https://dokku.com/install/v0.25.4/bootstrap.sh
 sudo DOKKU_TAG=v0.25.4 bash bootstrap.sh
 ```
 
@@ -1041,7 +1041,7 @@ sudo DOKKU_TAG=v0.25.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.25.3/bootstrap.sh
+wget https://dokku.com/install/v0.25.3/bootstrap.sh
 sudo DOKKU_TAG=v0.25.3 bash bootstrap.sh
 ```
 
@@ -1067,7 +1067,7 @@ sudo DOKKU_TAG=v0.25.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.25.2/bootstrap.sh
+wget https://dokku.com/install/v0.25.2/bootstrap.sh
 sudo DOKKU_TAG=v0.25.2 bash bootstrap.sh
 ```
 
@@ -1096,7 +1096,7 @@ sudo DOKKU_TAG=v0.25.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.25.1/bootstrap.sh
+wget https://dokku.com/install/v0.25.1/bootstrap.sh
 sudo DOKKU_TAG=v0.25.1 bash bootstrap.sh
 ```
 
@@ -1113,7 +1113,7 @@ sudo DOKKU_TAG=v0.25.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.25.0/bootstrap.sh
+wget https://dokku.com/install/v0.25.0/bootstrap.sh
 sudo DOKKU_TAG=v0.25.0 bash bootstrap.sh
 ```
 
@@ -1198,7 +1198,7 @@ See the [0.25.0 migration guide](/docs/appendices/0.25.0-migration-guide.md) for
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.10/bootstrap.sh
+wget https://dokku.com/install/v0.24.10/bootstrap.sh
 sudo DOKKU_TAG=v0.24.10 bash bootstrap.sh
 ```
 
@@ -1220,7 +1220,7 @@ sudo DOKKU_TAG=v0.24.10 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.9/bootstrap.sh
+wget https://dokku.com/install/v0.24.9/bootstrap.sh
 sudo DOKKU_TAG=v0.24.9 bash bootstrap.sh
 ```
 
@@ -1249,7 +1249,7 @@ sudo DOKKU_TAG=v0.24.9 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.8/bootstrap.sh
+wget https://dokku.com/install/v0.24.8/bootstrap.sh
 sudo DOKKU_TAG=v0.24.8 bash bootstrap.sh
 ```
 
@@ -1281,7 +1281,7 @@ sudo DOKKU_TAG=v0.24.8 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.7/bootstrap.sh
+wget https://dokku.com/install/v0.24.7/bootstrap.sh
 sudo DOKKU_TAG=v0.24.7 bash bootstrap.sh
 ```
 
@@ -1298,7 +1298,7 @@ sudo DOKKU_TAG=v0.24.7 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.6/bootstrap.sh
+wget https://dokku.com/install/v0.24.6/bootstrap.sh
 sudo DOKKU_TAG=v0.24.6 bash bootstrap.sh
 ```
 
@@ -1325,7 +1325,7 @@ sudo DOKKU_TAG=v0.24.6 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.5/bootstrap.sh
+wget https://dokku.com/install/v0.24.5/bootstrap.sh
 sudo DOKKU_TAG=v0.24.5 bash bootstrap.sh
 ```
 
@@ -1346,7 +1346,7 @@ sudo DOKKU_TAG=v0.24.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.4/bootstrap.sh
+wget https://dokku.com/install/v0.24.4/bootstrap.sh
 sudo DOKKU_TAG=v0.24.4 bash bootstrap.sh
 ```
 
@@ -1387,7 +1387,7 @@ sudo DOKKU_TAG=v0.24.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.3/bootstrap.sh
+wget https://dokku.com/install/v0.24.3/bootstrap.sh
 sudo DOKKU_TAG=v0.24.3 bash bootstrap.sh
 ```
 
@@ -1411,7 +1411,7 @@ sudo DOKKU_TAG=v0.24.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.2/bootstrap.sh
+wget https://dokku.com/install/v0.24.2/bootstrap.sh
 sudo DOKKU_TAG=v0.24.2 bash bootstrap.sh
 ```
 
@@ -1430,7 +1430,7 @@ sudo DOKKU_TAG=v0.24.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.1/bootstrap.sh
+wget https://dokku.com/install/v0.24.1/bootstrap.sh
 sudo DOKKU_TAG=v0.24.1 bash bootstrap.sh
 ```
 
@@ -1449,7 +1449,7 @@ sudo DOKKU_TAG=v0.24.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.24.0/bootstrap.sh
+wget https://dokku.com/install/v0.24.0/bootstrap.sh
 sudo DOKKU_TAG=v0.24.0 bash bootstrap.sh
 ```
 
@@ -1483,7 +1483,7 @@ See the [0.24.0 migration guide](/docs/appendices/0.24.0-migration-guide.md) for
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.23.9/bootstrap.sh
+wget https://dokku.com/install/v0.23.9/bootstrap.sh
 sudo DOKKU_TAG=v0.23.9 bash bootstrap.sh
 ```
 
@@ -1501,7 +1501,7 @@ sudo DOKKU_TAG=v0.23.9 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.23.8/bootstrap.sh
+wget https://dokku.com/install/v0.23.8/bootstrap.sh
 sudo DOKKU_TAG=v0.23.8 bash bootstrap.sh
 ```
 
@@ -1529,7 +1529,7 @@ sudo DOKKU_TAG=v0.23.8 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.23.7/bootstrap.sh
+wget https://dokku.com/install/v0.23.7/bootstrap.sh
 sudo DOKKU_TAG=v0.23.7 bash bootstrap.sh
 ```
 
@@ -1558,7 +1558,7 @@ sudo DOKKU_TAG=v0.23.7 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.23.6/bootstrap.sh
+wget https://dokku.com/install/v0.23.6/bootstrap.sh
 sudo DOKKU_TAG=v0.23.6 bash bootstrap.sh
 ```
 
@@ -1575,7 +1575,7 @@ sudo DOKKU_TAG=v0.23.6 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.23.5/bootstrap.sh
+wget https://dokku.com/install/v0.23.5/bootstrap.sh
 sudo DOKKU_TAG=v0.23.5 bash bootstrap.sh
 ```
 
@@ -1596,7 +1596,7 @@ sudo DOKKU_TAG=v0.23.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.23.4/bootstrap.sh
+wget https://dokku.com/install/v0.23.4/bootstrap.sh
 sudo DOKKU_TAG=v0.23.4 bash bootstrap.sh
 ```
 
@@ -1614,7 +1614,7 @@ sudo DOKKU_TAG=v0.23.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.23.3/bootstrap.sh
+wget https://dokku.com/install/v0.23.3/bootstrap.sh
 sudo DOKKU_TAG=v0.23.3 bash bootstrap.sh
 ```
 
@@ -1648,7 +1648,7 @@ sudo DOKKU_TAG=v0.23.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.23.2/bootstrap.sh
+wget https://dokku.com/install/v0.23.2/bootstrap.sh
 sudo DOKKU_TAG=v0.23.2 bash bootstrap.sh
 ```
 
@@ -1680,7 +1680,7 @@ sudo DOKKU_TAG=v0.23.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.23.1/bootstrap.sh
+wget https://dokku.com/install/v0.23.1/bootstrap.sh
 sudo DOKKU_TAG=v0.23.1 bash bootstrap.sh
 ```
 
@@ -1710,7 +1710,7 @@ sudo DOKKU_TAG=v0.23.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.23.0/bootstrap.sh
+wget https://dokku.com/install/v0.23.0/bootstrap.sh
 sudo DOKKU_TAG=v0.23.0 bash bootstrap.sh
 ```
 
@@ -1760,7 +1760,7 @@ See the [0.23.0 migration guide](/docs/appendices/0.23.0-migration-guide.md) for
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.22.9/bootstrap.sh
+wget https://dokku.com/install/v0.22.9/bootstrap.sh
 sudo DOKKU_TAG=v0.22.9 bash bootstrap.sh
 ```
 
@@ -1802,7 +1802,7 @@ sudo DOKKU_TAG=v0.22.9 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.22.8/bootstrap.sh
+wget https://dokku.com/install/v0.22.8/bootstrap.sh
 sudo DOKKU_TAG=v0.22.8 bash bootstrap.sh
 ```
 
@@ -1819,7 +1819,7 @@ sudo DOKKU_TAG=v0.22.8 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.22.7/bootstrap.sh
+wget https://dokku.com/install/v0.22.7/bootstrap.sh
 sudo DOKKU_TAG=v0.22.7 bash bootstrap.sh
 ```
 
@@ -1832,7 +1832,7 @@ sudo DOKKU_TAG=v0.22.7 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.22.6/bootstrap.sh
+wget https://dokku.com/install/v0.22.6/bootstrap.sh
 sudo DOKKU_TAG=v0.22.6 bash bootstrap.sh
 ```
 
@@ -1866,7 +1866,7 @@ sudo DOKKU_TAG=v0.22.6 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.22.5/bootstrap.sh
+wget https://dokku.com/install/v0.22.5/bootstrap.sh
 sudo DOKKU_TAG=v0.22.5 bash bootstrap.sh
 ```
 
@@ -1891,7 +1891,7 @@ sudo DOKKU_TAG=v0.22.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.22.4/bootstrap.sh
+wget https://dokku.com/install/v0.22.4/bootstrap.sh
 sudo DOKKU_TAG=v0.22.4 bash bootstrap.sh
 ```
 
@@ -1920,7 +1920,7 @@ sudo DOKKU_TAG=v0.22.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.22.3/bootstrap.sh
+wget https://dokku.com/install/v0.22.3/bootstrap.sh
 sudo DOKKU_TAG=v0.22.3 bash bootstrap.sh
 ```
 
@@ -1955,7 +1955,7 @@ sudo DOKKU_TAG=v0.22.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.22.2/bootstrap.sh
+wget https://dokku.com/install/v0.22.2/bootstrap.sh
 sudo DOKKU_TAG=v0.22.2 bash bootstrap.sh
 ```
 
@@ -1976,7 +1976,7 @@ sudo DOKKU_TAG=v0.22.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.22.1/bootstrap.sh
+wget https://dokku.com/install/v0.22.1/bootstrap.sh
 sudo DOKKU_TAG=v0.22.1 bash bootstrap.sh
 ```
 
@@ -2022,7 +2022,7 @@ sudo DOKKU_TAG=v0.22.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.22.0/bootstrap.sh
+wget https://dokku.com/install/v0.22.0/bootstrap.sh
 sudo DOKKU_TAG=v0.22.0 bash bootstrap.sh
 ```
 
@@ -2108,7 +2108,7 @@ See the [0.22.0 migration guide](/docs/appendices/0.22.0-migration-guide.md) for
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.21.4/bootstrap.sh
+wget https://dokku.com/install/v0.21.4/bootstrap.sh
 sudo DOKKU_TAG=v0.21.4 bash bootstrap.sh
 ```
 
@@ -2138,7 +2138,7 @@ sudo DOKKU_TAG=v0.21.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.21.3/bootstrap.sh
+wget https://dokku.com/install/v0.21.3/bootstrap.sh
 sudo DOKKU_TAG=v0.21.3 bash bootstrap.sh
 ```
 
@@ -2156,7 +2156,7 @@ sudo DOKKU_TAG=v0.21.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.21.2/bootstrap.sh
+wget https://dokku.com/install/v0.21.2/bootstrap.sh
 sudo DOKKU_TAG=v0.21.2 bash bootstrap.sh
 ```
 
@@ -2186,7 +2186,7 @@ sudo DOKKU_TAG=v0.21.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.21.1/bootstrap.sh
+wget https://dokku.com/install/v0.21.1/bootstrap.sh
 sudo DOKKU_TAG=v0.21.1 bash bootstrap.sh
 ```
 
@@ -2287,7 +2287,7 @@ sudo DOKKU_TAG=v0.21.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.20.4/bootstrap.sh
+wget https://dokku.com/install/v0.20.4/bootstrap.sh
 sudo DOKKU_TAG=v0.20.4 bash bootstrap.sh
 ```
 
@@ -2310,7 +2310,7 @@ sudo DOKKU_TAG=v0.20.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.20.3/bootstrap.sh
+wget https://dokku.com/install/v0.20.3/bootstrap.sh
 sudo DOKKU_TAG=v0.20.3 bash bootstrap.sh
 ```
 
@@ -2329,7 +2329,7 @@ sudo DOKKU_TAG=v0.20.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.20.2/bootstrap.sh
+wget https://dokku.com/install/v0.20.2/bootstrap.sh
 sudo DOKKU_TAG=v0.20.2 bash bootstrap.sh
 ```
 
@@ -2347,7 +2347,7 @@ sudo DOKKU_TAG=v0.20.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.20.1/bootstrap.sh
+wget https://dokku.com/install/v0.20.1/bootstrap.sh
 sudo DOKKU_TAG=v0.20.1 bash bootstrap.sh
 ```
 
@@ -2378,7 +2378,7 @@ sudo DOKKU_TAG=v0.20.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.20.0/bootstrap.sh
+wget https://dokku.com/install/v0.20.0/bootstrap.sh
 sudo DOKKU_TAG=v0.20.0 bash bootstrap.sh
 ```
 
@@ -2451,7 +2451,7 @@ sudo DOKKU_TAG=v0.20.0 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.13/bootstrap.sh
+wget https://dokku.com/install/v0.19.13/bootstrap.sh
 sudo DOKKU_TAG=v0.19.13 bash bootstrap.sh
 ```
 
@@ -2468,7 +2468,7 @@ sudo DOKKU_TAG=v0.19.13 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.12/bootstrap.sh
+wget https://dokku.com/install/v0.19.12/bootstrap.sh
 sudo DOKKU_TAG=v0.19.12 bash bootstrap.sh
 ```
 
@@ -2500,7 +2500,7 @@ sudo DOKKU_TAG=v0.19.12 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.11/bootstrap.sh
+wget https://dokku.com/install/v0.19.11/bootstrap.sh
 sudo DOKKU_TAG=v0.19.11 bash bootstrap.sh
 ```
 
@@ -2521,7 +2521,7 @@ sudo DOKKU_TAG=v0.19.11 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.10/bootstrap.sh
+wget https://dokku.com/install/v0.19.10/bootstrap.sh
 sudo DOKKU_TAG=v0.19.10 bash bootstrap.sh
 ```
 
@@ -2562,7 +2562,7 @@ sudo DOKKU_TAG=v0.19.10 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.9/bootstrap.sh
+wget https://dokku.com/install/v0.19.9/bootstrap.sh
 sudo DOKKU_TAG=v0.19.9 bash bootstrap.sh
 ```
 
@@ -2582,7 +2582,7 @@ sudo DOKKU_TAG=v0.19.9 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.8/bootstrap.sh
+wget https://dokku.com/install/v0.19.8/bootstrap.sh
 sudo DOKKU_TAG=v0.19.8 bash bootstrap.sh
 ```
 
@@ -2591,7 +2591,7 @@ sudo DOKKU_TAG=v0.19.8 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.7/bootstrap.sh
+wget https://dokku.com/install/v0.19.7/bootstrap.sh
 sudo DOKKU_TAG=v0.19.7 bash bootstrap.sh
 ```
 
@@ -2609,7 +2609,7 @@ sudo DOKKU_TAG=v0.19.7 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.6/bootstrap.sh
+wget https://dokku.com/install/v0.19.6/bootstrap.sh
 sudo DOKKU_TAG=v0.19.6 bash bootstrap.sh
 ```
 
@@ -2624,7 +2624,7 @@ sudo DOKKU_TAG=v0.19.6 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.5/bootstrap.sh
+wget https://dokku.com/install/v0.19.5/bootstrap.sh
 sudo DOKKU_TAG=v0.19.5 bash bootstrap.sh
 ```
 
@@ -2637,7 +2637,7 @@ sudo DOKKU_TAG=v0.19.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.4/bootstrap.sh
+wget https://dokku.com/install/v0.19.4/bootstrap.sh
 sudo DOKKU_TAG=v0.19.4 bash bootstrap.sh
 ```
 
@@ -2650,7 +2650,7 @@ sudo DOKKU_TAG=v0.19.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.3/bootstrap.sh
+wget https://dokku.com/install/v0.19.3/bootstrap.sh
 sudo DOKKU_TAG=v0.19.3 bash bootstrap.sh
 ```
 
@@ -2687,7 +2687,7 @@ sudo DOKKU_TAG=v0.19.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.2/bootstrap.sh
+wget https://dokku.com/install/v0.19.2/bootstrap.sh
 sudo DOKKU_TAG=v0.19.2 bash bootstrap.sh
 ```
 
@@ -2700,7 +2700,7 @@ sudo DOKKU_TAG=v0.19.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.1/bootstrap.sh
+wget https://dokku.com/install/v0.19.1/bootstrap.sh
 sudo DOKKU_TAG=v0.19.1 bash bootstrap.sh
 ```
 
@@ -2713,7 +2713,7 @@ sudo DOKKU_TAG=v0.19.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.19.0/bootstrap.sh
+wget https://dokku.com/install/v0.19.0/bootstrap.sh
 sudo DOKKU_TAG=v0.19.0 bash bootstrap.sh
 ```
 
@@ -2756,7 +2756,7 @@ sudo DOKKU_TAG=v0.19.0 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.18.5/bootstrap.sh
+wget https://dokku.com/install/v0.18.5/bootstrap.sh
 sudo DOKKU_TAG=v0.18.5 bash bootstrap.sh
 ```
 
@@ -2769,7 +2769,7 @@ sudo DOKKU_TAG=v0.18.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.18.4/bootstrap.sh
+wget https://dokku.com/install/v0.18.4/bootstrap.sh
 sudo DOKKU_TAG=v0.18.4 bash bootstrap.sh
 ```
 
@@ -2782,7 +2782,7 @@ sudo DOKKU_TAG=v0.18.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.18.3/bootstrap.sh
+wget https://dokku.com/install/v0.18.3/bootstrap.sh
 sudo DOKKU_TAG=v0.18.3 bash bootstrap.sh
 ```
 
@@ -2807,7 +2807,7 @@ sudo DOKKU_TAG=v0.18.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.18.2/bootstrap.sh
+wget https://dokku.com/install/v0.18.2/bootstrap.sh
 sudo DOKKU_TAG=v0.18.2 bash bootstrap.sh
 ```
 
@@ -2829,7 +2829,7 @@ sudo DOKKU_TAG=v0.18.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.18.1/bootstrap.sh
+wget https://dokku.com/install/v0.18.1/bootstrap.sh
 sudo DOKKU_TAG=v0.18.1 bash bootstrap.sh
 ```
 
@@ -2843,7 +2843,7 @@ sudo DOKKU_TAG=v0.18.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.18.0/bootstrap.sh
+wget https://dokku.com/install/v0.18.0/bootstrap.sh
 sudo DOKKU_TAG=v0.18.0 bash bootstrap.sh
 ```
 
@@ -2885,7 +2885,7 @@ sudo DOKKU_TAG=v0.18.0 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.17.9/bootstrap.sh
+wget https://dokku.com/install/v0.17.9/bootstrap.sh
 sudo DOKKU_TAG=v0.17.9 bash bootstrap.sh
 ```
 
@@ -2902,7 +2902,7 @@ sudo DOKKU_TAG=v0.17.9 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.17.8/bootstrap.sh
+wget https://dokku.com/install/v0.17.8/bootstrap.sh
 sudo DOKKU_TAG=v0.17.8 bash bootstrap.sh
 ```
 
@@ -2919,7 +2919,7 @@ sudo DOKKU_TAG=v0.17.8 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.17.7/bootstrap.sh
+wget https://dokku.com/install/v0.17.7/bootstrap.sh
 sudo DOKKU_TAG=v0.17.7 bash bootstrap.sh
 ```
 
@@ -2940,7 +2940,7 @@ sudo DOKKU_TAG=v0.17.7 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.17.6/bootstrap.sh
+wget https://dokku.com/install/v0.17.6/bootstrap.sh
 sudo DOKKU_TAG=v0.17.6 bash bootstrap.sh
 ```
 
@@ -2953,7 +2953,7 @@ sudo DOKKU_TAG=v0.17.6 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.17.5/bootstrap.sh
+wget https://dokku.com/install/v0.17.5/bootstrap.sh
 sudo DOKKU_TAG=v0.17.5 bash bootstrap.sh
 ```
 
@@ -2966,7 +2966,7 @@ sudo DOKKU_TAG=v0.17.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.17.4/bootstrap.sh
+wget https://dokku.com/install/v0.17.4/bootstrap.sh
 sudo DOKKU_TAG=v0.17.4 bash bootstrap.sh
 ```
 
@@ -2979,7 +2979,7 @@ sudo DOKKU_TAG=v0.17.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.17.3/bootstrap.sh
+wget https://dokku.com/install/v0.17.3/bootstrap.sh
 sudo DOKKU_TAG=v0.17.3 bash bootstrap.sh
 ```
 
@@ -2997,7 +2997,7 @@ sudo DOKKU_TAG=v0.17.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.17.2/bootstrap.sh
+wget https://dokku.com/install/v0.17.2/bootstrap.sh
 sudo DOKKU_TAG=v0.17.2 bash bootstrap.sh
 ```
 
@@ -3010,7 +3010,7 @@ sudo DOKKU_TAG=v0.17.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.17.1/bootstrap.sh
+wget https://dokku.com/install/v0.17.1/bootstrap.sh
 sudo DOKKU_TAG=v0.17.1 bash bootstrap.sh
 ```
 
@@ -3023,7 +3023,7 @@ sudo DOKKU_TAG=v0.17.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.17.0/bootstrap.sh
+wget https://dokku.com/install/v0.17.0/bootstrap.sh
 sudo DOKKU_TAG=v0.17.0 bash bootstrap.sh
 ```
 
@@ -3060,7 +3060,7 @@ sudo DOKKU_TAG=v0.17.0 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.16.4/bootstrap.sh
+wget https://dokku.com/install/v0.16.4/bootstrap.sh
 sudo DOKKU_TAG=v0.16.4 bash bootstrap.sh
 ```
 
@@ -3077,7 +3077,7 @@ sudo DOKKU_TAG=v0.16.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.16.3/bootstrap.sh
+wget https://dokku.com/install/v0.16.3/bootstrap.sh
 sudo DOKKU_TAG=v0.16.3 bash bootstrap.sh
 ```
 
@@ -3101,7 +3101,7 @@ sudo DOKKU_TAG=v0.16.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.16.2/bootstrap.sh
+wget https://dokku.com/install/v0.16.2/bootstrap.sh
 sudo DOKKU_TAG=v0.16.2 bash bootstrap.sh
 ```
 
@@ -3115,7 +3115,7 @@ sudo DOKKU_TAG=v0.16.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.16.1/bootstrap.sh
+wget https://dokku.com/install/v0.16.1/bootstrap.sh
 sudo DOKKU_TAG=v0.16.1 bash bootstrap.sh
 ```
 
@@ -3132,7 +3132,7 @@ sudo DOKKU_TAG=v0.16.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.16.0/bootstrap.sh
+wget https://dokku.com/install/v0.16.0/bootstrap.sh
 sudo DOKKU_TAG=v0.16.0 bash bootstrap.sh
 ```
 
@@ -3158,7 +3158,7 @@ sudo DOKKU_TAG=v0.16.0 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.15.5/bootstrap.sh
+wget https://dokku.com/install/v0.15.5/bootstrap.sh
 sudo DOKKU_TAG=v0.15.5 bash bootstrap.sh
 ```
 
@@ -3177,7 +3177,7 @@ sudo DOKKU_TAG=v0.15.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.15.4/bootstrap.sh
+wget https://dokku.com/install/v0.15.4/bootstrap.sh
 sudo DOKKU_TAG=v0.15.4 bash bootstrap.sh
 ```
 
@@ -3204,7 +3204,7 @@ sudo DOKKU_TAG=v0.15.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.15.3/bootstrap.sh
+wget https://dokku.com/install/v0.15.3/bootstrap.sh
 sudo DOKKU_TAG=v0.15.3 bash bootstrap.sh
 ```
 
@@ -3217,7 +3217,7 @@ sudo DOKKU_TAG=v0.15.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.15.2/bootstrap.sh
+wget https://dokku.com/install/v0.15.2/bootstrap.sh
 sudo DOKKU_TAG=v0.15.2 bash bootstrap.sh
 ```
 
@@ -3230,7 +3230,7 @@ sudo DOKKU_TAG=v0.15.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.15.1/bootstrap.sh
+wget https://dokku.com/install/v0.15.1/bootstrap.sh
 sudo DOKKU_TAG=v0.15.1 bash bootstrap.sh
 ```
 
@@ -3243,7 +3243,7 @@ sudo DOKKU_TAG=v0.15.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.15.0/bootstrap.sh
+wget https://dokku.com/install/v0.15.0/bootstrap.sh
 sudo DOKKU_TAG=v0.15.0 bash bootstrap.sh
 ```
 
@@ -3281,7 +3281,7 @@ sudo DOKKU_TAG=v0.15.0 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.14.6/bootstrap.sh
+wget https://dokku.com/install/v0.14.6/bootstrap.sh
 sudo DOKKU_TAG=v0.14.6 bash bootstrap.sh
 ```
 
@@ -3312,7 +3312,7 @@ sudo DOKKU_TAG=v0.14.6 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.14.5/bootstrap.sh
+wget https://dokku.com/install/v0.14.5/bootstrap.sh
 sudo DOKKU_TAG=v0.14.5 bash bootstrap.sh
 ```
 
@@ -3325,7 +3325,7 @@ sudo DOKKU_TAG=v0.14.5 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.14.4/bootstrap.sh
+wget https://dokku.com/install/v0.14.4/bootstrap.sh
 sudo DOKKU_TAG=v0.14.4 bash bootstrap.sh
 ```
 
@@ -3338,7 +3338,7 @@ sudo DOKKU_TAG=v0.14.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.14.3/bootstrap.sh
+wget https://dokku.com/install/v0.14.3/bootstrap.sh
 sudo DOKKU_TAG=v0.14.3 bash bootstrap.sh
 ```
 
@@ -3369,7 +3369,7 @@ sudo DOKKU_TAG=v0.14.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.14.2/bootstrap.sh
+wget https://dokku.com/install/v0.14.2/bootstrap.sh
 sudo DOKKU_TAG=v0.14.2 bash bootstrap.sh
 ```
 
@@ -3388,7 +3388,7 @@ sudo DOKKU_TAG=v0.14.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.14.1/bootstrap.sh
+wget https://dokku.com/install/v0.14.1/bootstrap.sh
 sudo DOKKU_TAG=v0.14.1 bash bootstrap.sh
 ```
 
@@ -3401,7 +3401,7 @@ sudo DOKKU_TAG=v0.14.1 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.14.0/bootstrap.sh
+wget https://dokku.com/install/v0.14.0/bootstrap.sh
 sudo DOKKU_TAG=v0.14.0 bash bootstrap.sh
 ```
 
@@ -3462,7 +3462,7 @@ sudo DOKKU_TAG=v0.14.0 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.13.4/bootstrap.sh
+wget https://dokku.com/install/v0.13.4/bootstrap.sh
 sudo DOKKU_TAG=v0.13.4 bash bootstrap.sh
 ```
 
@@ -3479,7 +3479,7 @@ sudo DOKKU_TAG=v0.13.4 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.13.3/bootstrap.sh
+wget https://dokku.com/install/v0.13.3/bootstrap.sh
 sudo DOKKU_TAG=v0.13.3 bash bootstrap.sh
 ```
 
@@ -3496,7 +3496,7 @@ sudo DOKKU_TAG=v0.13.3 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.13.2/bootstrap.sh
+wget https://dokku.com/install/v0.13.2/bootstrap.sh
 sudo DOKKU_TAG=v0.13.2 bash bootstrap.sh
 ```
 
@@ -3514,7 +3514,7 @@ sudo DOKKU_TAG=v0.13.2 bash bootstrap.sh
 Install/update via the bootstrap script:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.13.1/bootstrap.sh
+wget https://dokku.com/install/v0.13.1/bootstrap.sh
 sudo DOKKU_TAG=v0.13.1 bash bootstrap.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Otherwise, you will need to import the keypair manually after installation using
 To install the latest stable release, run the following commands as a user who has access to `sudo`:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/v0.29.4/bootstrap.sh
+wget https://dokku.com/install/v0.29.4/bootstrap.sh
 sudo DOKKU_TAG=v0.29.4 bash bootstrap.sh
 ```
 

--- a/contrib/release-dokku
+++ b/contrib/release-dokku
@@ -287,7 +287,7 @@ fn-repo-update-history-and-commit() {
   HISTORY="${HISTORY}"$'\n\n'"## ${NEXT_VERSION}"
   HISTORY="${HISTORY}"$'\n\n'"Install/update via the bootstrap script:"
   HISTORY="${HISTORY}"$'\n\n'"\`\`\`shell"
-  HISTORY="${HISTORY}"$'\n'"wget https://raw.githubusercontent.com/dokku/dokku/v${NEXT_VERSION}/bootstrap.sh"
+  HISTORY="${HISTORY}"$'\n'"wget https://dokku.com/install/v${NEXT_VERSION}/bootstrap.sh"
   HISTORY="${HISTORY}"$'\n'"sudo DOKKU_TAG=v${NEXT_VERSION} bash bootstrap.sh"
   HISTORY="${HISTORY}"$'\n'"\`\`\`"
 

--- a/docs/getting-started/advanced-installation.md
+++ b/docs/getting-started/advanced-installation.md
@@ -22,7 +22,7 @@ You can always install Dokku straight from the latest - potentially unstable - `
 
 ```shell
 # using a branch results in installing from source
-wget https://raw.githubusercontent.com/dokku/dokku/master/bootstrap.sh;
+wget https://dokku.com/install/master/bootstrap.sh;
 sudo DOKKU_BRANCH=master bash bootstrap.sh
 ```
 
@@ -47,7 +47,7 @@ sudo SSHCOMMAND_URL=https://raw.githubusercontent.com/yourusername/sshcommand/ma
 The bootstrap script allows the Dokku repository URL to be overridden to bootstrap a host from your own clone of Dokku using the `DOKKU_REPO` environment variable. Example:
 
 ```shell
-wget https://raw.githubusercontent.com/dokku/dokku/master/bootstrap.sh;
+wget https://dokku.com/install/master/bootstrap.sh;
 chmod +x bootstrap.sh
 sudo DOKKU_REPO=https://github.com/yourusername/dokku.git DOKKU_BRANCH=master ./bootstrap.sh
 ```

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -38,7 +38,7 @@ To install the latest stable version of Dokku, you can run the following shell c
 
 ```shell
 # for debian systems, installs Dokku via apt-get
-wget https://raw.githubusercontent.com/dokku/dokku/v0.29.4/bootstrap.sh
+wget https://dokku.com/install/v0.29.4/bootstrap.sh
 sudo DOKKU_TAG=v0.29.4 bash bootstrap.sh
 ```
 

--- a/docs/home.html
+++ b/docs/home.html
@@ -117,7 +117,7 @@
                             <br>
                             <p class="line">
                                 <span class="prompt">$</span>
-                                <span class="command">wget https://raw.githubusercontent.com/dokku/dokku/v0.29.4/bootstrap.sh</span>
+                                <span class="command">wget https://dokku.com/install/v0.29.4/bootstrap.sh</span>
                             </p>
                             <p class="line">
                                 <span class="output"># run the installer</span>


### PR DESCRIPTION
This brings the installer to the dokku.com domain, from which we can point it wherever we want.