### PR TITLE
Add a note about required upgrade to 0.29.x for versions prior to 0.25.x

### DIFF
--- a/docs/appendices/0.30.0-migration-guide.md
+++ b/docs/appendices/0.30.0-migration-guide.md
@@ -1,5 +1,7 @@
 # 0.30.0 Migration Guide
 
+> **Important**: Due to the removal of `DOKKU_SCALE` support, users with a version older than 0.25.x are heavily encouraged to upgrade to 0.29.x prior to 0.30.x. Not doing so will result in all app containers stopping on rebuild due to having no scale settings.
+
 ## Deprecations
 
 - Support for Ubuntu 18.04 has been deprecated. Please upgrade your host OS in advance of the [End Of Life in April 2023](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes).


### PR DESCRIPTION
We introduced a method of migrating from DOKKU_SCALE to app.json in 0.25.x. This was removed in 0.30.x, so users need to ensure they either set their own scale manually _or_ upgrade. The upgrade is probably the safest bet.