### PR TITLE
Add DOKKU_LIB_HOST_ROOT to docker usage docs

### DIFF
--- a/docs/getting-started/install/docker.md
+++ b/docs/getting-started/install/docker.md
@@ -12,6 +12,7 @@ Next, run the image.
 docker container run \
   --env DOKKU_HOSTNAME=dokku.me \
   --env DOKKU_HOST_ROOT=/var/lib/dokku/home/dokku \
+  --env DOKKU_LIB_HOST_ROOT=/var/lib/dokku/var/lib/dokku \
   --name dokku \
   --publish 3022:22 \
   --publish 8080:80 \


### PR DESCRIPTION
This is necessary to fix certain plugins that need to be aware of host paths for volume mounting.