### PR TITLE
Support pack-based images that do not have a Procfile

### DIFF
--- a/plugins/builder-pack/docker-args-process-deploy
+++ b/plugins/builder-pack/docker-args-process-deploy
@@ -5,16 +5,23 @@ set -eo pipefail
 trigger-builder-pack-docker-args-process-deploy() {
   declare desc="builder-pack core-post-deploy plugin trigger"
   declare trigger="docker-args-process-deploy"
-  declare APP="$1" IMAGE_SOURCE_TYPE="$2"
+  declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3" PROC_TYPE="$4"
   local STDIN=$(cat)
-  local output
+  local inject_launcher output
 
   if [[ "$IMAGE_SOURCE_TYPE" != "pack" ]]; then
     return
   fi
 
-  # without this, the command and arguments are passed as args to the default process type
-  output="--entrypoint launcher "
+  inject_launcher=true
+  if [[ -n "$IMAGE_TAG" ]] && [[ -n "$PROC_TYPE" ]] && [[ -z "$(plugn trigger procfile-get-command "$APP" "$PROC_TYPE" "5000" 2>/dev/null || echo '')" ]]; then
+    inject_launcher=false
+  fi
+
+  if [[ "$inject_launcher" == "true" ]]; then
+    # without this, the command and arguments are passed as args to the default process type
+    output="--entrypoint launcher "
+  fi
 
   echo -n "$STDIN$output"
 }

--- a/tests/unit/builder-pack.bats
+++ b/tests/unit/builder-pack.bats
@@ -75,6 +75,13 @@ teardown() {
   assert_output_contains 'Installing requirements with pip'
 }
 
+@test "(builder-pack) git:from-image without a Procfile" {
+  run /bin/bash -c "dokku git:from-image $TEST_APP dokku/smoke-test-gradle-app:1"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
 inject_requirements_txt() {
   local APP="$1"
   local APP_REPO_DIR="$2"


### PR DESCRIPTION
If no Procfile is set, we'll leave the entrypoint alone, resulting in the default launcher for the web process (or whatever pack decided was default) executing.

Closes #5753