### PR TITLE
Add application/wasm to nginx.conf.sigil gzip

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -22,7 +22,7 @@ server {
     gzip on;
     gzip_min_length  1100;
     gzip_buffers  4 32k;
-    gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+    gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/wasm application/json application/xml application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
     gzip_vary on;
     gzip_comp_level  6;
 


### PR DESCRIPTION
Hi! `.wasm` files tend to be the largest out there and also the ones that benefit from gzip a lot. This PR adds them as candidates for gzipping