### PR TITLE
Clarify how to specify the contents of an ssh key for dokku

### DIFF
--- a/docs/deployment/user-management.md
+++ b/docs/deployment/user-management.md
@@ -58,7 +58,7 @@ dokku ssh-keys:list --format json admin
 
 ### Adding SSH keys
 
-You can add your public key to Dokku with the `ssh-keys:add` command. The output will be the fingerprint of the SSH key:
+You can add your public key to Dokku with the `ssh-keys:add` command. The path specified must contain your desired public ssh key contents and must exist on the server. Any special characters - such as `~` - are interpreted under the `dokku` user context. The output will be the fingerprint of the SSH key:
 
 ```shell
 dokku ssh-keys:add KEY_NAME path/to/id_rsa.pub
@@ -71,6 +71,26 @@ SHA256:ABC123ABC123+abc123abc123Zabc123abcZ123abc
 `KEY_NAME` is the name you want to use to refer to this particular key. Including the word `admin` in the name will grant the user privileges to add additional keys remotely.
 
 > `KEY_NAME` is a unique name which is used to identify public keys. Attempting to re-use a key name will result in an error. The SSH (Git) user is *always* `dokku`, as this is the system user that the `dokku` binary uses to perform all its actions.
+
+Alternatively, you may pipe the contents of your ssh key via `cat` or `echo` into the `ssh-keys:add` command instead of specifying a path to the ssh key:
+
+```shell
+echo "$CONTENTS_OF_YOUR_PUBLIC_SSH_KEY_HERE" | dokku ssh-keys:add KEY_NAME
+```
+
+```
+SHA256:ABC123ABC123+abc123abc123Zabc123abcZ123abc
+```
+
+
+```shell
+cat path/to/id_rsa.pub | dokku ssh-keys:add KEY_NAME
+```
+
+```
+SHA256:ABC123ABC123+abc123abc123Zabc123abcZ123abc
+```
+
 
 Admin users and root can add keys remotely by specifying the `dokku` bin on their `ssh` command:
 


### PR DESCRIPTION
- The path has to exist on the remote server
- The `~` is interpreted as the dokku user
- You can echo or cat your key instead of specifying a path