### PR TITLE
Ignore release branches in changelog output

### DIFF
--- a/contrib/release-dokku
+++ b/contrib/release-dokku
@@ -276,7 +276,9 @@ fn-repo-update-history-and-commit() {
     TYPE="$(jq -r '.labels[] | select( .name | contains("type") ) | .name' "$ISSUE_FILE" | cut -d' ' -f2)"
     CHANGELOG_TEXT="- #${PULL_REQUEST_ID}: @${AUTHOR} ${TITLE}"
 
-    if [[ "$TYPE" == "bc-break" ]]; then
+    if [[ "$TYPE" == "release" ]]; then
+      continue
+    elif [[ "$TYPE" == "bc-break" ]]; then
       HISTORY_BC_BREAK="${HISTORY_BC_BREAK}"$'\n'"$CHANGELOG_TEXT"
     elif [[ "$TYPE" == "bug" ]]; then
       HISTORY_BUG="${HISTORY_BUG}"$'\n'"$CHANGELOG_TEXT"


### PR DESCRIPTION
This change allows us to have an integration branch for each release that contains tested changes for each minor. Rather than have to block merging until a minor is ready for release - and subsequently have to deal with constant rebase issues - we will now have an integration branch per-release. This will be the target for minor-related changes - mostly new features, but also refactors and bc-breaks - while the trunk branch will stay safe for merging patch changes.

Note that we'll still need to rebase the integration branch every so often, but at least this allows us to avoid many long-running MRs.