### PR TITLE
Mount the vector data directory instead of the vector file

### DIFF
--- a/docs/appendices/0.31.0-migration-guide.md
+++ b/docs/appendices/0.31.0-migration-guide.md
@@ -4,3 +4,4 @@
 
 - Herokuish build cache is now mounted from a docker volume - eg. `cache-node-js-app` - instead of the local filesystem. All existing app cache will be cleared upon upgrading past 0.29.0.
 - The `proxy:ports*` commands have been replaced with the new `ports` plugin. Users will be able to use the old `proxy:ports*` commands for a single minor release, and they will be removed in the next minor release.
+- The `vector` container integration now mounts config to `/etc/vector` instead of the path `/etc/vector/vector.json`, allowing users the ability to provide extra configuration for Vector Sinks. To take advantage of the new functionality, the vector container should be stopped (via `dokku logs:vector-stop`) and then started (via `dokku logs:vector-start`).

--- a/plugins/logs/functions.go
+++ b/plugins/logs/functions.go
@@ -72,7 +72,7 @@ func startVectorContainer(vectorImage string) error {
 		"container",
 		"run", "--detach", "--name", vectorContainerName, common.MustGetEnv("DOKKU_GLOBAL_RUN_ARGS"),
 		"--restart", "unless-stopped",
-		"--volume", "/var/lib/dokku/data/logs/vector.json:/etc/vector/vector.json",
+		"--volume", "/var/lib/dokku/data/logs:/etc/vector",
 		"--volume", "/var/run/docker.sock:/var/run/docker.sock",
 		"--volume", common.MustGetEnv("DOKKU_LOGS_HOST_DIR") + ":/var/logs/dokku/apps",
 		"--volume", common.MustGetEnv("DOKKU_LOGS_HOST_DIR") + "/apps:/var/log/dokku/apps",


### PR DESCRIPTION
This allows users to provide extra configuration files for Vector, such as when using the GCP Operations log sink.

Closes #4971