### PR TITLE
Stop using the `latest` tag for the default `DOKKU_CNB_BUILDER`

### DIFF
--- a/dokku
+++ b/dokku
@@ -42,7 +42,7 @@ DOKKU_DISTRO=$(
 export DOCKER_BIN=${DOCKER_BIN:="docker"}
 
 export DOKKU_IMAGE=${DOKKU_IMAGE:="gliderlabs/herokuish:latest-20"}
-export DOKKU_CNB_BUILDER=${DOKKU_CNB_BUILDER:="heroku/buildpacks"}
+export DOKKU_CNB_BUILDER=${DOKKU_CNB_BUILDER:="heroku/buildpacks:20"}
 export DOKKU_LIB_ROOT=${DOKKU_LIB_PATH:="/var/lib/dokku"}
 
 export PLUGIN_PATH=${PLUGIN_PATH:="$DOKKU_LIB_ROOT/plugins"}


### PR DESCRIPTION
Previously the default value for `DOKKU_CNB_BUILDER` was `heroku/buildpacks`, which for Docker is equivalent to `heroku/buildpacks:latest`.

The `latest` tag is about to be deleted (see heroku/builder#344), so this switches the default value to `heroku/buildpacks:20` - which is what the `latest` tag is currently as alias for.

Longer term, `DOKKU_CNB_BUILDER` should be switched to the non-deprecated `heroku/builder:*` images, however, that's potentially a breaking change, so is out of scope of this bug-fix PR.

For the list of available builders/tags, see:
https://github.com/heroku/builder#heroku-builder-images

Fixes #5861.