### PR TITLE
Allow the check-commit CI job to work with PRs from other repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: check if message contain keywords ace scopeid
         id: check-commit


### PR DESCRIPTION
To address CI (check-commit) failures on PRs raised from different repos.