### PR TITLE
Un-deprecate apps and config cli aliases

### DIFF
--- a/plugins/apps/src/commands/commands.go
+++ b/plugins/apps/src/commands/commands.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dokku/dokku/plugins/apps"
 	"github.com/dokku/dokku/plugins/common"
 )
 
@@ -37,7 +38,15 @@ func main() {
 
 	cmd := flag.Arg(0)
 	switch cmd {
-	case "apps", "apps:help":
+	case "apps":
+		args := flag.NewFlagSet("apps", flag.ExitOnError)
+		args.Usage = usage
+		args.Parse(os.Args[2:])
+
+		if err := apps.CommandList(); err != nil {
+			common.LogFailWithError(err)
+		}
+	case "apps:help":
 		usage()
 	case "help":
 		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))

--- a/plugins/config/src/commands/commands.go
+++ b/plugins/config/src/commands/commands.go
@@ -38,16 +38,16 @@ func main() {
 	cmd := flag.Arg(0)
 	switch cmd {
 	case "config":
-		common.LogWarn("Deprecated: Use the 'config:show' command instead")
-		args := flag.NewFlagSet("config:show", flag.ExitOnError)
+		args := flag.NewFlagSet("config", flag.ExitOnError)
+		args.Usage = usage
 		global := args.Bool("global", false, "--global: use the global environment")
 		shell := args.Bool("shell", false, "--shell: in a single-line for usage in command-line utilities [deprecated]")
 		export := args.Bool("export", false, "--export: print the env as eval-compatible exports [deprecated]")
 		merged := args.Bool("merged", false, "--merged: display the app's environment merged with the global environment")
 		args.Parse(os.Args[2:])
 		appName := args.Arg(0)
-		err := config.CommandShow(appName, *global, *merged, *shell, *export)
-		if err != nil {
+
+		if err := config.CommandShow(appName, *global, *merged, *shell, *export); err != nil {
 			common.LogFailWithError(err)
 		}
 	case "config:help":

--- a/tests/unit/apps_1.bats
+++ b/tests/unit/apps_1.bats
@@ -11,7 +11,7 @@ teardown() {
 }
 
 @test "(apps) apps:help" {
-  run /bin/bash -c "dokku apps"
+  run /bin/bash -c "dokku apps --help"
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "Manage apps"

--- a/tests/unit/config.bats
+++ b/tests/unit/config.bats
@@ -19,10 +19,17 @@ teardown() {
 }
 
 @test "(config) config:help" {
+  run /bin/bash -c "dokku config --help"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "Manage global and app-specific config vars"
+  help_output="$output"
+
   run /bin/bash -c "dokku config:help"
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "Manage global and app-specific config vars"
+  assert_output "$help_output"
 }
 
 @test "(config) config:set --global" {


### PR DESCRIPTION
This better follows Heroku's output and is more useful to users. The subcommands will be treated as the primary, documented versions, while the aliases are there for convenience.

Closes #5362