### PR TITLE
Ignore issue where errors are required to be lowercased

### DIFF
--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,1 @@
+checks = ["inherit", "-ST1005"]


### PR DESCRIPTION
For aesthetic reasons, error messages start with an uppercase character. This allows us to print them as is.