### PR TITLE
Keep image specified by git:from-image on app rebuild

### DIFF
--- a/plugins/scheduler-docker-local/scheduler-register-retired
+++ b/plugins/scheduler-docker-local/scheduler-register-retired
@@ -19,12 +19,15 @@ trigger-scheduler-docker-local-scheduler-register-retired() {
   fn-scheduler-docker-local-register-retired "container" "$APP" "$CONTAINER_ID" "$WAIT"
 
   if [[ -n "$IMAGE_ID" ]] && [[ -z "$DOKKU_SKIP_IMAGE_CLEANUP_REGISTRATION" ]]; then
-    ALT_IMAGE_TAG="$("$DOCKER_BIN" image inspect --format '{{ index .Config.Labels "com.dokku.docker-image-labeler/alternate-tags" }}' "$IMAGE_ID" 2>/dev/null || true)"
+    ALT_IMAGE_TAGS="$("$DOCKER_BIN" image inspect --format '{{ index .Config.Labels "com.dokku.docker-image-labeler/alternate-tags" }}' "$IMAGE_ID" 2>/dev/null || true)"
 
     fn-scheduler-docker-local-register-retired "image" "$APP" "$IMAGE_ID" "$WAIT"
-    if [[ -n "$ALT_IMAGE_TAG" ]]; then
-      ALT_IMAGE_ID="$("$DOCKER_BIN" image inspect --format '{{ .Id }}' "$(echo "$ALT_IMAGE_TAG" | jq -r ".[]")" 2>/dev/null || true)"
-      fn-scheduler-docker-local-register-retired "image" "$APP" "$(echo "$ALT_IMAGE_ID" | cut -d ':' -f2)" "$WAIT"
+    if [[ -n "$ALT_IMAGE_TAGS" ]]; then
+      ALT_IMAGE_TAG="$(echo "$ALT_IMAGE_TAGS" | jq -r ".[]")"
+      if [[ "$(plugn trigger git-get-property "$APP" "source-image")" != "$ALT_IMAGE_TAG" ]]; then
+        ALT_IMAGE_ID="$("$DOCKER_BIN" image inspect --format '{{ .Id }}' "$ALT_IMAGE_TAG" 2>/dev/null || true)"
+        fn-scheduler-docker-local-register-retired "image" "$APP" "$(echo "$ALT_IMAGE_ID" | cut -d ':' -f2)" "$WAIT"
+      fi
     fi
   fi
 }


### PR DESCRIPTION
Rather than always delete the image, we will now check if the alt image tag is equivalent to the source-image specified by the git:from-image command. If it is, we will ignore deletion.

Closes #5702