### PR TITLE
Remove deprecated ability to call logs:failed without specifying an app or --all flag

### DIFF
--- a/docs/deployment/logs.md
+++ b/docs/deployment/logs.md
@@ -2,7 +2,7 @@
 
 ```
 logs <app> [-h|--help] [-t|--tail] [-n|--num num] [-q|--quiet] [-p|--ps process]  # Display recent log output
-logs:failed [--all|<app>]                                                  # Shows the last failed deploy logs
+logs:failed --all|<app>                                                    # Shows the last failed deploy logs
 logs:report [<app>] [<flag>]                                               # Displays a logs report for one or more apps
 logs:set [--global|<app>] <key> <value>                                    # Set or clear a logs property for an app
 logs:vector-logs [--num num] [--tail]                                      # Display vector log output

--- a/plugins/logs/subcommands.go
+++ b/plugins/logs/subcommands.go
@@ -37,11 +37,6 @@ func CommandFailed(appName string, allApps bool) error {
 		return common.RunCommandAgainstAllAppsSerially(GetFailedLogs, "logs:failed")
 	}
 
-	if appName == "" {
-		common.LogWarn("Deprecated: logs:failed specified without app, assuming --all")
-		return common.RunCommandAgainstAllAppsSerially(GetFailedLogs, "logs:failed")
-	}
-
 	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}


### PR DESCRIPTION
This option was deprecated in Dokku 0.22.0.