### PR TITLE
fix: trim whitespace on registry property values

### DIFF
--- a/plugins/registry/functions.go
+++ b/plugins/registry/functions.go
@@ -16,6 +16,7 @@ func getRegistryServerForApp(appName string) string {
 	if value == "" {
 		value = common.PropertyGet("registry", "--global", "server")
 	}
+	value = strings.TrimSpace(value)
 
 	value = strings.TrimSuffix(value, "/")
 	if value == "hub.docker.com" || value == "docker.io" {
@@ -39,6 +40,7 @@ func incrementTagVersion(appName string) (int, error) {
 		tag = "0"
 	}
 
+	tag = strings.TrimSpace(tag)
 	version, err := strconv.Atoi(tag)
 	if err != nil {
 		return 0, fmt.Errorf("Unable to convert existing tag version (%s) to integer: %v", tag, err)

--- a/plugins/registry/report.go
+++ b/plugins/registry/report.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"strings"
+
 	"github.com/dokku/dokku/plugins/common"
 )
 
@@ -35,6 +37,7 @@ func ReportSingleApp(appName string, format string, infoFlag string) error {
 
 func reportComputedImageRepo(appName string) string {
 	imageRepo := reportImageRepo(appName)
+	imageRepo = strings.TrimSpace(imageRepo)
 	if imageRepo == "" {
 		imageRepo = common.GetAppImageRepo(appName)
 	}
@@ -48,6 +51,7 @@ func reportImageRepo(appName string) string {
 
 func reportComputedPushOnRelease(appName string) string {
 	value := reportPushOnRelease(appName)
+	value = strings.TrimSpace(value)
 	if value == "" {
 		value = reportGlobalPushOnRelease(appName)
 	}
@@ -68,7 +72,8 @@ func reportPushOnRelease(appName string) string {
 }
 
 func reportComputedServer(appName string) string {
-	return getRegistryServerForApp(appName)
+	server := getRegistryServerForApp(appName)
+	return strings.TrimSpace(server)
 }
 
 func reportGlobalServer(appName string) string {
@@ -80,5 +85,6 @@ func reportServer(appName string) string {
 }
 
 func reportTagVersion(appName string) string {
-	return common.PropertyGet("registry", appName, "tag-version")
+	tagVersion := common.PropertyGet("registry", appName, "tag-version")
+	return strings.TrimSpace(tagVersion)
 }

--- a/plugins/registry/triggers.go
+++ b/plugins/registry/triggers.go
@@ -11,6 +11,7 @@ import (
 // TriggerDeployedAppImageRepo outputs the associated image repo to stdout
 func TriggerDeployedAppImageRepo(appName string) error {
 	imageRepo := common.PropertyGet("registry", appName, "image-repo")
+	imageRepo = strings.TrimSpace(imageRepo)
 	if imageRepo == "" {
 		imageRepo = common.GetAppImageRepo(appName)
 	}
@@ -26,6 +27,7 @@ func TriggerDeployedAppImageTag(appName string) error {
 	}
 
 	tagVersion := common.PropertyGet("registry", appName, "tag-version")
+	tagVersion = strings.TrimSpace(tagVersion)
 	if tagVersion == "" {
 		tagVersion = "1"
 	}


### PR DESCRIPTION
When upgrading from an older install of Dokku with the old community registry plugin, newlines could be available in the properties set on disk. Trim them so any usage of the properties continues to work as expected by users.