### PR TITLE
Add json format output to cron:list command

### DIFF
--- a/docs/processes/scheduled-cron-tasks.md
+++ b/docs/processes/scheduled-cron-tasks.md
@@ -3,8 +3,8 @@
 > New as of 0.23.0
 
 ```
-cron:list <app>               # List scheduled cron tasks for an app
-cron:report [<app>] [<flag>]  # Display report about an app
+cron:list <app> [--format json|stdout] # List scheduled cron tasks for an app
+cron:report [<app>] [<flag>]           # Display report about an app
 ```
 
 ## Usage
@@ -60,6 +60,16 @@ dokku cron:list node-js-app
 ID                                    Schedule   Command
 cGhwPT09cGhwIHRlc3QucGhwPT09QGRhaWx5  @daily     node index.js
 cGhwPT09dHJ1ZT09PSogKiAqICogKg==      * * * * *  true
+```
+
+The output can also be displayed in json format:
+
+```shell
+dokku cron:list node-js-app --format json
+```
+
+```
+[{"id":"cGhwPT09cGhwIHRlc3QucGhwPT09QGRhaWx5","app":"node-js-app","command":"node index.js","schedule":"@daily"}]
 ```
 
 #### Displaying reports

--- a/plugins/cron/cron.go
+++ b/plugins/cron/cron.go
@@ -14,12 +14,12 @@ import (
 )
 
 type TemplateCommand struct {
-	ID         string
-	App        string
-	Command    string
-	Schedule   string
-	AltCommand string
-	LogFile    string
+	ID         string `json:"id"`
+	App        string `json:"app"`
+	Command    string `json:"command"`
+	Schedule   string `json:"schedule"`
+	AltCommand string `json:"-"`
+	LogFile    string `json:"-"`
 }
 
 func (t TemplateCommand) CronCommand() string {

--- a/plugins/cron/src/commands/commands.go
+++ b/plugins/cron/src/commands/commands.go
@@ -18,7 +18,7 @@ Manage scheduled cron tasks
 Additional commands:`
 
 	helpContent = `
-    cron:list <app>, List scheduled cron tasks for an app
+    cron:list <app> [--format json|stdout], List scheduled cron tasks for an app
     cron:report [<app>] [<flag>], Display report about an app
 `
 )

--- a/plugins/cron/src/subcommands/subcommands.go
+++ b/plugins/cron/src/subcommands/subcommands.go
@@ -20,9 +20,10 @@ func main() {
 	switch subcommand {
 	case "list":
 		args := flag.NewFlagSet("cron:list", flag.ExitOnError)
+		format := args.String("format", "stdout", "format: [ stdout | json ]")
 		args.Parse(os.Args[2:])
 		appName := args.Arg(0)
-		err = cron.CommandList(appName)
+		err = cron.CommandList(appName, *format)
 	case "report":
 		args := flag.NewFlagSet("cron:report", flag.ExitOnError)
 		format := args.String("format", "stdout", "format: [ stdout | json ]")

--- a/tests/unit/cron.bats
+++ b/tests/unit/cron.bats
@@ -177,6 +177,26 @@ teardown() {
   assert_failure
 }
 
+@test "(cron) cron:list --format json" {
+  run deploy_app python dokku@dokku.me:$TEST_APP template_cron_file_valid
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku cron:list $TEST_APP --format json"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_exists
+
+  cron_id="$(dokku cron:list $TEST_APP --format json | jq -r '.[0].id')"
+  run /bin/bash -c "echo $cron_id"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_exists
+}
+
 template_cron_file_invalid() {
   local APP="$1"
   local APP_REPO_DIR="$2"


### PR DESCRIPTION
This makes it easier to parse output in a machine-readable format - such as when interacting with cron tasks via jq for writing tests.