### PR TITLE
Automatically clear the git source-image property when changing deployment methodologies

### DIFF
--- a/docs/appendices/0.31.0-migration-guide.md
+++ b/docs/appendices/0.31.0-migration-guide.md
@@ -3,3 +3,4 @@
 ## Changes
 
 - Herokuish build cache is now mounted from a docker volume - eg. `cache-node-js-app` - instead of the local filesystem. All existing app cache will be cleared upon upgrading past 0.29.0.
+- Users no longer need to clear the `source-image` git property when transitioning from image-based deploys (`git:from-image` and `git:load-image`) to other deployment methods (git push, `git:from-archive`, `git:sync`).

--- a/docs/deployment/methods/git.md
+++ b/docs/deployment/methods/git.md
@@ -160,19 +160,6 @@ dokku git:from-image node-js-app dokku/node-js-getting-started:latest "Camila" "
 
 If the image is a private image that requires a docker login to access, the `registry:login` command should be used to log into the registry. See the [registry documentation](/docs/advanced-usage/registry-management.md#logging-into-a-registry) for more details on this process.
 
-Building an app from an image will result in the following files being extracted from the source image (with all custom paths specified for each file being respected):
-
-- `app.json`
-- `nginx.conf.sigil`
-- `Procfile`
-
-In the case where the repository is later modified to manually add any of the above files and deployed via `git push`, the files will still be extracted from the initial source image. To avoid this, please clear the `source-image` git property. It will be set back to the original source image on any subsequent `git:from-image` calls.
-
-```shell
-# sets an empty value
-dokku git:set node-js-app source-image
-```
-
 Finally, certain images may require a custom build context in order for `ONBUILD ADD` and `ONBUILD COPY` statements to succeed. A custom build context can be specified via the `--build-dir` flag. All files in the specified `build-dir` will be copied into the repository for use within the `docker build` process. The build context _must_ be specified on each deploy, and is not otherwise persisted between builds.
 
 ```shell
@@ -246,19 +233,6 @@ The `git:load-image` command can optionally take a git `user.name` and `user.ema
 
 ```shell
 docker image save dokku/node-js-getting-started:latest | ssh dokku@dokku.me git:load-image node-js-app dokku/node-js-getting-started:latest "Camila" "camila@example.com"
-```
-
-Building an app from an image will result in the following files being extracted from the source image (with all custom paths specified for each file being respected):
-
-- `app.json`
-- `nginx.conf.sigil`
-- `Procfile`
-
-In the case where the repository is later modified to manually add any of the above files and deployed via `git push`, the files will still be extracted from the initial source image. To avoid this, please clear the `source-image` git property. It will be set back to the original source image on any subsequent `git:load-image` calls.
-
-```shell
-# sets an empty value
-dokku git:set node-js-app source-image
 ```
 
 Finally, certain images may require a custom build context in order for `ONBUILD ADD` and `ONBUILD COPY` statements to succeed. A custom build context can be specified via the `--build-dir` flag. All files in the specified `build-dir` will be copied into the repository for use within the `docker build` process. The build context _must_ be specified on each deploy, and is not otherwise persisted between builds.

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -599,6 +599,21 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 echo 'derp.dkr.ecr.us-east-1.amazonaws.com'
 ```
 
+### `deploy-source-set`
+
+- Description: Used to set metadata about how the app is being deployed
+- Invoked by: `git:from-archive`, `git:from-image`, `git:load-image`, `git:sync`, and all git push commands
+- Arguments: `$APP $SOURCE_TYPE $METADATA`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+# TODO
+```
+
 ### `docker-args-build`
 
 > Warning: Deprecated, please use `docker-args-process-build` instead

--- a/plugins/git/deploy-source-set
+++ b/plugins/git/deploy-source-set
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-git-deploy-source-set() {
+  declare desc="clears the source-image if the source type is not docker"
+  declare trigger="deploy-source-set"
+  declare APP="$1" SOURCE_TYPE="$2"
+
+  if [[ "$SOURCE_TYPE" == "docker-image" ]]; then
+    return
+  fi
+
+  fn-plugin-property-write "git" "$APP" "source-image"
+}
+
+trigger-git-deploy-source-set "$@"


### PR DESCRIPTION
This ensures users don't have issues with cached state in regards to files pulled from the repo/image.

Closes #5963