### PR TITLE
Fix traefik vhosts compose template

### DIFF
--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -33,8 +33,8 @@ services:
       - "traefik.http.routers.api.entrypoints={{ if $.TRAEFIK_LETSENCRYPT_EMAIL }}https{{ else }}http{{ end }}"
       {{ end }}
       
-      - "traefik.http.routers.api.middlewares=auth"
       {{ if $.TRAEFIK_BASIC_AUTH }}
+      - "traefik.http.routers.api.middlewares=auth"
       - "traefik.http.middlewares.auth.basicauth.users={{ $.TRAEFIK_BASIC_AUTH }}"
       {{ end }}
 

--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -25,7 +25,12 @@ services:
       - --certificatesresolvers.leresolver.acme.tlschallenge=true
       {{ end }}
 
+    {{ if or (eq $.TRAEFIK_API_ENABLED "true") ($.TRAEFIK_BASIC_AUTH) ($.TRAEFIK_LETSENCRYPT_EMAIL) }}
     labels:
+    {{ else }}
+    labels: []
+    {{ end }}
+
       {{ if eq $.TRAEFIK_API_ENABLED "true" }}
       # Dashboard
       - "traefik.http.routers.api.rule=Host(`{{ $.TRAEFIK_API_VHOST }}`)"

--- a/tests/unit/traefik.bats
+++ b/tests/unit/traefik.bats
@@ -238,3 +238,25 @@ teardown() {
   echo "status: $status"
   assert_output "http:80:5000"
 }
+
+@test "(traefik) show-config without auth set" {
+  run /bin/bash -c "dokku traefik:set --global basic-auth-username \"\""
+  run /bin/bash -c "dokku traefik:set --global basic-auth-password \"\""
+
+  run /bin/bash -c "dokku traefik:show-config"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  refute_line '      - "traefik.http.routers.api.middlewares=auth"'
+}
+
+@test "(traefik) show-config with auth set" {
+  run /bin/bash -c "dokku traefik:set --global basic-auth-username test-username"
+  run /bin/bash -c "dokku traefik:set --global basic-auth-password test-password"
+
+  run /bin/bash -c "dokku traefik:show-config"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_line '      - "traefik.http.routers.api.middlewares=auth"'
+}


### PR DESCRIPTION
`auth` middleware label should only be added if `TRAEFIK_BASIC_AUTH` set

Original discord question: https://discord.com/channels/952684157123837952/1128590189812518972