### PR TITLE
Add note about ubuntu 18.04 being deprecated

### DIFF
--- a/docs/appendices/0.30.0-migration-guide.md
+++ b/docs/appendices/0.30.0-migration-guide.md
@@ -1,5 +1,9 @@
 # 0.30.0 Migration Guide
 
+## Deprecations
+
+- Support for Ubuntu 18.04 has been deprecated. Please upgrade your host OS in advance of the [End Of Life in April 2023](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes).
+
 ## Changes
 
 - The `app.json` file is now extracted from the source code instead of the built image. For deploys via `git:from-image`, the file is extracted from the built image.


### PR DESCRIPTION
This was an omission by error in the 0.30.x release notes.