### PR TITLE
Timeout build jobs within 45 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     strategy:
       fail-fast: true
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
If a build goes on for longer than 30 minutes, it is likely stalled due to a buildx issue. We add a 15 minute buffer in case our build times increase.