### PR TITLE
Remove extra location block from built docs nginx config

### DIFF
--- a/docs/_build/app-nginx.conf.sigil
+++ b/docs/_build/app-nginx.conf.sigil
@@ -19,10 +19,6 @@ http {
     port_in_redirect off;
 
     include /app/www/nginx.conf.d/*.conf;
-    location ^~ /nginx.conf.d/ {
-      return 404;
-    }
-
     location / {
       try_files $uri $uri/ =404;
     }


### PR DESCRIPTION
This is handled upstream in the docs repo.