### PR TITLE
Detect and use systemd on Debian systems when interacting with nginx

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -58,10 +58,8 @@ A value of 64 would allow domains with up to 64 characters. Set it to 128 if you
 Save the file and try stopping nginx and starting it again:
 
 ```shell
-/etc/init.d/nginx stop
-## * Stopping nginx nginx                                        [ OK ]
-/etc/init.d/nginx start
-## * Starting nginx nginx                                        [ OK ]
+dokku nginx:stop
+dokku nginx:start
 ```
 
 ---

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -69,7 +69,11 @@ trigger-nginx-vhosts-install() {
   local mode="0440"
   case "$DOKKU_DISTRO" in
     debian | raspbian)
-      echo "%dokku ALL=(ALL) NOPASSWD:/usr/sbin/invoke-rc.d $NGINX_INIT_NAME enable, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME disable, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME reload, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME start, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME stop, $NGINX_BIN -t, ${NGINX_BIN} -t -c *" >"$NGINX_SUDOERS_FILE"
+      if [[ -x /usr/bin/systemctl ]]; then
+        echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl enable $NGINX_INIT_NAME, /usr/bin/systemctl disable $NGINX_INIT_NAME, /usr/bin/systemctl reload $NGINX_INIT_NAME, /usr/bin/systemctl start $NGINX_INIT_NAME, /usr/bin/systemctl stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
+      else
+        echo "%dokku ALL=(ALL) NOPASSWD:/usr/sbin/invoke-rc.d $NGINX_INIT_NAME enable, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME disable, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME reload, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME start, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME stop, $NGINX_BIN -t, ${NGINX_BIN} -t -c *" >"$NGINX_SUDOERS_FILE"
+      fi
       ;;
 
     ubuntu)

--- a/plugins/nginx-vhosts/internal-functions
+++ b/plugins/nginx-vhosts/internal-functions
@@ -125,7 +125,11 @@ fn-nginx-vhosts-nginx-init-cmd() {
 
   case "$DOKKU_DISTRO" in
     debian | raspbian)
-      sudo /usr/sbin/invoke-rc.d "$NGINX_INIT_NAME" "$CMD"
+      if [[ -x /usr/bin/systemctl ]]; then
+        sudo /usr/bin/systemctl "$CMD" "$NGINX_INIT_NAME"
+      else
+        sudo /usr/sbin/invoke-rc.d "$NGINX_INIT_NAME" "$CMD"
+      fi
       ;;
 
     ubuntu)


### PR DESCRIPTION
Debian Bookworm completely removes invoke-rc.d, thus breaking interactions with nginx.

Closes #6020