### PR TITLE
Remove assertion for unconsumed build arguments

### DIFF
--- a/tests/unit/docker-options.bats
+++ b/tests/unit/docker-options.bats
@@ -323,7 +323,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains "One or more build-args \[PAYPAL_CLIENT_ID PAYPAL_CLIENT_MODE\] were not consumed"
+  # assert_output_contains "One or more build-args \[PAYPAL_CLIENT_ID PAYPAL_CLIENT_MODE\] were not consumed"
 
   CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
   run /bin/bash -c "docker inspect -f '{{ .Config.Volumes }}' $CID | sed -e 's:map::g' | tr -d '[]' | tr ' ' $'\n' | sort | xargs"


### PR DESCRIPTION
Docker no longer outputs any logging for unconsumed build arguments with the switch to buildx.