### PR TITLE
Standardize on ls subcommand when interacting with the docker binary

### DIFF
--- a/plugins/builder/functions.go
+++ b/plugins/builder/functions.go
@@ -16,7 +16,7 @@ func listImagesByAppLabel(appName string) ([]string, error) {
 	command := []string{
 		common.DockerBin(),
 		"image",
-		"list",
+		"ls",
 		"--quiet",
 		"--filter",
 		fmt.Sprintf("label=com.dokku.app-name=%v", appName),
@@ -40,7 +40,7 @@ func listImagesByImageRepo(imageRepo string) ([]string, error) {
 	command := []string{
 		common.DockerBin(),
 		"image",
-		"list",
+		"ls",
 		"--quiet",
 		imageRepo,
 	}

--- a/plugins/common/docker.go
+++ b/plugins/common/docker.go
@@ -303,7 +303,7 @@ func ListDanglingImages(appName string) ([]string, error) {
 	command := []string{
 		DockerBin(),
 		"image",
-		"list",
+		"ls",
 		"--quiet",
 		"--filter",
 		"dangling=true",
@@ -360,7 +360,7 @@ func DockerFilterContainers(filters []string) ([]string, error) {
 	command := []string{
 		DockerBin(),
 		"container",
-		"list",
+		"ls",
 		"--quiet",
 		"--all",
 	}

--- a/plugins/network/functions.go
+++ b/plugins/network/functions.go
@@ -128,7 +128,7 @@ func networkExists(networkName string) (bool, error) {
 
 // listNetworks returns a list of docker networks
 func listNetworks() ([]string, error) {
-	b, err := sh.Command(common.DockerBin(), "network", "list", "--format", "{{ .Name }}").Output()
+	b, err := sh.Command(common.DockerBin(), "network", "ls", "--format", "{{ .Name }}").Output()
 	output := strings.TrimSpace(string(b[:]))
 
 	networks := []string{}

--- a/plugins/scheduler-docker-local/core-post-deploy
+++ b/plugins/scheduler-docker-local/core-post-deploy
@@ -37,7 +37,7 @@ trigger-scheduler-docker-local-core-post-deploy() {
     local NAME="$APP.$DYNO"
     local CURRENT_CONTAINER_ID="$(<"$container")"
     # TODO: Ensure these are from the current service
-    local PREVIOUS_CIDS=$("$DOCKER_BIN" container list --all --quiet --filter name="^.?$NAME\$" | xargs) || true
+    local PREVIOUS_CIDS=$("$DOCKER_BIN" container ls --all --quiet --filter name="^.?$NAME\$" | xargs) || true
     if [[ -n $PREVIOUS_CIDS ]]; then
       dokku_log_verbose_quiet "Found previous container(s) ($PREVIOUS_CIDS) named $NAME"
       # in case $PREVIOUS_CIDS has more than one entry

--- a/plugins/scheduler-docker-local/scheduler-pre-restore
+++ b/plugins/scheduler-docker-local/scheduler-pre-restore
@@ -14,7 +14,7 @@ trigger-scheduler-docker-local-scheduler-pre-restore() {
 
   # delete all "old" containers
   # shellcheck disable=SC2046
-  "$DOCKER_BIN" container rm $("$DOCKER_BIN" container list --all --format "{{.Names}}" --filter "label=$DOKKU_CONTAINER_LABEL" --quiet | grep -E '(.+\..+\.[0-9]+\.[0-9]+$)') &>/dev/null || true
+  "$DOCKER_BIN" container rm $("$DOCKER_BIN" container ls --all --format "{{.Names}}" --filter "label=$DOKKU_CONTAINER_LABEL" --quiet | grep -E '(.+\..+\.[0-9]+\.[0-9]+$)') &>/dev/null || true
 }
 
 trigger-scheduler-docker-local-scheduler-pre-restore "$@"


### PR DESCRIPTION
The ls command is what is referenced in the --help output for the subcommands, so we should just use that everywhere.