### PR TITLE
Do not start proxy implementations during server restore if they weren't manually started via the :start command

### DIFF
--- a/plugins/caddy-vhosts/pre-restore
+++ b/plugins/caddy-vhosts/pre-restore
@@ -8,7 +8,7 @@ trigger-caddy-pre-restore() {
   declare desc="pre-restore the caddy proxy"
   declare trigger="install"
 
-  if [[ "$(fn-plugin-property-get "caddy" "--global" "proxy-status")" == "stopped" ]]; then
+  if [[ "$(fn-plugin-property-get "caddy" "--global" "proxy-status")" != "started" ]]; then
     return
   fi
 

--- a/plugins/haproxy-vhosts/pre-restore
+++ b/plugins/haproxy-vhosts/pre-restore
@@ -8,7 +8,7 @@ trigger-haproxy-pre-restore() {
   declare desc="pre-restore the caddy proxy"
   declare trigger="install"
 
-  if [[ "$(fn-plugin-property-get "haproxy" "--global" "proxy-status")" == "stopped" ]]; then
+  if [[ "$(fn-plugin-property-get "haproxy" "--global" "proxy-status")" != "started" ]]; then
     return
   fi
 

--- a/plugins/nginx-vhosts/pre-restore
+++ b/plugins/nginx-vhosts/pre-restore
@@ -8,7 +8,7 @@ trigger-nginx-pre-restore() {
   declare desc="pre-restore the nginx proxy"
   declare trigger="install"
 
-  if [[ "$(fn-plugin-property-get "nginx" "--global" "proxy-status")" == "stopped" ]]; then
+  if [[ "$(fn-plugin-property-get "nginx" "--global" "proxy-status")" != "started" ]]; then
     return
   fi
 

--- a/plugins/traefik-vhosts/pre-restore
+++ b/plugins/traefik-vhosts/pre-restore
@@ -8,7 +8,7 @@ trigger-traefik-pre-restore() {
   declare desc="pre-restore the traefik proxy"
   declare trigger="install"
 
-  if [[ "$(fn-plugin-property-get "traefik" "--global" "proxy-status")" == "stopped" ]]; then
+  if [[ "$(fn-plugin-property-get "traefik" "--global" "proxy-status")" != "started" ]]; then
     return
   fi
 


### PR DESCRIPTION
This change ensures users don't have unnecessary proxies starting on their servers and potentially have apps not routing correctly due to another proxy squatting on a port.

Closes #5846