### PR TITLE
Update build-base docker image to ensure we can build on all supported platforms without stalling

### DIFF
--- a/contrib/build-base.Dockerfile
+++ b/contrib/build-base.Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -qq && apt-get -qq -y --no-install-recommends install ca-certificates curl gcc git build-essential wget ruby-dev lintian rpm help2man man-db
+RUN apt-get update -qq && apt-get -qq -y --no-install-recommends install ca-certificates curl gcc git build-essential wget ruby-dev lintian rpm help2man man-db sudo
 RUN curl -sL -o /usr/local/share/ca-certificates/GlobalSignRootCA_R3.crt https://raw.githubusercontent.com/rubygems/rubygems/master/lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA_R3.pem
 RUN update-ca-certificates
 RUN command -v fpm || gem install fpm

--- a/contrib/build-base.Dockerfile
+++ b/contrib/build-base.Dockerfile
@@ -2,5 +2,7 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -qq && apt-get -qq -y --no-install-recommends install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
-RUN command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
+RUN apt-get update -qq && apt-get -qq -y --no-install-recommends install ca-certificates curl gcc git build-essential wget ruby-dev lintian rpm help2man man-db
+RUN curl -sL -o /usr/local/share/ca-certificates/GlobalSignRootCA_R3.crt https://raw.githubusercontent.com/rubygems/rubygems/master/lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA_R3.pem
+RUN update-ca-certificates
+RUN command -v fpm || gem install fpm

--- a/contrib/build-dokku.Dockerfile
+++ b/contrib/build-dokku.Dockerfile
@@ -2,9 +2,6 @@ FROM dokku/build-base:0.0.1 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -qq && apt-get -qq -y --no-install-recommends install gcc git build-essential wget ruby-dev ruby1.9.1 lintian rpm help2man man-db
-RUN command -v fpm >/dev/null || sudo gem install fpm --no-ri --no-rdoc
-
 ARG GOLANG_VERSION
 
 RUN wget -qO /tmp/go${GOLANG_VERSION}.linux.tar.gz "https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \


### PR DESCRIPTION
The image can now be built via:

    docker buildx build --platform linux/arm,linux/arm64,linux/amd64 --progress plain --push --tag dokku/build-base:latest --tag dokku/build-base:0.0.1 -f contrib/build-base.Dockerfile .