### PR TITLE
tests: split out image building into it's own job to speed up ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: build package
         run: ./tests/ci/setup.sh build
         env:
-         SKIP_IMAGE_BUILD: true
+          SKIP_IMAGE_BUILD: true
 
       - name: set matrix for build
         id: set-matrix
@@ -104,7 +104,7 @@ jobs:
       - name: set up docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-      
+
       - name: build docker image
         run: |
           docker buildx build \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: build package
         run: ./tests/ci/setup.sh build
+        env:
+         SKIP_IMAGE_BUILD: true
 
       - name: set matrix for build
         id: set-matrix
@@ -74,6 +76,41 @@ jobs:
         with:
           name: build
           path: build
+
+  build-image:
+    name: build-image.${{ matrix.architecture }}
+    needs: build
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - linux/amd64
+          - linux/arm
+          - linux/arm64
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: download packages
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: build
+
+      - name: set up qemu
+        uses: docker/setup-qemu-action@v2
+
+      - name: set up docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: build docker image
+        run: |
+          docker buildx build \
+                --platform ${{ matrix.architecture }} \
+                --progress plain \
+                --tag "dokku/dokku:latest"
 
   unit-tests:
     name: unit.${{ matrix.index }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,8 @@ jobs:
           docker buildx build \
                 --platform ${{ matrix.architecture }} \
                 --progress plain \
-                --tag "dokku/dokku:latest"
+                --tag "dokku/dokku:latest" \
+                .
 
   unit-tests:
     name: unit.${{ matrix.index }}

--- a/contrib/release-dokku
+++ b/contrib/release-dokku
@@ -391,7 +391,7 @@ fn-build-docker-image() {
       --push \
       --tag "dokku/dokku:latest" \
       --tag "dokku/dokku:$VERSION" .
-  else
+  elif [[ "$SKIP_IMAGE_BUILD" != "true" ]]; then
     docker buildx build \
       --platform linux/arm,linux/arm64,linux/amd64 \
       --progress plain \


### PR DESCRIPTION
Previously, we would build the dokku package and install it in the same step. While the package building was relatively quick, because of our multi-architecture support, we would end up spending a large amount of time waiting for arm/arm64 images to build.

This change splits those builds out, allowing unit tests to start much quicker and each platform to be tested in parallel.