### PR TITLE
Trigger nginx proxy rebuild early to avoid downtime if deploying large numbers of processes

### DIFF
--- a/plugins/nginx-vhosts/scheduler-post-deploy-process
+++ b/plugins/nginx-vhosts/scheduler-post-deploy-process
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/nginx-vhosts/functions"
+
+trigger-nginx-vhosts-scheduler-post-deploy-process() {
+  declare desc="nginx-vhosts scheduler-post-deploy-process plugin trigger"
+  declare trigger="scheduler-post-deploy-process"
+  declare APP="$1" PROCESS_TYPE="$2"
+
+  if [[ "$PROCESS_TYPE" != "web" ]]; then
+    return
+  fi
+
+  if [[ "$(plugn trigger proxy-type "$APP")" != "nginx" ]]; then
+    return
+  fi
+
+  dokku_log_info1 "Triggering early nginx proxy rebuild"
+  plugn trigger proxy-build-config "$APP"
+}
+
+trigger-nginx-vhosts-scheduler-post-deploy-process "$@"

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process
@@ -51,6 +51,8 @@ main() {
   PARALLEL_DEPLOY_COUNT="$(plugn trigger "app-json-process-deploy-parallelism" "$APP" "$PROC_TYPE")"
   DOKKU_CHECKS_DISABLED="$DOKKU_CHECKS_DISABLED" INJECT_INIT_FLAG="$INJECT_INIT_FLAG" parallel --will-cite --halt soon,fail=1 --jobs "$PARALLEL_DEPLOY_COUNT" --ungroup <"$PROCESS_TMP_FILE"
 
+  plugn trigger scheduler-post-deploy-process "$APP" "$PROC_TYPE"
+
   # cleanup when we scale down
   if [[ "$PROC_COUNT" == 0 ]]; then
     local CONTAINER_IDX_OFFSET=0


### PR DESCRIPTION
Due to how the nginx proxy implementation works, if an app has either many process types or many containers for a process type other than web, it is possible to see downtime on the web process due to the old web containers rotating out _before_ we reload the nginx config.

The correct fix would be to use some sort of dns-based resolution for the nginx config, but pending that change, we reload nginx twice now - ugh - to avoid this.