### PR TITLE
Ensure users can push from an image-deploy repository and respect deploy-branch

### DIFF
--- a/plugins/git/git-from-directory
+++ b/plugins/git/git-from-directory
@@ -27,16 +27,17 @@ trigger-git-git-from-directory() {
   dokku_log_info1 "Updating git repository with specified build context"
   if [[ "$has_code" == "false" ]]; then
     # setup new repo
+    local DEPLOY_BRANCH="$(fn-git-deploy-branch "$APP")"
     cp -rT "$SOURCECODE_WORK_DIR" "$TMP_WORK_DIR"
     suppress_output fn-git-cmd "$TMP_WORK_DIR" init
+    suppress_output fn-git-cmd "$TMP_WORK_DIR" config init.defaultBranch "$DEPLOY_BRANCH"
     suppress_output fn-git-cmd "$TMP_WORK_DIR" config user.name "$USER_NAME"
     suppress_output fn-git-cmd "$TMP_WORK_DIR" config user.email "$USER_EMAIL"
     suppress_output fn-git-cmd "$TMP_WORK_DIR" add --all
     suppress_output fn-git-cmd "$TMP_WORK_DIR" commit -m "Initial commit"
 
     REV="$(fn-git-cmd "$TMP_WORK_DIR" rev-parse HEAD)"
-    rsync -a "$TMP_WORK_DIR/.git/" "$APP_ROOT"
-    fn-git-create-hook "$APP"
+    fn-git-clone "$APP" "$TMP_WORK_DIR" "$DEPLOY_BRANCH"
   else
     # update existing repo
     GIT_TERMINAL_PROMPT=0 suppress_output git clone "$APP_ROOT" "$TMP_WORK_DIR_2"

--- a/plugins/git/git-from-directory
+++ b/plugins/git/git-from-directory
@@ -37,6 +37,7 @@ trigger-git-git-from-directory() {
     suppress_output fn-git-cmd "$TMP_WORK_DIR" commit -m "Initial commit"
 
     REV="$(fn-git-cmd "$TMP_WORK_DIR" rev-parse HEAD)"
+    fn-git-create-hook "$APP"
     fn-git-clone "$APP" "$TMP_WORK_DIR" "$DEPLOY_BRANCH"
   else
     # update existing repo

--- a/plugins/git/git-from-directory
+++ b/plugins/git/git-from-directory
@@ -30,6 +30,7 @@ trigger-git-git-from-directory() {
     local DEPLOY_BRANCH="$(fn-git-deploy-branch "$APP")"
     cp -rT "$SOURCECODE_WORK_DIR" "$TMP_WORK_DIR"
     suppress_output fn-git-cmd "$TMP_WORK_DIR" init
+    suppress_output fn-git-cmd "$TMP_WORK_DIR" checkout -b "$DEPLOY_BRANCH"
     suppress_output fn-git-cmd "$TMP_WORK_DIR" config init.defaultBranch "$DEPLOY_BRANCH"
     suppress_output fn-git-cmd "$TMP_WORK_DIR" config user.name "$USER_NAME"
     suppress_output fn-git-cmd "$TMP_WORK_DIR" config user.email "$USER_EMAIL"

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -202,6 +202,7 @@ cmd-git-sync() {
 
   local APP_ROOT="$DOKKU_ROOT/$APP"
   if [[ "$(fn-git-cmd "$APP_ROOT" count-objects)" == "0 objects, 0 kilobytes" ]]; then
+    dokku_log_info1_quiet "Cloning $APP from $GIT_REMOTE#$GIT_REF"
     fn-git-clone "$APP" "$GIT_REMOTE" "$GIT_REF"
   else
     fn-git-fetch "$APP" "$GIT_REMOTE" "$GIT_REF"
@@ -394,7 +395,6 @@ fn-git-clone() {
     GIT_REF="$(fn-git-deploy-branch "$APP")"
   fi
 
-  dokku_log_info1_quiet "Cloning $APP from $GIT_REMOTE#$GIT_REF"
   trap "rm -rf '$APP_CLONE_ROOT' > /dev/null" RETURN INT TERM EXIT
 
   is_ref=true

--- a/tests/unit/git_4.bats
+++ b/tests/unit/git_4.bats
@@ -27,6 +27,30 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+
+  run /bin/bash -c "cat /home/dokku/$TEST_APP/HEAD"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "ref: refs/heads/master"
+}
+
+@test "(git) git:from-image [normal-custom-branch]" {
+  run /bin/bash -c "dokku git:set $TEST_APP deploy-branch main"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:from-image $TEST_APP linuxserver/foldingathome:7.5.1-ls1"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "cat /home/dokku/$TEST_APP/HEAD"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "ref: refs/heads/main"
 }
 
 @test "(git) git:from-image [normal-git-init]" {

--- a/tests/unit/git_4.bats
+++ b/tests/unit/git_4.bats
@@ -41,7 +41,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku git:from-image $TEST_APP linuxserver/foldingathome:7.5.1-ls1"
+  run /bin/bash -c "dokku git:from-image $TEST_APP linuxserver/foldingathome:7.6.21"
   echo "output: $output"
   echo "status: $status"
   assert_success


### PR DESCRIPTION
Previously, we created this weird bare repo that didn't do set all the normal git config. This change switches to cloning the local temp directory, fixing the `receive.denyCurrentBranch` property that blocked pushing to this weird bare repo after calling git:from-image or git:from-archive.

Additionally, since we now use a git clone, we set the default branch correctly, ensuring git pushes later on that branch work as expected (and not on master if it was customized prior to app creation).

Closes #5601
Closes #5662