### PR TITLE
Standardize how plugins manage the data directories

### DIFF
--- a/plugins/app-json/triggers.go
+++ b/plugins/app-json/triggers.go
@@ -2,7 +2,6 @@ package appjson
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/dokku/dokku/plugins/common"
 )

--- a/plugins/app-json/triggers.go
+++ b/plugins/app-json/triggers.go
@@ -58,7 +58,7 @@ func TriggerPostAppCloneSetup(oldAppName string, newAppName string) error {
 
 // TriggerPostAppRename removes the old app data
 func TriggerPostAppRename(oldAppName string, newAppName string) error {
-	return common.RemoveAppDataDirectory("app-json", oldAppName)
+	return common.MigrateAppDataDirectory("app-json", oldAppName, newAppName)
 }
 
 // TriggerPostAppRenameSetup renames app-json files
@@ -81,7 +81,7 @@ func TriggerPostCreate(appName string) error {
 
 // TriggerPostDelete destroys the app-json data for a given app container
 func TriggerPostDelete(appName string) error {
-	dataErr := os.RemoveAll(common.GetAppDataDirectory("app-json", appName))
+	dataErr := common.RemoveAppDataDirectory("app-json", appName)
 	propertyErr := common.PropertyDestroy("app-json", appName)
 
 	if dataErr != nil {

--- a/plugins/builder-lambda/install
+++ b/plugins/builder-lambda/install
@@ -8,9 +8,7 @@ trigger-builder-lambda-install() {
   declare trigger="install"
 
   fn-plugin-property-setup "builder-lambda"
-
-  mkdir -p "${DOKKU_LIB_ROOT}/data/builder-lambda"
-  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/builder-lambda"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet setup-data-directory "builder-lambda"
 }
 
 trigger-builder-lambda-install "$@"

--- a/plugins/builder-lambda/post-app-clone-setup
+++ b/plugins/builder-lambda/post-app-clone-setup
@@ -9,6 +9,7 @@ trigger-builder-lambda-post-app-clone-setup() {
   declare OLD_APP="$1" NEW_APP="$2"
 
   fn-plugin-property-clone "builder-lambda" "$OLD_APP" "$NEW_APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet clone-data-directory "builder-lambda" "$OLD_APP" "$NEW_APP"
 }
 
 trigger-builder-lambda-post-app-clone-setup "$@"

--- a/plugins/builder-lambda/post-app-rename-setup
+++ b/plugins/builder-lambda/post-app-rename-setup
@@ -10,6 +10,7 @@ trigger-builder-lambda-post-app-rename-setup() {
 
   fn-plugin-property-clone "builder-lambda" "$OLD_APP" "$NEW_APP"
   fn-plugin-property-destroy "builder-lambda" "$OLD_APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet migrate-data-directory "builder-lambda" "$OLD_APP" "$NEW_APP"
 }
 
 trigger-builder-lambda-post-app-rename-setup "$@"

--- a/plugins/builder-lambda/post-create
+++ b/plugins/builder-lambda/post-create
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-builder-lambda-post-create() {
+  declare desc="builder-lambda post-create plugin trigger"
+  declare trigger="post-create"
+  declare APP="$1"
+
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet create-data-directory "builder-lambda" "$APP"
+}
+
+trigger-builder-lambda-post-create "$@"

--- a/plugins/builder-lambda/post-delete
+++ b/plugins/builder-lambda/post-delete
@@ -9,7 +9,7 @@ trigger-builder-lambda-post-delete() {
   declare APP="$1"
 
   fn-plugin-property-destroy "builder-lambda" "$APP"
-  rm -rf "${DOKKU_LIB_ROOT}/data/builder-lambda/$APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet migrate-data-directory "builder-lambda" "$APP"
 }
 
 trigger-builder-lambda-post-delete "$@"

--- a/plugins/caddy-vhosts/install
+++ b/plugins/caddy-vhosts/install
@@ -8,10 +8,8 @@ trigger-caddy-install() {
   declare desc="installs the caddy plugin"
   declare trigger="install"
 
-  mkdir -p "${DOKKU_LIB_ROOT}/data/caddy"
-  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/caddy"
-
   fn-plugin-property-setup "caddy"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet setup-data-directory "caddy"
 }
 
 trigger-caddy-install "$@"

--- a/plugins/caddy-vhosts/post-app-clone-setup
+++ b/plugins/caddy-vhosts/post-app-clone-setup
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-caddy-vhosts-post-app-clone-setup() {
+  declare desc="sets up properties for new app"
+  declare trigger="post-app-clone-setup"
+  declare OLD_APP="$1" NEW_APP="$2"
+
+  fn-plugin-property-clone "caddy-vhosts" "$OLD_APP" "$NEW_APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet clone-data-directory "caddy-vhosts" "$OLD_APP" "$NEW_APP"
+}
+
+trigger-caddy-vhosts-post-app-clone-setup "$@"

--- a/plugins/caddy-vhosts/post-app-rename-setup
+++ b/plugins/caddy-vhosts/post-app-rename-setup
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-caddy-vhosts-post-app-rename-setup() {
+  declare desc="updates settings for new app"
+  declare trigger="post-app-rename-setup"
+  declare OLD_APP="$1" NEW_APP="$2"
+
+  fn-plugin-property-clone "caddy-vhosts" "$OLD_APP" "$NEW_APP"
+  fn-plugin-property-destroy "caddy-vhosts" "$OLD_APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet migrate-data-directory "caddy-vhosts" "$OLD_APP" "$NEW_APP"
+}
+
+trigger-caddy-vhosts-post-app-rename-setup "$@"

--- a/plugins/caddy-vhosts/post-create
+++ b/plugins/caddy-vhosts/post-create
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-caddy-vhosts-post-create() {
+  declare desc="caddy-vhosts post-create plugin trigger"
+  declare trigger="post-create"
+  declare APP="$1"
+
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet create-data-directory "caddy-vhosts" "$APP"
+}
+
+trigger-caddy-vhosts-post-create "$@"

--- a/plugins/caddy-vhosts/post-delete
+++ b/plugins/caddy-vhosts/post-delete
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-caddy-vhosts-post-delete() {
+  declare desc="destroys the caddy-vhosts properties for a given app"
+  declare trigger="post-delete"
+  declare APP="$1"
+
+  fn-plugin-property-destroy "caddy-vhosts" "$APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet migrate-data-directory "caddy-vhosts" "$APP"
+}
+
+trigger-caddy-vhosts-post-delete "$@"

--- a/plugins/common/data.go
+++ b/plugins/common/data.go
@@ -46,6 +46,15 @@ func GetDataDirectory(pluginName string) string {
 	return filepath.Join(MustGetEnv("DOKKU_LIB_ROOT"), "data", pluginName)
 }
 
+// MigrateAppDataDirectory migrates the data directory for one app to another
+func MigrateAppDataDirectory(pluginName string, oldAppName string, newAppName string) error {
+	if err := CloneAppData(pluginName, oldAppName, newAppName); err != nil {
+		return err
+	}
+
+	return RemoveAppDataDirectory(pluginName, oldAppName)
+}
+
 // RemoveAppDataDirectory removes the path to the data directory for the given plugin/app combination
 func RemoveAppDataDirectory(pluginName, appName string) error {
 	return os.RemoveAll(GetAppDataDirectory(pluginName, appName))

--- a/plugins/common/src/common/common.go
+++ b/plugins/common/src/common/common.go
@@ -20,6 +20,19 @@ func main() {
 
 	var err error
 	switch cmd {
+	case "clone-data-directory":
+		pluginName := flag.Arg(1)
+		oldAppName := flag.Arg(2)
+		newAppName := flag.Arg(3)
+		err = common.CloneAppData(pluginName, oldAppName, newAppName)
+	case "create-data-directory":
+		pluginName := flag.Arg(1)
+		appName := flag.Arg(2)
+		err = common.CreateAppDataDirectory(pluginName, appName)
+	case "delete-data-directory":
+		pluginName := flag.Arg(1)
+		appName := flag.Arg(2)
+		err = common.RemoveAppDataDirectory(pluginName, appName)
 	case "docker-cleanup":
 		appName := flag.Arg(1)
 		force := common.ToBool(flag.Arg(2))
@@ -47,12 +60,20 @@ func main() {
 		} else {
 			fmt.Print("false")
 		}
+	case "migrate-data-directory":
+		pluginName := flag.Arg(1)
+		oldAppName := flag.Arg(2)
+		newAppName := flag.Arg(3)
+		err = common.MigrateAppDataDirectory(pluginName, oldAppName, newAppName)
 	case "scheduler-detect":
 		appName := flag.Arg(1)
 		if *global {
 			appName = "--global"
 		}
 		fmt.Print(common.GetAppScheduler(appName))
+	case "setup-data-directory":
+		pluginName := flag.Arg(1)
+		err = common.SetupAppData(pluginName)
 	case "verify-app-name":
 		appName := flag.Arg(1)
 		err = common.VerifyAppName(appName)

--- a/plugins/git/install
+++ b/plugins/git/install
@@ -9,10 +9,9 @@ trigger-git-install() {
   declare desc="installs the git plugin"
   declare trigger="install"
 
-  mkdir -p "${DOKKU_LIB_ROOT}/data/git"
-  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/git"
-
   fn-plugin-property-setup "git"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet setup-data-directory "git"
+
   migrate_git_vars_0_12_0 "$@"
 }
 

--- a/plugins/git/post-app-clone-setup
+++ b/plugins/git/post-app-clone-setup
@@ -13,6 +13,7 @@ trigger-git-post-app-clone-setup() {
   fi
 
   fn-plugin-property-clone "git" "$OLD_APP" "$NEW_APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet clone-data-directory "git" "$OLD_APP" "$NEW_APP"
 }
 
 trigger-git-post-app-clone-setup "$@"

--- a/plugins/git/post-app-rename-setup
+++ b/plugins/git/post-app-rename-setup
@@ -14,6 +14,7 @@ trigger-git-post-app-rename-setup() {
 
   fn-plugin-property-clone "git" "$OLD_APP" "$NEW_APP"
   fn-plugin-property-destroy "git" "$OLD_APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet migrate-data-directory "git" "$OLD_APP" "$NEW_APP"
 }
 
 trigger-git-post-app-rename-setup "$@"

--- a/plugins/git/post-create
+++ b/plugins/git/post-create
@@ -9,6 +9,7 @@ trigger-git-post-create() {
   declare APP="$1"
 
   fn-git-create-hook "$APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet create-data-directory "git" "$APP"
 }
 
 trigger-git-post-create "$@"

--- a/plugins/git/post-delete
+++ b/plugins/git/post-delete
@@ -9,6 +9,7 @@ trigger-git-post-delete() {
   declare APP="$1"
 
   fn-plugin-property-destroy "git" "$APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet migrate-data-directory "git" "$APP"
 }
 
 trigger-git-post-delete "$@"

--- a/plugins/logs/triggers.go
+++ b/plugins/logs/triggers.go
@@ -118,7 +118,7 @@ func TriggerPostAppCloneSetup(oldAppName string, newAppName string) error {
 
 // TriggerPostAppRename removes the old app data
 func TriggerPostAppRename(oldAppName string, newAppName string) error {
-	return common.RemoveAppDataDirectory("logs", oldAppName)
+	return common.MigrateAppDataDirectory("logs", oldAppName, newAppName)
 }
 
 // TriggerPostAppRenameSetup renames logs files
@@ -141,7 +141,7 @@ func TriggerPostCreate(appName string) error {
 
 // TriggerPostDelete destroys the logs property for a given app container
 func TriggerPostDelete(appName string) error {
-	dataErr := os.RemoveAll(common.GetAppDataDirectory("logs", appName))
+	dataErr := common.RemoveAppDataDirectory("logs", appName)
 	propertyErr := common.PropertyDestroy("logs", appName)
 
 	if dataErr != nil {

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -119,8 +119,9 @@ trigger-nginx-vhosts-install() {
   [[ -f /etc/logrotate.d/nginx ]] && sed -i -e 's/create 0640 www-data dokku/create 0640 www-data adm/g' /etc/logrotate.d/nginx
 
   # Create nginx error templates
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet setup-data-directory "nginx-vhosts"
   mkdir -p "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors"
-  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/nginx-vhosts"
+  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors"
   cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/400-error.html" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors/400-error.html"
   cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/404-error.html" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors/404-error.html"
   cp "${PLUGIN_CORE_AVAILABLE_PATH}/nginx-vhosts/templates/500-error.html" "${DOKKU_LIB_ROOT}/data/nginx-vhosts/dokku-errors/500-error.html"

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -182,7 +182,7 @@ func TriggerPostAppCloneSetup(oldAppName string, newAppName string) error {
 
 // TriggerPostAppRename rebuilds the renamed app
 func TriggerPostAppRename(oldAppName string, newAppName string) error {
-	if err := common.RemoveAppDataDirectory("ps", oldAppName); err != nil {
+	if err := common.MigrateAppDataDirectory("ps", oldAppName, newAppName); err != nil {
 		return err
 	}
 

--- a/plugins/scheduler-docker-local/install
+++ b/plugins/scheduler-docker-local/install
@@ -9,10 +9,8 @@ trigger-scheduler-docker-local-install() {
   declare trigger="install"
   local DOKKU_PATH
 
-  mkdir -p "${DOKKU_LIB_ROOT}/data/scheduler-docker-local"
-  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/scheduler-docker-local"
-
   fn-plugin-property-setup "scheduler-docker-local"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet setup-data-directory "scheduler-docker-local"
 
   DOKKU_PATH="$(command -v dokku)"
 

--- a/plugins/scheduler-docker-local/post-app-clone-setup
+++ b/plugins/scheduler-docker-local/post-app-clone-setup
@@ -10,6 +10,7 @@ trigger-scheduler-docker-local-post-app-clone-setup() {
   local APP_ROOT="$DOKKU_ROOT/$NEW_APP"
 
   fn-plugin-property-clone "scheduler-docker-local" "$OLD_APP" "$NEW_APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet clone-data-directory "scheduler-docker-local" "$OLD_APP" "$NEW_APP"
   pushd "$APP_ROOT" >/dev/null
   find "$APP_ROOT" -type f -name 'CONTAINER.*' -exec rm {} \;
   popd &>/dev/null || pushd "/tmp" >/dev/null

--- a/plugins/scheduler-docker-local/post-app-rename-setup
+++ b/plugins/scheduler-docker-local/post-app-rename-setup
@@ -10,6 +10,7 @@ trigger-scheduler-docker-local-post-app-rename-setup() {
 
   fn-plugin-property-clone "scheduler-docker-local" "$OLD_APP" "$NEW_APP"
   fn-plugin-property-destroy "scheduler-docker-local" "$OLD_APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet migrate-data-directory "scheduler-docker-local" "$OLD_APP" "$NEW_APP"
 }
 
 trigger-scheduler-docker-local-post-app-rename-setup "$@"

--- a/plugins/scheduler-docker-local/post-create
+++ b/plugins/scheduler-docker-local/post-create
@@ -7,8 +7,7 @@ trigger-scheduler-docker-local-post-create() {
   declare trigger="post-create"
   declare APP="$1"
 
-  mkdir -p "${DOKKU_LIB_ROOT}/data/scheduler-docker-local/${APP}"
-  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/scheduler-docker-local/${APP}"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet create-data-directory "scheduler-docker-local" "$APP"
 }
 
 trigger-scheduler-docker-local-post-create "$@"

--- a/plugins/scheduler-docker-local/post-delete
+++ b/plugins/scheduler-docker-local/post-delete
@@ -9,9 +9,6 @@ trigger-scheduler-docker-local-post-delete() {
   declare trigger="post-delete"
   declare APP="$1"
 
-  fn-plugin-property-destroy "scheduler-docker-local" "$APP"
-  rm -rf "${DOKKU_LIB_ROOT}/data/scheduler-docker-local/$APP"
-
   local DOKKU_SCHEDULER=$(get_app_scheduler "$APP")
   if [[ "$DOKKU_SCHEDULER" != "docker-local" ]]; then
     return
@@ -29,6 +26,9 @@ trigger-scheduler-docker-local-post-delete() {
 
   # shellcheck disable=SC2046
   "$DOCKER_BIN" image remove $("$DOCKER_BIN" image list --quiet "$IMAGE_REPO" | xargs) &>/dev/null || true
+
+  fn-plugin-property-destroy "scheduler-docker-local" "$APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet migrate-data-directory "scheduler-docker-local" "$APP"
 }
 
 trigger-scheduler-docker-local-post-delete "$@"

--- a/plugins/storage/install
+++ b/plugins/storage/install
@@ -6,6 +6,7 @@ trigger-storage-install() {
   declare desc="storage install trigger"
   declare trigger="install"
 
+  # don't use the common golang helper because we don't want to recursively set permissions
   mkdir -p "${DOKKU_LIB_ROOT}/data/storage"
   chown "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/storage"
 

--- a/plugins/traefik-vhosts/install
+++ b/plugins/traefik-vhosts/install
@@ -8,10 +8,8 @@ trigger-traefik-install() {
   declare desc="installs the traefik plugin"
   declare trigger="install"
 
-  mkdir -p "${DOKKU_LIB_ROOT}/data/traefik"
-  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/traefik"
-
   fn-plugin-property-setup "traefik"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet setup-data-directory "traefik-vhosts"
 }
 
 trigger-traefik-install "$@"

--- a/plugins/traefik-vhosts/post-app-clone-setup
+++ b/plugins/traefik-vhosts/post-app-clone-setup
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-traefik-vhosts-post-app-clone-setup() {
+  declare desc="sets up properties for new app"
+  declare trigger="post-app-clone-setup"
+  declare OLD_APP="$1" NEW_APP="$2"
+
+  fn-plugin-property-clone "traefik-vhosts" "$OLD_APP" "$NEW_APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet clone-data-directory "traefik-vhosts" "$OLD_APP" "$NEW_APP"
+}
+
+trigger-traefik-vhosts-post-app-clone-setup "$@"

--- a/plugins/traefik-vhosts/post-app-rename-setup
+++ b/plugins/traefik-vhosts/post-app-rename-setup
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-traefik-vhosts-post-app-rename-setup() {
+  declare desc="updates settings for new app"
+  declare trigger="post-app-rename-setup"
+  declare OLD_APP="$1" NEW_APP="$2"
+
+  fn-plugin-property-clone "traefik-vhosts" "$OLD_APP" "$NEW_APP"
+  fn-plugin-property-destroy "traefik-vhosts" "$OLD_APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet migrate-data-directory "traefik-vhosts" "$OLD_APP" "$NEW_APP"
+}
+
+trigger-traefik-vhosts-post-app-rename-setup "$@"

--- a/plugins/traefik-vhosts/post-create
+++ b/plugins/traefik-vhosts/post-create
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-traefik-vhosts-post-create() {
+  declare desc="traefik-vhosts post-create plugin trigger"
+  declare trigger="post-create"
+  declare APP="$1"
+
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet create-data-directory "traefik-vhosts" "$APP"
+}
+
+trigger-traefik-vhosts-post-create "$@"

--- a/plugins/traefik-vhosts/post-delete
+++ b/plugins/traefik-vhosts/post-delete
@@ -9,6 +9,7 @@ trigger-traefik-vhosts-post-delete() {
   declare APP="$1"
 
   fn-plugin-property-destroy "traefik" "$APP"
+  "$PLUGIN_CORE_AVAILABLE_PATH/common/common" --quiet migrate-data-directory "traefik-vhosts" "$APP"
 }
 
 trigger-traefik-vhosts-post-delete "$@"


### PR DESCRIPTION
- The storage plugin doesn't use the `data` directory in the same way - it is used for user data mounts
- The nginx-vhosts plugin references data in a different manner - with `app-` as the prefix - due to how it also stores error messages there. This needs to be fixed in a different MR.