### PR TITLE
Add permissions to allow publishing test results for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,8 @@ jobs:
     name: publish-test-results
     needs: unit-tests
     runs-on: ubuntu-20.04
+    permissions:
+      checks: write
     # the build-and-test job might be skipped, we don't need to run this job then
     if: success() || failure()
 


### PR DESCRIPTION
Without this, almost every PR from a non-contributor will fail at the publish-test-results