### PR TITLE
Export environment variables during dockerfile builds for use with value-less --build-arg flags

### DIFF
--- a/docs/deployment/builders/dockerfiles.md
+++ b/docs/deployment/builders/dockerfiles.md
@@ -112,10 +112,10 @@ Dockerfile2
 
 For security reasons - and as per [Docker recommendations](https://github.com/docker/docker/issues/13490) - Dockerfile-based deploys have variables available only during runtime.
 
-For users that require customization in the `build` phase, you may use build arguments via the [docker-options plugin](/docs/advanced-usage/docker-options.md):
+For users that require customization in the `build` phase, you may use build arguments via the [docker-options plugin](/docs/advanced-usage/docker-options.md). All environment variables set by the `config` plugin are automatically exported during a docker build, and thus `--build-arg` only requires setting a key without a value.
 
 ```shell
-dokku docker-options:add node-js-app build '--build-arg NODE_ENV=production'
+dokku docker-options:add node-js-app build '--build-arg NODE_ENV'
 ```
 
 Once set, the Dockerfile usage would be as follows:

--- a/plugins/builder-dockerfile/builder-build
+++ b/plugins/builder-dockerfile/builder-build
@@ -38,6 +38,7 @@ trigger-builder-dockerfile-builder-build() {
   declare -a ARG_ARRAY
   eval "ARG_ARRAY=($DOCKER_ARGS)"
 
+  eval "$(config_export app "$APP")"
   "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS "${ARG_ARRAY[@]}" ${DOKKU_DOCKER_BUILD_OPTS} -t $IMAGE .
 
   plugn trigger post-build-dockerfile "$APP"

--- a/tests/unit/builder-dockerfile.bats
+++ b/tests/unit/builder-dockerfile.bats
@@ -48,3 +48,21 @@ teardown() {
   assert_success
   assert_output_contains 'echo hi' 0
 }
+
+@test "(builder-dockerfile) config export" {
+  run /bin/bash -c "dokku config:set $TEST_APP GITHUB_TOKEN=custom-value"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku docker-options:add $TEST_APP build '--build-arg GITHUB_TOKEN"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app dockerfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "TOKEN is: custom-value"
+}

--- a/tests/unit/builder-dockerfile.bats
+++ b/tests/unit/builder-dockerfile.bats
@@ -55,7 +55,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku docker-options:add $TEST_APP build '--build-arg GITHUB_TOKEN"
+  run /bin/bash -c "dokku docker-options:add $TEST_APP build '--build-arg GITHUB_TOKEN'"
   echo "output: $output"
   echo "status: $status"
   assert_success


### PR DESCRIPTION
Exposing all config values will allow users to skip setting environment variables twice - once as a docker option and once as an env var. Docker will automatically pull the value from the environment if none is set for the --build-arg flag.

Users will still be required to specify each desired env var via --build-arg as otherwise docker builds will complain about unused build arguments.

Closes #5903