### PR TITLE
Add assertions to various bats tests

### DIFF
--- a/tests/unit/apps_1.bats
+++ b/tests/unit/apps_1.bats
@@ -55,11 +55,16 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+
   run /bin/bash -c "dokku apps:list | grep $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_output $TEST_APP
-  destroy_app
+
+  run destroy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku apps:create 1994testapp"
   echo "output: $output"
@@ -95,12 +100,16 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+
   run /bin/bash -c "dokku apps:list | grep $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_output $TEST_APP
 
-  destroy_app
+  run destroy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 }
 
 @test "(apps) app autocreate disabled" {
@@ -117,13 +126,21 @@ teardown() {
 }
 
 @test "(apps) apps:destroy" {
-  create_app
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku --force apps:destroy $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  create_app
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku --force --app $TEST_APP apps:destroy"
   echo "output: $output"
   echo "status: $status"
@@ -131,7 +148,10 @@ teardown() {
 }
 
 @test "(apps) apps:rename" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "dokku apps:rename $TEST_APP great-test-name"
   echo "output: $output"
   echo "status: $status"
@@ -248,7 +268,11 @@ teardown() {
   echo "status: $status"
   assert_failure
 
-  create_app
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku apps:exists $TEST_APP"
   echo "output: $output"
   echo "status: $status"
@@ -262,7 +286,10 @@ teardown() {
 }
 
 @test "(apps) apps:lock/locked/unlock" {
-  create_app
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku apps:report $TEST_APP --app-locked"
   echo "output: $output"

--- a/tests/unit/apps_2.bats
+++ b/tests/unit/apps_2.bats
@@ -11,7 +11,10 @@ teardown() {
 }
 
 @test "(apps) apps:clone" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "dokku apps:clone $TEST_APP great-test-name"
   echo "output: $output"
   echo "status: $status"
@@ -144,7 +147,10 @@ teardown() {
 }
 
 @test "(apps) apps:clone --skip-deploy" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "dokku apps:clone --skip-deploy $TEST_APP great-test-name"
   echo "output: $output"
   echo "status: $status"
@@ -172,7 +178,10 @@ teardown() {
 }
 
 @test "(apps) apps:clone --ignore-existing" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "dokku apps:create great-test-name"
   echo "output: $output"
   echo "status: $status"

--- a/tests/unit/build-env.bats
+++ b/tests/unit/build-env.bats
@@ -18,7 +18,10 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "dokku config $TEST_APP"
   assert_success
 }
@@ -34,7 +37,10 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "dokku config:get --global CURL_CONNECT_TIMEOUT | grep 90"
   echo "output: $output"
   echo "status: $status"
@@ -76,7 +82,10 @@ teardown() {
 }
 
 @test "(build-env) DOKKU_ROOT cache bind is used by default" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   BUILD_CID=$(docker ps -a | grep $TEST_APP | grep /bin/bash | awk '{print $1}' | head -n1)
   run /bin/bash -c "docker inspect --format '{{ .HostConfig.Binds }}' $BUILD_CID | tr -d '[]' | cut -f1 -d:"

--- a/tests/unit/checks.bats
+++ b/tests/unit/checks.bats
@@ -188,7 +188,10 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku checks:run $TEST_APP"
   echo "output: $output"
@@ -227,7 +230,10 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku checks:disable $TEST_APP worker"
   echo "output: $output"

--- a/tests/unit/client.bats
+++ b/tests/unit/client.bats
@@ -171,7 +171,10 @@ teardown() {
 #   # looks like docker exec is built to work with docker-under-libcontainer,
 #   # but we're using docker-under-lxc. I don't have an estimated time for the fix, sorry
 #   skip "circleci does not support docker exec at the moment."
-#   deploy_app
+#   run deploy_app
+#   echo "output: $output"
+#   echo "status: $status"
+#   assert_success
 #   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh ps $TEST_APP | grep -q 'node web.js'"
 #   echo "output: $output"
 #   echo "status: $status"
@@ -179,7 +182,10 @@ teardown() {
 # }
 
 @test "(client) ps:start" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh ps:stop $TEST_APP"
   echo "output: $output"
   echo "status: $status"
@@ -197,7 +203,10 @@ teardown() {
 }
 
 @test "(client) ps:stop" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh ps:stop $TEST_APP"
   echo "output: $output"
   echo "status: $status"
@@ -211,7 +220,10 @@ teardown() {
 }
 
 @test "(client) ps:restart" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh ps:restart $TEST_APP"
   echo "output: $output"
   echo "status: $status"

--- a/tests/unit/core_1.bats
+++ b/tests/unit/core_1.bats
@@ -16,7 +16,10 @@ teardown() {
 }
 
 @test "(core) remove exited containers" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   # make sure we have many exited containers of the same 'type'
   run /bin/bash -c "for cnt in 1 2 3; do dokku run $TEST_APP echo $TEST_APP; done"
@@ -89,7 +92,11 @@ EOF
 
   CID=$(<"$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1")
   docker commit --change "ENV USER postgres" "$CID" "dokku/${TEST_APP}:latest"
-  dokku config:set --no-restart "$TEST_APP" DOKKU_APP_USER=postgres
+  run /bin/bash -c "dokku config:set --no-restart $TEST_APP DOKKU_APP_USER=postgres"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
   source "$PLUGIN_CORE_AVAILABLE_PATH/config/functions"
 

--- a/tests/unit/core_2.bats
+++ b/tests/unit/core_2.bats
@@ -39,7 +39,12 @@ teardown() {
 
 @test "(core) urls (non-ssl)" {
   assert_urls "http://${TEST_APP}.dokku.me"
-  dokku domains:add $TEST_APP "test.dokku.me"
+
+  run /bin/bash -c "dokku domains:add $TEST_APP test.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   assert_urls "http://${TEST_APP}.dokku.me" "http://test.dokku.me"
 }
 

--- a/tests/unit/domains.bats
+++ b/tests/unit/domains.bats
@@ -342,9 +342,16 @@ teardown() {
   echo "status: $status"
   assert_success
 
+  run /bin/bash -c "dokku --quiet apps:create test.dokku.test"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   # run domains:clear in order to invoke default vhost creation
-  dokku --quiet apps:create test.dokku.test
-  dokku --quiet domains:clear test.dokku.test
+  run /bin/bash -c "dokku --quiet domains:clear test.dokku.test"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku domains:report test.dokku.test --domains-app-vhosts"
   echo "output: $output"
@@ -352,7 +359,10 @@ teardown() {
   assert_success
   assert_output "test.dokku.test"
 
-  dokku --force apps:destroy test.dokku.test
+  run /bin/bash -c "dokku --force apps:destroy test.dokku.test"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 }
 
 @test "(domains) app rename only renames domains associated with global domains" {

--- a/tests/unit/events.bats
+++ b/tests/unit/events.bats
@@ -24,14 +24,17 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+
   run /bin/bash -c "test -f /etc/rsyslog.d/99-dokku.conf"
   echo "output: $output"
   echo "status: $status"
   assert_success
+
   run /bin/bash -c "stat -c '%U:%G:%a' /var/log/dokku/"
   echo "output: $output"
   echo "status: $status"
   assert_output "syslog:dokku:775"
+
   run /bin/bash -c "stat -c '%U:%G:%a' /var/log/dokku/events.log"
   echo "output: $output"
   echo "status: $status"
@@ -40,10 +43,22 @@ teardown() {
 
 @test "(events) log commands" {
   run /bin/bash -c "dokku events:on"
-  deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku events"
   echo "output: $output"
   echo "status: $status"
   assert_success
+
   run /bin/bash -c "dokku events:off"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 }

--- a/tests/unit/git_2.bats
+++ b/tests/unit/git_2.bats
@@ -94,7 +94,10 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "test -d $DOKKU_ROOT/$TEST_APP/refs"
   echo "output: $output"

--- a/tests/unit/init.bats
+++ b/tests/unit/init.bats
@@ -15,7 +15,11 @@ teardown() {
 @test "(init) buildpack" {
   source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
   local APP="zombies-buildpack"
-  deploy_app "$APP"
+  run deploy_app "$APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   local CIDS=$(get_app_container_ids "$APP")
 
   run "$DOCKER_BIN" container top "$CIDS"
@@ -26,7 +30,11 @@ teardown() {
 @test "(init) dockerfile no tini" {
   source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
   local APP="zombies-dockerfile-no-tini"
-  deploy_app "$APP"
+  run deploy_app "$APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   local CIDS=$(get_app_container_ids "$APP")
 
   run "$DOCKER_BIN" container top "$CIDS"
@@ -37,7 +45,11 @@ teardown() {
 @test "(init) dockerfile with tini" {
   source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
   local APP="zombies-dockerfile-tini"
-  deploy_app "$APP"
+  run deploy_app "$APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   local CIDS=$(get_app_container_ids "$APP")
 
   run "$DOCKER_BIN" container top "$CIDS"

--- a/tests/unit/network.bats
+++ b/tests/unit/network.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   docker network rm create-network || true
   docker network rm deploy-network || true
@@ -32,7 +32,10 @@ teardown() {
 }
 
 @test "(network) network:set bind-all-interfaces" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   assert_nonssl_domain "${TEST_APP}.dokku.me"
 
   run /bin/bash -c "dokku network:set $TEST_APP bind-all-interfaces true"

--- a/tests/unit/nginx-vhosts_1.bats
+++ b/tests/unit/nginx-vhosts_1.bats
@@ -29,8 +29,15 @@ teardown() {
 }
 
 @test "(nginx-vhosts) proxy:build-config (domains:disable/enable)" {
-  deploy_app
-  dokku domains:disable $TEST_APP
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:disable $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   HOSTNAME=$(<"$DOKKU_ROOT/VHOST")
   check_urls http://${HOSTNAME}:[0-9]+
@@ -40,19 +47,29 @@ teardown() {
     assert_http_success $URL
   done
 
-  dokku domains:enable $TEST_APP
+  run /bin/bash -c "dokku domains:enable $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   check_urls http://${TEST_APP}.dokku.me
   assert_http_success http://${TEST_APP}.dokku.me
 }
 
 @test "(nginx-vhosts) proxy:build-config (domains:add pre deploy)" {
-  create_app
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   sleep 5 # wait for nginx to reload
 
   check_urls http://www.test.app.dokku.me
@@ -61,7 +78,10 @@ teardown() {
 
 @test "(nginx-vhosts) proxy:build-config (with global VHOST)" {
   echo "dokku.me" >"$DOKKU_ROOT/VHOST"
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   check_urls http://${TEST_APP}.dokku.me
   assert_http_success http://${TEST_APP}.dokku.me

--- a/tests/unit/nginx-vhosts_10.bats
+++ b/tests/unit/nginx-vhosts_10.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }

--- a/tests/unit/nginx-vhosts_11.bats
+++ b/tests/unit/nginx-vhosts_11.bats
@@ -9,13 +9,16 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }
 
 @test "(nginx-vhosts) nginx:set proxy-buffer-size" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffer-size 2k"
   echo "output: $output"
@@ -49,7 +52,10 @@ teardown() {
 }
 
 @test "(nginx-vhosts) nginx:set proxy-buffering" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffering off"
   echo "output: $output"
@@ -83,7 +89,10 @@ teardown() {
 }
 
 @test "(nginx-vhosts) nginx:set proxy-buffers" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku nginx:set $TEST_APP proxy-buffers \"64 4k\""
   echo "output: $output"
@@ -117,7 +126,10 @@ teardown() {
 }
 
 @test "(nginx-vhosts) nginx:set proxy-busy-buffers-size" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku nginx:set $TEST_APP proxy-busy-buffers-size 10k"
   echo "output: $output"

--- a/tests/unit/nginx-vhosts_12.bats
+++ b/tests/unit/nginx-vhosts_12.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }

--- a/tests/unit/nginx-vhosts_2.bats
+++ b/tests/unit/nginx-vhosts_2.bats
@@ -9,33 +9,69 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }
 
 @test "(nginx-vhosts) proxy:build-config (with SSL and unrelated domain)" {
   setup_test_tls
-  dokku domains:add $TEST_APP "node-js-app.dokku.me"
-  dokku domains:add $TEST_APP "test.dokku.me"
-  deploy_app
-  dokku nginx:show-config $TEST_APP
+  run /bin/bash -c "dokku domains:add $TEST_APP node-js-app.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:add $TEST_APP test.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   assert_ssl_domain "node-js-app.dokku.me"
   assert_http_redirect "http://test.dokku.me" "https://test.dokku.me:443/"
 }
 
 @test "(nginx-vhosts) proxy:build-config (wildcard SSL)" {
   setup_test_tls wildcard
-  dokku domains:add $TEST_APP "wildcard1.dokku.me"
-  dokku domains:add $TEST_APP "wildcard2.dokku.me"
-  deploy_app
-  dokku nginx:show-config $TEST_APP
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard1.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard2.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   assert_ssl_domain "wildcard1.dokku.me"
   assert_ssl_domain "wildcard2.dokku.me"
 }
 
 @test "(nginx-vhosts) proxy:build-config (wildcard SSL and unrelated domain) 1" {
-  destroy_app
+  run destroy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   TEST_APP="${TEST_APP}.example.com"
   run /bin/bash -c "dokku apps:create $TEST_APP"
   echo "output: $output"
@@ -43,18 +79,45 @@ teardown() {
   assert_success
 
   setup_test_tls wildcard
-  deploy_app nodejs-express dokku@dokku.me:$TEST_APP
+
+  run deploy_app nodejs-express dokku@dokku.me:$TEST_APP
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku nginx:show-config $TEST_APP | grep -e '*.dokku.me' | wc -l"
-  dokku nginx:show-config $TEST_APP
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   assert_output "0"
 }
 
 @test "(nginx-vhosts) proxy:build-config (with SSL and Multiple SANs)" {
   setup_test_tls sans
-  dokku domains:add $TEST_APP "test.dokku.me"
-  dokku domains:add $TEST_APP "www.test.dokku.me"
-  dokku domains:add $TEST_APP "www.test.app.dokku.me"
-  deploy_app
+  run /bin/bash -c "dokku domains:add $TEST_APP test.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   assert_ssl_domain "test.dokku.me"
   assert_ssl_domain "www.test.dokku.me"
   assert_ssl_domain "www.test.app.dokku.me"

--- a/tests/unit/nginx-vhosts_3.bats
+++ b/tests/unit/nginx-vhosts_3.bats
@@ -11,7 +11,7 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }

--- a/tests/unit/nginx-vhosts_4.bats
+++ b/tests/unit/nginx-vhosts_4.bats
@@ -16,7 +16,10 @@ teardown() {
 
 @test "(nginx-vhosts) proxy:build-config (without global VHOST)" {
   rm "$DOKKU_ROOT/VHOST"
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku --quiet urls $TEST_APP"
   echo "output: $output"
@@ -35,7 +38,10 @@ teardown() {
 @test "(nginx-vhosts) proxy:build-config (without global VHOST and IPv4 address set as HOSTNAME)" {
   rm "$DOKKU_ROOT/VHOST"
   echo "127.0.0.1" >"$DOKKU_ROOT/VHOST"
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   HOSTNAME=$(<"$DOKKU_ROOT/VHOST")
   check_urls http://${HOSTNAME}:[0-9]+
@@ -49,7 +55,10 @@ teardown() {
 @test "(nginx-vhosts) proxy:build-config (without global VHOST and IPv6 address set as HOSTNAME)" {
   rm "$DOKKU_ROOT/VHOST"
   echo "fda5:c7db:a520:bb6d::aabb:ccdd:eeff" >"$DOKKU_ROOT/VHOST"
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   HOSTNAME=$(<"$DOKKU_ROOT/VHOST")
   check_urls http://${HOSTNAME}:[0-9]+
@@ -57,16 +66,35 @@ teardown() {
 
 @test "(nginx-vhosts) proxy:build-config (without global VHOST and domains:add pre deploy)" {
   rm "$DOKKU_ROOT/VHOST"
-  create_app
-  dokku domains:add $TEST_APP "www.test.app.dokku.me"
-  deploy_app
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   assert_nonssl_domain "www.test.app.dokku.me"
 }
 
 @test "(nginx-vhosts) proxy:build-config (without global VHOST and domains:add post deploy)" {
   rm "$DOKKU_ROOT/VHOST"
-  deploy_app
-  dokku domains:add $TEST_APP "www.test.app.dokku.me"
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   check_urls http://www.test.app.dokku.me
   assert_http_success http://www.test.app.dokku.me
 }

--- a/tests/unit/nginx-vhosts_5.bats
+++ b/tests/unit/nginx-vhosts_5.bats
@@ -17,16 +17,26 @@ teardown() {
 
 @test "(nginx-vhosts) proxy:build-config (sslip.io style hostnames)" {
   echo "127.0.0.1.sslip.io.dokku.me" >"$DOKKU_ROOT/VHOST"
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   check_urls http://${TEST_APP}.127.0.0.1.sslip.io.dokku.me
   assert_http_success http://${TEST_APP}.127.0.0.1.sslip.io.dokku.me
 }
 
 @test "(nginx-vhosts) proxy:build-config (dockerfile expose)" {
-  deploy_app dockerfile
+  run deploy_app dockerfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
-  dokku domains:add $TEST_APP "www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   check_urls http://${TEST_APP}.dokku.me:3000
   check_urls http://${TEST_APP}.dokku.me:3003
   check_urls http://www.test.app.dokku.me:3000
@@ -39,7 +49,10 @@ teardown() {
 }
 
 @test "(nginx-vhosts) proxy:build-config (multiple networks)" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   create_attach_network
   run /bin/bash -c "dokku proxy:build-config $TEST_APP"
@@ -52,7 +65,10 @@ teardown() {
   local GLOBAL_PORT=30999
   run /bin/bash -c "dokku config:set --global DOKKU_PROXY_PORT=${GLOBAL_PORT}"
 
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   check_urls http://${TEST_APP}.dokku.me:${GLOBAL_PORT}
   assert_http_success http://${TEST_APP}.dokku.me:${GLOBAL_PORT}
 

--- a/tests/unit/nginx-vhosts_6.bats
+++ b/tests/unit/nginx-vhosts_6.bats
@@ -9,13 +9,16 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }
 
 @test "(nginx-vhosts) nginx (no server tokens)" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "curl -s -D - $(dokku url $TEST_APP) -o /dev/null | grep -E '^Server' | grep -E '[0-9]+'"
   echo "output: $output"
   echo "status: $status"
@@ -205,7 +208,10 @@ teardown() {
 }
 
 @test "(nginx-vhosts) nginx:validate-config" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   run /bin/bash -c "dokku nginx:validate-config"
   echo "output: $output"
   echo "status: $status"

--- a/tests/unit/nginx-vhosts_7.bats
+++ b/tests/unit/nginx-vhosts_7.bats
@@ -9,16 +9,27 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }
 
 @test "(nginx-vhosts) proxy:build-config (wildcard SSL and custom nginx template)" {
   setup_test_tls wildcard
-  dokku domains:add $TEST_APP "wildcard1.dokku.me"
-  dokku domains:add $TEST_APP "wildcard2.dokku.me"
-  deploy_app nodejs-express dokku@dokku.me:$TEST_APP custom_ssl_nginx_template
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard1.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard2.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app nodejs-express dokku@dokku.me:$TEST_APP custom_ssl_nginx_template
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   assert_ssl_domain "wildcard1.dokku.me"
   assert_ssl_domain "wildcard2.dokku.me"
@@ -27,7 +38,11 @@ teardown() {
 }
 
 @test "(nginx-vhosts) proxy:build-config (custom nginx template - no ssl)" {
-  dokku domains:add $TEST_APP "www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run deploy_app nodejs-express dokku@dokku.me:$TEST_APP custom_nginx_template
   echo "output: $output"
   echo "status: $status"
@@ -53,7 +68,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  dokku domains:add $TEST_APP "www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run deploy_app nodejs-express dokku@dokku.me:$TEST_APP custom_nginx_template
   echo "output: $output"
   echo "status: $status"

--- a/tests/unit/nginx-vhosts_8.bats
+++ b/tests/unit/nginx-vhosts_8.bats
@@ -9,13 +9,16 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }
 
 @test "(nginx-vhosts) nginx:set client-max-body-size" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku nginx:set $TEST_APP client-max-body-size"
   echo "output: $output"
@@ -49,7 +52,10 @@ teardown() {
 }
 
 @test "(nginx-vhosts) nginx:set proxy-read-timeout" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku nginx:set $TEST_APP proxy-read-timeout 45s"
   echo "output: $output"
@@ -84,7 +90,10 @@ teardown() {
 
 @test "(nginx-vhosts) nginx:set proxy-read-timeout (with SSL)" {
   setup_test_tls
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku nginx:set $TEST_APP proxy-read-timeout 45s"
   echo "output: $output"

--- a/tests/unit/nginx-vhosts_9.bats
+++ b/tests/unit/nginx-vhosts_9.bats
@@ -9,13 +9,16 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }
 
 @test "(nginx-vhosts) logging" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run [ -a "/var/log/nginx/$TEST_APP-access.log" ]
   echo "output: $output"
@@ -39,7 +42,10 @@ teardown() {
 }
 
 @test "(nginx-vhosts) log-path" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku nginx:set $TEST_APP access-log-path off"
   echo "output: $output"
@@ -103,7 +109,10 @@ teardown() {
 }
 
 @test "(nginx-vhosts) access-log-format" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku nginx:set $TEST_APP access-log-format combined"
   echo "output: $output"
@@ -154,20 +163,52 @@ teardown() {
 
 @test "(nginx-vhosts) proxy:build-config (with SSL and unrelated domain)" {
   setup_test_tls
-  dokku domains:add $TEST_APP "node-js-app.dokku.me"
-  dokku domains:add $TEST_APP "test.dokku.me"
-  deploy_app
-  dokku nginx:show-config $TEST_APP
+  run /bin/bash -c "dokku domains:add $TEST_APP node-js-app.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:add $TEST_APP test.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   assert_ssl_domain "node-js-app.dokku.me"
   assert_http_redirect "http://test.dokku.me" "https://test.dokku.me:443/"
 }
 
 @test "(nginx-vhosts) proxy:build-config (wildcard SSL)" {
   setup_test_tls wildcard
-  dokku domains:add $TEST_APP "wildcard1.dokku.me"
-  dokku domains:add $TEST_APP "wildcard2.dokku.me"
-  deploy_app
-  dokku nginx:show-config $TEST_APP
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard1.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard2.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   assert_ssl_domain "wildcard1.dokku.me"
   assert_ssl_domain "wildcard2.dokku.me"
 }

--- a/tests/unit/ports.bats
+++ b/tests/unit/ports.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }
@@ -91,7 +91,11 @@ teardown() {
 }
 
 @test "(ports:add) post-deploy add" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku ports:add $TEST_APP http:8080:5000 http:8081:5000"
   echo "output: $output"
   echo "status: $status"

--- a/tests/unit/proxy.bats
+++ b/tests/unit/proxy.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 teardown() {
-  destroy_app 0 $TEST_APP
+  destroy_app
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST" && chown dokku:dokku "$DOKKU_ROOT/VHOST"
   global_teardown
 }
@@ -91,7 +91,11 @@ teardown() {
 }
 
 @test "(proxy) proxy:enable/disable" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   assert_nonssl_domain "${TEST_APP}.dokku.me"
 
   run /bin/bash -c "dokku proxy:disable $TEST_APP"

--- a/tests/unit/ps-dockerfile-1.bats
+++ b/tests/unit/ps-dockerfile-1.bats
@@ -13,11 +13,16 @@ teardown() {
 }
 
 @test "(ps) dockerfile" {
-  deploy_app dockerfile
+  run deploy_app dockerfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku ps:stop $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
+
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.*; do
     run /bin/bash -c "docker ps -q --no-trunc | grep -q $(<$CID_FILE)"
     echo "output: $output"
@@ -65,9 +70,21 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  destroy_app
-  create_app
-  deploy_app dockerfile-procfile
+  run destroy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app dockerfile-procfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku ps:scale $TEST_APP non-existent=2"
   echo "output: $output"
   echo "status: $status"
@@ -80,7 +97,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  deploy_app dockerfile
+  run deploy_app dockerfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CIDS=""
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.web.*; do
     CIDS+=$(<$CID_FILE)

--- a/tests/unit/ps-dockerfile-2.bats
+++ b/tests/unit/ps-dockerfile-2.bats
@@ -18,7 +18,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  deploy_app dockerfile-app-json-formations
+  run deploy_app dockerfile-app-json-formations
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CIDS=""
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.web.*; do
     CIDS+=$(<$CID_FILE)
@@ -42,7 +46,11 @@ teardown() {
 }
 
 @test "(ps) dockerfile with procfile" {
-  deploy_app dockerfile-procfile
+  run deploy_app dockerfile-procfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku ps:stop $TEST_APP"
   echo "output: $output"
   echo "status: $status"
@@ -106,7 +114,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  deploy_app dockerfile-procfile
+  run deploy_app dockerfile-procfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   for PROC_TYPE in web worker; do
     run /bin/bash -c "docker ps --format '{{.ID}} {{.Command}}' --no-trunc"
     echo "output: $output"

--- a/tests/unit/ps-general-1.bats
+++ b/tests/unit/ps-general-1.bats
@@ -27,8 +27,15 @@ teardown() {
 }
 
 @test "(ps) ps:inspect" {
-  dokku config:set "$TEST_APP" key=value key=value=value
-  deploy_app dockerfile
+  run /bin/bash -c "dokku config:set $TEST_APP key=value key=value=value"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app dockerfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "dokku ps:inspect $TEST_APP"
@@ -113,7 +120,10 @@ EOF
   echo "status: $status"
   assert_output "$test_restart_policy"
 
-  deploy_app dockerfile
+  run deploy_app dockerfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect -f '{{ .HostConfig.RestartPolicy.Name }}:{{ .HostConfig.RestartPolicy.MaximumRetryCount }}' $CID"

--- a/tests/unit/ps-herokuish-1.bats
+++ b/tests/unit/ps-herokuish-1.bats
@@ -13,7 +13,11 @@ teardown() {
 }
 
 @test "(ps) herokuish" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku ps:stop $TEST_APP"
   echo "output: $output"
   echo "status: $status"

--- a/tests/unit/ps-herokuish-2.bats
+++ b/tests/unit/ps-herokuish-2.bats
@@ -19,7 +19,10 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   for PROC_TYPE in web worker; do
     CIDS=""
     for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.$PROC_TYPE.*; do
@@ -71,8 +74,15 @@ teardown() {
 
 @test "(ps:restore) herokuish" {
   MYAPP="manual-randomtestapp-1"
-  create_app "$MYAPP"
-  deploy_app
+  run create_app "$MYAPP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku ps:stop $TEST_APP"
   echo "output: $output"

--- a/tests/unit/report.bats
+++ b/tests/unit/report.bats
@@ -39,14 +39,21 @@ teardown() {
   assert_output_contains "App fake-app-name does not exist"
   assert_failure
 
-  dokku apps:create "${TEST_APP}-2"
+  run /bin/bash -c "dokku apps:create ${TEST_APP}-2"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku report ${TEST_APP}-2 2>&1"
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "Deployed:                      false"
   assert_success
 
-  dokku --force apps:destroy "${TEST_APP}-2"
+  run /bin/bash -c "dokku --force apps:destroy ${TEST_APP}-2"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 }
 
 @test "(report) custom docker bin" {

--- a/tests/unit/resource_1.bats
+++ b/tests/unit/resource_1.bats
@@ -32,7 +32,11 @@ teardown() {
   echo "status: $status"
   assert_output_contains "resource limits $TEST_APP information"
 
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku resource:limit --memory 512MB $TEST_APP"
   echo "output: $output"
   echo "status: $status"
@@ -44,7 +48,11 @@ teardown() {
   echo "status: $status"
   assert_output "0"
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.Memory}}' $CID"
   echo "output: $output"
@@ -56,7 +64,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.Memory}}' $CID"
   echo "output: $output"
@@ -68,7 +80,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.Memory}}' $CID"
   echo "output: $output"
@@ -80,7 +96,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.Memory}}' $CID"
   echo "output: $output"
@@ -92,7 +112,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.Memory}}' $CID"
   echo "output: $output"
@@ -104,7 +128,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.Memory}}' $CID"
   echo "output: $output"

--- a/tests/unit/resource_2.bats
+++ b/tests/unit/resource_2.bats
@@ -18,7 +18,11 @@ teardown() {
   echo "status: $status"
   assert_output_contains "resource reservation $TEST_APP information"
 
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku resource:reserve --memory 512MB $TEST_APP"
   echo "output: $output"
   echo "status: $status"
@@ -30,7 +34,11 @@ teardown() {
   echo "status: $status"
   assert_output "0"
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.MemoryReservation}}' $CID"
   echo "output: $output"
@@ -47,7 +55,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.MemoryReservation}}' $CID"
   echo "output: $output"
@@ -59,7 +71,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.MemoryReservation}}' $CID"
   echo "output: $output"
@@ -71,7 +87,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.MemoryReservation}}' $CID"
   echo "output: $output"
@@ -83,7 +103,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  dokku ps:rebuild "$TEST_APP"
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect --format '{{.HostConfig.MemoryReservation}}' $CID"
   echo "output: $output"

--- a/tests/unit/run_1.bats
+++ b/tests/unit/run_1.bats
@@ -24,7 +24,11 @@ teardown() {
 }
 
 @test "(run) run (with --options)" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku --force --quiet run $TEST_APP python -V"
   echo "output: $output"
   echo "status: $status"

--- a/tests/unit/run_2.bats
+++ b/tests/unit/run_2.bats
@@ -13,7 +13,10 @@ teardown() {
 }
 
 @test "(run) run" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku run $TEST_APP echo $TEST_APP"
   echo "output: $output"
@@ -27,7 +30,10 @@ teardown() {
 }
 
 @test "(run) run:detached" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   RANDOM_RUN_CID="$(dokku --label=com.dokku.test-label=value run:detached $TEST_APP sleep 300)"
   run /bin/bash -c "docker inspect -f '{{ .State.Status }}' $RANDOM_RUN_CID"
@@ -53,7 +59,11 @@ teardown() {
 }
 
 @test "(run) run (with tty)" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku run $TEST_APP ls /app/null"
   echo "output: $output"
   echo "status: $status"
@@ -61,7 +71,11 @@ teardown() {
 }
 
 @test "(run) run (without tty)" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c ": |dokku run $TEST_APP ls /app/null"
   echo "output: $output"
   echo "status: $status"
@@ -69,7 +83,11 @@ teardown() {
 }
 
 @test "(run) run command from Procfile" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku run $TEST_APP custom 'hi dokku' | tail -n 1"
   echo "output: $output"
   echo "status: $status"
@@ -79,7 +97,10 @@ teardown() {
 }
 
 @test "(run) list" {
-  deploy_app
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 
   run /bin/bash -c "dokku --quiet run:list $TEST_APP"
   echo "output: $output"

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -195,9 +195,7 @@ create_key() {
 }
 
 destroy_app() {
-  local RC="$1"
-  local RC=${RC:=0}
-  local APP="$2"
+  declare RC="${1:-0}" APP="$2"
   local TEST_APP=${APP:=$TEST_APP}
   dokku --force apps:destroy "$TEST_APP"
   return "$RC"


### PR DESCRIPTION
Missing these assertions didn't necessarily break tests but they are more correct and having them should help suss out bugs.