### PR TITLE
Mount the traefik data directory instead of the acme.json file when starting traefik

### DIFF
--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -19,7 +19,7 @@ services:
       {{ if $.TRAEFIK_LETSENCRYPT_EMAIL }}
       - --certificatesresolvers.leresolver.acme.caserver={{ $.TRAEFIK_LETSENCRYPT_SERVER }}
       - --certificatesresolvers.leresolver.acme.email={{ $.TRAEFIK_LETSENCRYPT_EMAIL }}
-      - --certificatesresolvers.leresolver.acme.storage=/acme.json
+      - --certificatesresolvers.leresolver.acme.storage=/data/acme.json
       - --certificatesresolvers.leresolver.acme.tlschallenge=true
       {{ end }}
 
@@ -60,4 +60,4 @@ services:
 
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "{{ $.TRAEFIK_DATA_DIR }}/traefik-acme.json:/acme.json"
+      - "{{ $.TRAEFIK_DATA_DIR }}:/data"


### PR DESCRIPTION
Without this change, Docker - at least on arm64 - appears to mount the file as 0755 instead of 0600. We can trick docker by mounting the folder and then referencing _that_ instead.

Closes #5714