### PR TITLE
Improve docs about `X-Forwarded-*` headers and move it to nginx.md

### DIFF
--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -135,3 +135,9 @@ Certain versions of nginx have bugs that prevent [HTTP/2](https://nginx.org/en/d
 ### SSL Port Exposure
 
 When your app is served from port `80` then the `/home/dokku/APP/nginx.conf` file will automatically be updated to instruct nginx to respond to ssl on port 443 as a new cert is added. If your app uses a non-standard port (perhaps you have a dockerfile deploy exposing port `99999`) you may need to manually expose an ssl port via `dokku proxy:ports-add <APP> https:443:99999`.
+
+## Other
+
+### Running behind a proxy (`X-Forwarded-Ssl`, etc.)
+
+See the [running behind another proxy documentation](/docs/networking/proxies/nginx.md#running-behind-another-proxy--configuring-x-forwarded--headers) for more information on how to configure your Nginx config when your server is running behind a proxy (e.g. load balancer, etc.).

--- a/docs/configuration/ssl.md
+++ b/docs/configuration/ssl.md
@@ -132,37 +132,6 @@ See the [NGINX HSTS documentation](/docs/networking/proxies/nginx.md#hsts-header
 
 Certain versions of nginx have bugs that prevent [HTTP/2](https://nginx.org/en/docs/http/ngx_http_v2_module.html) from properly responding to all clients, thus causing applications to be unavailable. For HTTP/2 to be enabled in your applications' nginx configs, you need to have installed nginx 1.11.5 or higher. See [issue 2435](https://github.com/dokku/dokku/issues/2435) for more details.
 
-## Running behind a load balancer
-
-Your application has access to the HTTP headers `X-Forwarded-Proto`, `X-Forwarded-Port` and `X-Forwarded-For`. These headers indicate the protocol of the original request (HTTP or HTTPS), the port number, and the IP address of the client making the request, respectively. The default configuration is for Nginx to set these headers.
-
-If your server runs behind an HTTP(S) load balancer, then Nginx will see all requests as coming from the load balancer. If your load balancer sets the `X-Forwarded-` headers, you can tell Nginx to pass these headers from load balancer to your application via `nginx:set`:
-
-```shell
-dokku nginx:set node-js-app x-forwarded-for-value "\$http_x_forwarded_for"
-dokku nginx:set node-js-app x-forwarded-port-value "\$http_x_forwarded_port"
-dokku nginx:set node-js-app x-forwarded-proto-value "\$http_x_forwarded_proto"
-```
-
-Only use this option if:
-1. All requests are terminated at the load balancer, and forwarded to Nginx
-2. The load balancer is configured to send the `X-Forwarded-` headers (this may be off by default)
-
-If it's possible to make HTTP(S) requests directly to Nginx, bypassing the load balancer, or if the load balancer is not configured to set these headers, then it becomes possible for a client to set these headers to arbitrary values.
-
-The `x-forwarded-ssl` property may also be set for application frameworks that require this value. Note that this is a non-standard version of setting `x-forwarded-proto` to `https`, and should only be done as a last resort.
-
-```shell
-# force-setting value to `on`
-dokku nginx:set node-js-app x-forwarded-ssl on
-
-# force-setting value to `off`
-dokku nginx:set node-js-app x-forwarded-ssl on
-
-# removing the value from nginx.conf (default)
-dokku nginx:set node-js-app x-forwarded-ssl
-```
-
 ### SSL Port Exposure
 
-When your app is served from port `80` then the `/home/dokku/APP/nginx.conf` file will automatically be updated to instruct nginx to respond to ssl on port 443 as a new cert is added.  If your app uses a non-standard port (perhaps you have a dockerfile deploy exposing port `99999`) you may need to manually expose an ssl port via `dokku proxy:ports-add <APP> https:443:99999`.
+When your app is served from port `80` then the `/home/dokku/APP/nginx.conf` file will automatically be updated to instruct nginx to respond to ssl on port 443 as a new cert is added. If your app uses a non-standard port (perhaps you have a dockerfile deploy exposing port `99999`) you may need to manually expose an ssl port via `dokku proxy:ports-add <APP> https:443:99999`.

--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -107,7 +107,7 @@ Once the HSTS setting is disabled globally, it can be re-enabled on a per-app ba
 dokku nginx:set node-js-app hsts true
 ```
 
-## Running behind another proxy — configuring `X-Forwarded-*` headers:
+### Running behind another proxy — configuring `X-Forwarded-*` headers:
 
 Dokku's default Nginx configuration passes the de-facto standard HTTP headers [`X-Forwarded-For`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For), [`X-Forwarded-Proto`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto), and `X-Forwarded-Port` to your application.
 These headers indicate the IP address of the original client making the request, the protocol of the original request (HTTP or HTTPS), and the port number of the original request, respectively.
@@ -492,10 +492,6 @@ See the [customizing hostnames documentation](/docs/configuration/domains.md#cus
 ### Disabling VHOSTS
 
 See the [disabling vhosts documentation](/docs/configuration/domains.md#disabling-vhosts) for more information on how to disable domain usage for your app.
-
-### Running behind a load balancer
-
-See the [load balancer documentation](/docs/configuration/ssl.md#running-behind-a-load-balancer) for more information on how to configure your nginx config for running behind a network load balancer.
 
 ### SSL Configuration
 


### PR DESCRIPTION
The documentation about customizing the `X-Forwarded-*` headers that Nginx sends to the app (e.g. `dokku nginx:set app x-forwarded-for-value '$http_x_forwarded_for'`) was previously located in the documentation page for SSL, but it really has nothing to do with SSL. I think this must've been a mistake, it actually belongs to the Nginx documentation, the command is literally `dokku nginx`, and these headers aren't specifically related to SSL.

I also made some improvements to this part of the documentation. For example, previously the docs here said that you're supposed to customize these headers if your server is running behind a **load balancer**, but this applies more generically, to any type of HTTP proxy that might be present in front of your Dokku server, a load balancer is just one type of proxy, this is not limited to load balancers, it also applies to CDN edge servers, for instance, and so on.

Another minor thing is that previously the command mentioned in the docs looked like this:
```sh
dokku nginx:set node-js-app x-forwarded-for-value "\$http_x_forwarded_for"
```
While it could just be:
```sh
dokku nginx:set node-js-app x-forwarded-for-value '$http_x_forwarded_for'
```
There's no need to use double quotes over single quotes just to then escape the `$`. You should just use single quotes when you don't want string interpolation.

I also reworded some parts of the explanation to make it more comprehensive and easily understandable.