### PR TITLE
Use an alternative curl request to ensure requests go to the local nginx

### DIFF
--- a/tests/unit/nginx-vhosts_5.bats
+++ b/tests/unit/nginx-vhosts_5.bats
@@ -31,11 +31,10 @@ teardown() {
   check_urls http://${TEST_APP}.dokku.me:3003
   check_urls http://www.test.app.dokku.me:3000
   check_urls http://www.test.app.dokku.me:3003
-  assert_http_success http://${TEST_APP}.dokku.me:3000
-  assert_http_success http://${TEST_APP}.dokku.me:3003
-  assert_http_success http://www.test.app.dokku.me:3000
-  assert_http_success http://www.test.app.dokku.me:3003
-
+  assert_http_localhost_success "http" "${TEST_APP}.dokku.me" "3000"
+  assert_http_localhost_success "http" "${TEST_APP}.dokku.me" "3003"
+  assert_http_localhost_success "http" "www.test.app.dokku.me" "3000"
+  assert_http_localhost_success "http" "www.test.app.dokku.me" "3003"
 }
 
 @test "(nginx-vhosts) proxy:build-config (multiple networks)" {

--- a/tests/unit/nginx-vhosts_7.bats
+++ b/tests/unit/nginx-vhosts_7.bats
@@ -39,7 +39,7 @@ teardown() {
   assert_success
 
   assert_nonssl_domain "www.test.app.dokku.me"
-  assert_http_success "customtemplate.dokku.me"
+  assert_http_localhost_success "http" "customtemplate.dokku.me"
 
   run /bin/bash -c "dokku nginx:show-config $TEST_APP"
   echo "output: $output"

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -223,6 +223,15 @@ assert_http_success() {
   assert_output "200"
 }
 
+assert_http_localhost_success() {
+  local scheme="$1" domain="$2" port="${3:-80}" path="${4:-}"
+  run curl --connect-to "$domain:$port:localhost:$port" -kSso /dev/null -w "%{http_code}" "$scheme://$domain:$port$path"
+  echo "curl: curl --connect-to $domain:$port:localhost:$port-kSso /dev/null -w %{http_code} $scheme://$domain:$port$path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "200"
+}
+
 assert_ssl_domain() {
   local domain=$1
   assert_app_domain "${domain}"


### PR DESCRIPTION
The alternative is to rely on DNS and /etc/hosts rules, which isn't quite great because it requires modifying the system.