### PR TITLE
Remove `:master` from `git push` commands in the documentation

### DIFF
--- a/docs/deployment/application-deployment.md
+++ b/docs/deployment/application-deployment.md
@@ -61,7 +61,7 @@ Now you can deploy the `ruby-getting-started` app to your Dokku server. All you 
 # the remote username *must* be dokku or pushes will fail
 cd ruby-getting-started
 git remote add dokku dokku@dokku.me:ruby-getting-started
-git push dokku main:master
+git push dokku main
 ```
 
 > Note: Some tools may not support the short-upstream syntax referenced above, and you may need to prefix
@@ -70,7 +70,7 @@ git push dokku main:master
 
 > Note: Your private key should be registered with `ssh-agent` in your local development environment. If you get a `permission denied` error when pushing, you can register your private key as follows: `ssh-add -k ~/<your private key>`.
 
-After running `git push dokku main:master`, you should have output similar to this in your terminal:
+After running `git push dokku main`, you should have output similar to this in your terminal:
 
 ```
 Counting objects: 231, done.
@@ -179,7 +179,7 @@ If you do not enter a fully qualified domain name when pushing your app, Dokku d
 # the remote username *must* be dokku or pushes will fail
 # the below example assumes your app server domain or IP is dokku.me. Push in the form of: dokku@{serveripordomain}:{dokkuappname} 
 git remote add dokku dokku@dokku.me:ruby-getting-started
-git push dokku main:master
+git push dokku main
 ```
 
 ```
@@ -193,7 +193,7 @@ You can also specify the fully qualified name as follows:
 # from your local machine
 # the remote username *must* be dokku or pushes will fail
 git remote add dokku dokku@dokku.me:app.dokku.me
-git push dokku main:master
+git push dokku main
 ```
 
 ```
@@ -207,7 +207,7 @@ This is useful when you want to deploy to the root domain:
 # from your local machine
 # the remote username *must* be dokku or pushes will fail
 git remote add dokku dokku@dokku.me:dokku.me
-git push dokku main:master
+git push dokku main
 ```
 
 ```

--- a/docs/deployment/application-management.md
+++ b/docs/deployment/application-management.md
@@ -150,7 +150,7 @@ By default, Dokku will deploy the renamed app, though you can skip the deploy by
 dokku apps:rename --skip-deploy node-js-app io-js-app
 ```
 
-Remember to also change your git remote on your local machine in order to make `git push dokku main:master` work again. For this you can use `git remote set-url`.
+Remember to also change your git remote on your local machine in order to make `git push dokku main` work again. For this you can use `git remote set-url`.
 
 ```shell
 git remote set-url dokku dokku@dokku.me:io-js-app


### PR DESCRIPTION
After #4225, the `:master` part in `git push main:master` is no longer necessary, you could just do `git push main`.