### PR TITLE
tests: make it possible to specify an alternative base domain for tests

### DIFF
--- a/.github/commands/ci-setup
+++ b/.github/commands/ci-setup
@@ -2,19 +2,23 @@
 set -eo pipefail
 set -x
 
+DOKKU_DOMAIN=${DOKKU_DOMAIN:="dokku.me"}
+
 echo "=====> set hostname"
 hostname
 internal_ip="$(ifconfig eth0 | grep 'inet ' | awk '{print $2}')"
-sudo hostname "dokku.me"
-echo "dokku.me" | sudo tee /etc/hostname
+sudo hostname "$DOKKU_DOMAIN"
+echo "$DOKKU_DOMAIN" | sudo tee /etc/hostname
 hostname
 sudo cat /etc/hostname
 
-echo "=====> resolve dokku.me"
+echo "=====> resolve $DOKKU_DOMAIN"
 sudo apt -qq -y --no-install-recommends install net-tools
-# dokku.me now resolves to 10.0.0.2. add 10.0.0.2/24 to eth0
-ifconfig
-sudo ip addr add 10.0.0.2/24 broadcast 10.0.0.255 dev eth0
+if [[ "$DOKKU_DOMAIN" == "dokku.me" ]]; then
+  # dokku.me now resolves to 10.0.0.2. add 10.0.0.2/24 to eth0
+  ifconfig
+  sudo ip addr add 10.0.0.2/24 broadcast 10.0.0.255 dev eth0
+fi
 
 echo "=====> install ci-dependencies"
 make ci-dependencies

--- a/tests.mk
+++ b/tests.mk
@@ -1,5 +1,6 @@
 SYSTEM := $(shell sh -c 'uname -s 2>/dev/null')
 DOKKU_SSH_PORT ?= 22
+DOKKU_DOMAIN ?= dokku.me
 
 bats:
 ifeq ($(SYSTEM),Darwin)
@@ -48,8 +49,8 @@ ifdef ENABLE_DOKKU_TRACE
 	echo "-----> Enable dokku trace"
 	dokku trace:on
 endif
-	@echo "Setting dokku.me in /etc/hosts"
-	sudo /bin/bash -c "[[ `ping -c1 dokku.me >/dev/null 2>&1; echo $$?` -eq 0 ]] || echo \"127.0.0.1  dokku.me *.dokku.me www.test.app.dokku.me\" >> /etc/hosts"
+	@echo "Setting $(DOKKU_DOMAIN) in /etc/hosts"
+	sudo /bin/bash -c "[[ `ping -c1 $(DOKKU_DOMAIN) >/dev/null 2>&1; echo $$?` -eq 0 ]] || echo \"127.0.0.1  $(DOKKU_DOMAIN) *.$(DOKKU_DOMAIN) www.test.app.$(DOKKU_DOMAIN)\" >> /etc/hosts"
 
 	@echo "-----> Generating keypair..."
 	mkdir -p /root/.ssh
@@ -61,10 +62,10 @@ endif
 
 	@echo "-----> Setting up ssh config..."
 ifneq ($(shell ls /root/.ssh/config >/dev/null 2>&1 ; echo $$?),0)
-	echo "Host dokku.me \\r\\n Port $(DOKKU_SSH_PORT) \\r\\n RequestTTY yes \\r\\n IdentityFile /root/.ssh/dokku_test_rsa" >> /root/.ssh/config
+	echo "Host $(DOKKU_DOMAIN) \\r\\n Port $(DOKKU_SSH_PORT) \\r\\n RequestTTY yes \\r\\n IdentityFile /root/.ssh/dokku_test_rsa" >> /root/.ssh/config
 	echo "Host 127.0.0.1 \\r\\n Port 22333 \\r\\n RequestTTY yes \\r\\n IdentityFile /root/.ssh/dokku_test_rsa" >> /root/.ssh/config
-else ifeq ($(shell grep dokku.me /root/.ssh/config),)
-	echo "Host dokku.me \\r\\n Port $(DOKKU_SSH_PORT) \\r\\n RequestTTY yes \\r\\n IdentityFile /root/.ssh/dokku_test_rsa" >> /root/.ssh/config
+else ifeq ($(shell grep $(DOKKU_DOMAIN) /root/.ssh/config),)
+	echo "Host $(DOKKU_DOMAIN) \\r\\n Port $(DOKKU_SSH_PORT) \\r\\n RequestTTY yes \\r\\n IdentityFile /root/.ssh/dokku_test_rsa" >> /root/.ssh/config
 	echo "Host 127.0.0.1 \\r\\n Port 22333 \\r\\n RequestTTY yes \\r\\n IdentityFile /root/.ssh/dokku_test_rsa" >> /root/.ssh/config
 else
 	sed --in-place 's/Port 22 \r/Port $(DOKKU_SSH_PORT) \r/g' /root/.ssh/config
@@ -86,9 +87,9 @@ endif
 	chmod 700 /home/dokku/.ssh
 	chmod 600 /home/dokku/.ssh/authorized_keys
 
-ifeq ($(shell grep dokku.me /home/dokku/VHOST 2>/dev/null),)
-	@echo "-----> Setting default VHOST to dokku.me..."
-	echo "dokku.me" > /home/dokku/VHOST
+ifeq ($(shell grep $(DOKKU_DOMAIN) /home/dokku/VHOST 2>/dev/null),)
+	@echo "-----> Setting default VHOST to $(DOKKU_DOMAIN)..."
+	echo "$(DOKKU_DOMAIN)" > /home/dokku/VHOST
 endif
 ifeq ($(DOKKU_SSH_PORT), 22)
 	$(MAKE) prime-ssh-known-hosts
@@ -105,8 +106,8 @@ endif
 
 prime-ssh-known-hosts:
 	@echo "-----> Intitial SSH connection to populate known_hosts..."
-	@echo "=====> SSH dokku.me"
-	ssh -o StrictHostKeyChecking=no dokku@dokku.me help >/dev/null
+	@echo "=====> SSH $(DOKKU_DOMAIN)"
+	ssh -o StrictHostKeyChecking=no dokku@$(DOKKU_DOMAIN) help >/dev/null
 	@echo "=====> SSH 127.0.0.1"
 	ssh -o StrictHostKeyChecking=no dokku@127.0.0.1 help >/dev/null
 
@@ -181,87 +182,87 @@ endif
 
 deploy-test-go-fail-predeploy:
 	@echo deploying go-fail-predeploy app...
-	cd tests && ./test_deploy ./apps/go-fail-predeploy dokku.me '' true
+	cd tests && ./test_deploy ./apps/go-fail-predeploy $(DOKKU_DOMAIN) '' true
 
 deploy-test-go-fail-postdeploy:
 	@echo deploying go-fail-postdeploy app...
-	cd tests && ./test_deploy ./apps/go-fail-postdeploy dokku.me '' true
+	cd tests && ./test_deploy ./apps/go-fail-postdeploy $(DOKKU_DOMAIN) '' true
 
 deploy-test-checks-root:
 	@echo deploying checks-root app...
-	cd tests && ./test_deploy ./apps/checks-root dokku.me '' true
+	cd tests && ./test_deploy ./apps/checks-root $(DOKKU_DOMAIN) '' true
 
 deploy-test-main-branch:
 	@echo deploying checks-root app to main branch...
-	cd tests && ./test_deploy ./apps/checks-root dokku.me '' true main
+	cd tests && ./test_deploy ./apps/checks-root $(DOKKU_DOMAIN) '' true main
 
 deploy-test-clojure:
 	@echo deploying config app...
-	cd tests && ./test_deploy ./apps/clojure dokku.me
+	cd tests && ./test_deploy ./apps/clojure $(DOKKU_DOMAIN)
 
 deploy-test-config:
 	@echo deploying config app...
-	cd tests && ./test_deploy ./apps/config dokku.me
+	cd tests && ./test_deploy ./apps/config $(DOKKU_DOMAIN)
 
 deploy-test-dockerfile:
 	@echo deploying dockerfile app...
-	cd tests && ./test_deploy ./apps/dockerfile dokku.me
+	cd tests && ./test_deploy ./apps/dockerfile $(DOKKU_DOMAIN)
 
 deploy-test-dockerfile-noexpose:
 	@echo deploying dockerfile-noexpose app...
-	cd tests && ./test_deploy ./apps/dockerfile-noexpose dokku.me
+	cd tests && ./test_deploy ./apps/dockerfile-noexpose $(DOKKU_DOMAIN)
 
 deploy-test-dockerfile-procfile:
 	@echo deploying dockerfile-procfile app...
-	cd tests && ./test_deploy ./apps/dockerfile-procfile dokku.me
+	cd tests && ./test_deploy ./apps/dockerfile-procfile $(DOKKU_DOMAIN)
 
 deploy-test-gitsubmodules:
 	@echo deploying gitsubmodules app...
-	cd tests && ./test_deploy ./apps/gitsubmodules dokku.me
+	cd tests && ./test_deploy ./apps/gitsubmodules $(DOKKU_DOMAIN)
 
 deploy-test-go:
 	@echo deploying go app...
-	cd tests && ./test_deploy ./apps/go dokku.me
+	cd tests && ./test_deploy ./apps/go $(DOKKU_DOMAIN)
 
 deploy-test-java:
 	@echo deploying java app...
-	cd tests && ./test_deploy ./apps/java dokku.me
+	cd tests && ./test_deploy ./apps/java $(DOKKU_DOMAIN)
 
 deploy-test-multi:
 	@echo deploying multi app...
-	cd tests && ./test_deploy ./apps/multi dokku.me
+	cd tests && ./test_deploy ./apps/multi $(DOKKU_DOMAIN)
 
 deploy-test-nodejs-express:
 	@echo deploying nodejs-express app...
-	cd tests && ./test_deploy ./apps/nodejs-express dokku.me
+	cd tests && ./test_deploy ./apps/nodejs-express $(DOKKU_DOMAIN)
 
 deploy-test-nodejs-express-noprocfile:
 	@echo deploying nodejs-express app with no Procfile...
-	cd tests && ./test_deploy ./apps/nodejs-express-noprocfile dokku.me
+	cd tests && ./test_deploy ./apps/nodejs-express-noprocfile $(DOKKU_DOMAIN)
 
 deploy-test-nodejs-worker:
 	@echo deploying nodejs-worker app...
-	cd tests && ./test_deploy ./apps/nodejs-worker dokku.me
+	cd tests && ./test_deploy ./apps/nodejs-worker $(DOKKU_DOMAIN)
 
 deploy-test-php:
 	@echo deploying php app...
-	cd tests && ./test_deploy ./apps/php dokku.me
+	cd tests && ./test_deploy ./apps/php $(DOKKU_DOMAIN)
 
 deploy-test-python-flask:
 	@echo deploying python-flask app...
-	cd tests && ./test_deploy ./apps/python-flask dokku.me
+	cd tests && ./test_deploy ./apps/python-flask $(DOKKU_DOMAIN)
 
 deploy-test-ruby:
 	@echo deploying ruby app...
-	cd tests && ./test_deploy ./apps/ruby dokku.me
+	cd tests && ./test_deploy ./apps/ruby $(DOKKU_DOMAIN)
 
 deploy-test-scala:
 	@echo deploying scala app...
-	cd tests && ./test_deploy ./apps/scala dokku.me
+	cd tests && ./test_deploy ./apps/scala $(DOKKU_DOMAIN)
 
 deploy-test-static:
 	@echo deploying static app...
-	cd tests && ./test_deploy ./apps/static dokku.me
+	cd tests && ./test_deploy ./apps/static $(DOKKU_DOMAIN)
 
 deploy-tests:
 	@echo running deploy tests...
@@ -305,7 +306,7 @@ generate-ssl-tars: generate-ssl-tar generate-ssl-sans-tar generate-ssl-wildcard-
 generate-ssl-tar:
 	rm -rf /tmp/dokku-server_ssl
 	mkdir -p /tmp/dokku-server_ssl
-	openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /tmp/dokku-server_ssl/server.key          -out /tmp/dokku-server_ssl/server.crt -subj "/CN=dokku.me" -days 3650
+	openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /tmp/dokku-server_ssl/server.key          -out /tmp/dokku-server_ssl/server.crt -subj "/CN=$(DOKKU_DOMAIN)" -days 3650
 	rm tests/unit/server_ssl.tar
 	cd /tmp/dokku-server_ssl && tar cvf $(PWD)/tests/unit/server_ssl.tar server.key server.crt
 	tar -tvf tests/unit/server_ssl.tar
@@ -313,7 +314,7 @@ generate-ssl-tar:
 generate-ssl-sans-tar:
 	rm -rf /tmp/dokku-server_ssl_sans
 	mkdir -p /tmp/dokku-server_ssl_sans
-	openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /tmp/dokku-server_ssl_sans/server.key     -out /tmp/dokku-server_ssl_sans/server.crt -subj "/CN=test.dokku.me" -days 3650 -addext "subjectAltName = DNS:www.test.dokku.me, DNS:www.test.app.dokku.me"
+	openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /tmp/dokku-server_ssl_sans/server.key     -out /tmp/dokku-server_ssl_sans/server.crt -subj "/CN=test.$(DOKKU_DOMAIN)" -days 3650 -addext "subjectAltName = DNS:www.test.$(DOKKU_DOMAIN), DNS:www.test.app.$(DOKKU_DOMAIN)"
 	rm tests/unit/server_ssl_sans.tar
 	cd /tmp/dokku-server_ssl_sans && tar cvf $(PWD)/tests/unit/server_ssl_sans.tar server.key server.crt
 	tar -tvf tests/unit/server_ssl_sans.tar
@@ -321,7 +322,7 @@ generate-ssl-sans-tar:
 generate-ssl-wildcard-tar:
 	rm -rf /tmp/dokku-server_ssl_wildcard
 	mkdir -p /tmp/dokku-server_ssl_wildcard
-	openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /tmp/dokku-server_ssl_wildcard/server.key -out /tmp/dokku-server_ssl_wildcard/server.crt -subj "/CN=*.dokku.me" -days 3650
+	openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /tmp/dokku-server_ssl_wildcard/server.key -out /tmp/dokku-server_ssl_wildcard/server.crt -subj "/CN=*.$(DOKKU_DOMAIN)" -days 3650
 	rm tests/unit/server_ssl_wildcard.tar
 	cd /tmp/dokku-server_ssl_wildcard && tar cvf $(PWD)/tests/unit/server_ssl_wildcard.tar server.key server.crt
 	tar -tvf tests/unit/server_ssl_wildcard.tar

--- a/tests/unit/app-json-2.bats
+++ b/tests/unit/app-json-2.bats
@@ -45,7 +45,7 @@ teardown() {
 }
 
 @test "(app-json) app.json dockerfile entrypoint release" {
-  run deploy_app dockerfile-entrypoint dokku@dokku.me:$TEST_APP add_release_command
+  run deploy_app dockerfile-entrypoint "dokku@$DOKKU_DOMAIN:$TEST_APP" add_release_command
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/app-json-3.bats
+++ b/tests/unit/app-json-3.bats
@@ -12,10 +12,10 @@ teardown() {
 }
 
 @test "(app-json) persist scale" {
-  local CUSTOM_TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local CUSTOM_TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
 
-  CUSTOM_TMP="$CUSTOM_TMP" run deploy_app python dokku@dokku.me:$TEST_APP persist_scale_callback_a
+  CUSTOM_TMP="$CUSTOM_TMP" run deploy_app python "dokku@$DOKKU_DOMAIN:$TEST_APP" persist_scale_callback_a
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/app-json.bats
+++ b/tests/unit/app-json.bats
@@ -47,7 +47,7 @@ teardown() {
 }
 
 @test "(app-json) app.json scripts postdeploy" {
-  run deploy_app python dokku@dokku.me:$TEST_APP add_postdeploy_command
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP add_postdeploy_command
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -73,7 +73,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP add_requirements_txt
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP add_requirements_txt
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -99,7 +99,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP add_requirements_txt
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP add_requirements_txt
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -181,7 +181,7 @@ teardown() {
 }
 
 @test "(app-json:set)" {
-  run deploy_app python dokku@dokku.me:$TEST_APP copy_app_json_to_sub_app
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP copy_app_json_to_sub_app
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/build-env.bats
+++ b/tests/unit/build-env.bats
@@ -70,7 +70,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP move_dockerfile_into_place
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP move_dockerfile_into_place
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/builder-herokuish.bats
+++ b/tests/unit/builder-herokuish.bats
@@ -11,7 +11,7 @@ teardown() {
 }
 
 @test "(builder-herouish:build .env)" {
-  run deploy_app python dokku@dokku.me:$TEST_APP
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/builder-lambda.bats
+++ b/tests/unit/builder-lambda.bats
@@ -25,7 +25,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app lambda-python dokku@dokku.me:$TEST_APP inject_lambda_yml
+  run deploy_app lambda-python dokku@$DOKKU_DOMAIN:$TEST_APP inject_lambda_yml
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/builder-pack.bats
+++ b/tests/unit/builder-pack.bats
@@ -30,7 +30,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP inject_requirements_txt
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP inject_requirements_txt
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/builder.bats
+++ b/tests/unit/builder.bats
@@ -11,7 +11,7 @@ teardown() {
 }
 
 @test "(builder) builder-detect [set]" {
-  local TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
 
   # test project.toml
@@ -79,7 +79,7 @@ teardown() {
 }
 
 @test "(builder) builder-detect [pack]" {
-  local TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
 
   # test project.toml
@@ -115,7 +115,7 @@ teardown() {
 }
 
 @test "(builder) builder-detect [dockerfile]" {
-  local TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
 
   run touch "$TMP/Dockerfile"
@@ -132,7 +132,7 @@ teardown() {
 }
 
 @test "(builder) builder-detect [herokuish]" {
-  local TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
 
   touch "$TMP/Dockerfile"

--- a/tests/unit/buildpacks.bats
+++ b/tests/unit/buildpacks.bats
@@ -298,7 +298,7 @@ teardown() {
 }
 
 @test "(buildpacks) cleanup existing .buildpacks file" {
-  run deploy_app python dokku@dokku.me:$TEST_APP template_buildpacks_cleanup
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP template_buildpacks_cleanup
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/caddy.bats
+++ b/tests/unit/caddy.bats
@@ -38,7 +38,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP convert_to_dockerfile
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP convert_to_dockerfile
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -56,28 +56,28 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP-2.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP-2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP convert_to_dockerfile
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP convert_to_dockerfile
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "curl --silent $TEST_APP.dokku.me"
+  run /bin/bash -c "curl --silent $TEST_APP.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
   assert_output "python/http.server"
 
-  run /bin/bash -c "curl --silent $TEST_APP-2.dokku.me"
+  run /bin/bash -c "curl --silent $TEST_APP-2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -104,7 +104,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output "$TEST_APP.dokku.me:80"
+  assert_output "$TEST_APP.${DOKKU_DOMAIN}:80"
 
   run /bin/bash -c "dokku caddy:set --global letsencrypt-email test@example.com"
   echo "output: $output"
@@ -135,7 +135,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output "$TEST_APP.dokku.me"
+  assert_output "$TEST_APP.${DOKKU_DOMAIN}"
 
   run /bin/bash -c "dokku --quiet ports:report $TEST_APP --ports-map"
   echo "output: $output"

--- a/tests/unit/checks.bats
+++ b/tests/unit/checks.bats
@@ -262,7 +262,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app nodejs-express dokku@dokku.me:$TEST_APP template_checks_file
+  run deploy_app nodejs-express dokku@$DOKKU_DOMAIN:$TEST_APP template_checks_file
   echo "output: $output"
   echo "status: $status"
   assert_output_contains "/healthcheck" 2

--- a/tests/unit/client.bats
+++ b/tests/unit/client.bats
@@ -4,7 +4,7 @@ load test_helper
 
 setup() {
   global_setup
-  export DOKKU_HOST=dokku.me
+  export "DOKKU_HOST=${DOKKU_DOMAIN}"
   create_app
 }
 
@@ -134,29 +134,29 @@ teardown() {
 }
 
 @test "(client) domains:add" {
-  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:add $TEST_APP www.test.app.dokku.me"
+  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:add $TEST_APP test.app.dokku.me"
+  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:add $TEST_APP test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 }
 
 @test "(client) domains:remove" {
-  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:add $TEST_APP test.app.dokku.me"
+  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:add $TEST_APP test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
-  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:remove $TEST_APP test.app.dokku.me"
+  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:remove $TEST_APP test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
-  refute_line "test.app.dokku.me"
+  refute_line "test.app.${DOKKU_DOMAIN}"
 }
 
 @test "(client) domains:clear" {
-  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:add $TEST_APP test.app.dokku.me"
+  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh domains:add $TEST_APP test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -273,7 +273,7 @@ teardown() {
   assert_success
   assert_output "dokku"
 
-  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh remote:add dokku2 dokku@dokku.me:dokku2"
+  run /bin/bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh remote:add dokku2 dokku@${DOKKU_DOMAIN}:dokku2"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/config.bats
+++ b/tests/unit/config.bats
@@ -33,14 +33,14 @@ teardown() {
 }
 
 @test "(config) config:set --global" {
-  run ssh "dokku@$DOKKU_DOMAIN"config:set --global test_var=true test_var2=\"hello world\" test_var3='double\"quotes'
+  run ssh "dokku@$DOKKU_DOMAIN" config:set --global test_var=true test_var2=\"hello world\" test_var3='double\"quotes'
   echo "output: $output"
   echo "status: $status"
   assert_success
 }
 
 @test "(config) config:get --global" {
-  run ssh "dokku@$DOKKU_DOMAIN"config:set --global test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\" test_var4='double\"quotes'
+  run ssh "dokku@$DOKKU_DOMAIN" config:set --global test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\" test_var4='double\"quotes'
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -59,7 +59,7 @@ teardown() {
 }
 
 @test "(config) config:unset --global" {
-  run ssh "dokku@$DOKKU_DOMAIN"config:set --global test_var=true test_var2=\"hello world\"
+  run ssh "dokku@$DOKKU_DOMAIN" config:set --global test_var=true test_var2=\"hello world\"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -78,7 +78,7 @@ teardown() {
 }
 
 @test "(config) config:set/get" {
-  run ssh "dokku@$DOKKU_DOMAIN"config:set $TEST_APP test_var1=true test_var2=\"hello world\" test_var3='double\"quotes'
+  run ssh "dokku@$DOKKU_DOMAIN" config:set $TEST_APP test_var1=true test_var2=\"hello world\" test_var3='double\"quotes'
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -125,7 +125,7 @@ teardown() {
 }
 
 @test "(config) config:clear" {
-  run ssh "dokku@$DOKKU_DOMAIN"config:set $TEST_APP test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
+  run ssh "dokku@$DOKKU_DOMAIN" config:set $TEST_APP test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -140,7 +140,7 @@ teardown() {
 }
 
 @test "(config) config:unset" {
-  run ssh "dokku@$DOKKU_DOMAIN"config:set $TEST_APP test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
+  run ssh "dokku@$DOKKU_DOMAIN" config:set $TEST_APP test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/config.bats
+++ b/tests/unit/config.bats
@@ -33,14 +33,14 @@ teardown() {
 }
 
 @test "(config) config:set --global" {
-  run ssh dokku@dokku.me config:set --global test_var=true test_var2=\"hello world\" test_var3='double\"quotes'
+  run ssh "dokku@$DOKKU_DOMAIN"config:set --global test_var=true test_var2=\"hello world\" test_var3='double\"quotes'
   echo "output: $output"
   echo "status: $status"
   assert_success
 }
 
 @test "(config) config:get --global" {
-  run ssh dokku@dokku.me config:set --global test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\" test_var4='double\"quotes'
+  run ssh "dokku@$DOKKU_DOMAIN"config:set --global test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\" test_var4='double\"quotes'
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -59,7 +59,7 @@ teardown() {
 }
 
 @test "(config) config:unset --global" {
-  run ssh dokku@dokku.me config:set --global test_var=true test_var2=\"hello world\"
+  run ssh "dokku@$DOKKU_DOMAIN"config:set --global test_var=true test_var2=\"hello world\"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -78,7 +78,7 @@ teardown() {
 }
 
 @test "(config) config:set/get" {
-  run ssh dokku@dokku.me config:set $TEST_APP test_var1=true test_var2=\"hello world\" test_var3='double\"quotes'
+  run ssh "dokku@$DOKKU_DOMAIN"config:set $TEST_APP test_var1=true test_var2=\"hello world\" test_var3='double\"quotes'
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -125,7 +125,7 @@ teardown() {
 }
 
 @test "(config) config:clear" {
-  run ssh dokku@dokku.me config:set $TEST_APP test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
+  run ssh "dokku@$DOKKU_DOMAIN"config:set $TEST_APP test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -140,7 +140,7 @@ teardown() {
 }
 
 @test "(config) config:unset" {
-  run ssh dokku@dokku.me config:set $TEST_APP test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
+  run ssh "dokku@$DOKKU_DOMAIN"config:set $TEST_APP test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/core_2.bats
+++ b/tests/unit/core_2.bats
@@ -38,18 +38,18 @@ teardown() {
 }
 
 @test "(core) urls (non-ssl)" {
-  assert_urls "http://${TEST_APP}.dokku.me"
+  assert_urls "http://${TEST_APP}.${DOKKU_DOMAIN}"
 
-  run /bin/bash -c "dokku domains:add $TEST_APP test.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP test.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  assert_urls "http://${TEST_APP}.dokku.me" "http://test.dokku.me"
+  assert_urls "http://${TEST_APP}.${DOKKU_DOMAIN}" "http://test.${DOKKU_DOMAIN}"
 }
 
 @test "(core) urls (app ssl)" {
-  assert_urls "http://${TEST_APP}.dokku.me"
+  assert_urls "http://${TEST_APP}.${DOKKU_DOMAIN}"
 
   run setup_test_tls
   echo "output: $output"
@@ -61,14 +61,14 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  assert_urls "https://${TEST_APP}.dokku.me"
+  assert_urls "https://${TEST_APP}.${DOKKU_DOMAIN}"
 
-  run /bin/bash -c "dokku domains:add $TEST_APP test.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP test.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  assert_urls "http://${TEST_APP}.dokku.me" "https://${TEST_APP}.dokku.me" "https://test.dokku.me" "http://test.dokku.me"
+  assert_urls "http://${TEST_APP}.${DOKKU_DOMAIN}" "https://${TEST_APP}.${DOKKU_DOMAIN}" "https://test.${DOKKU_DOMAIN}" "http://test.${DOKKU_DOMAIN}"
 }
 
 @test "(core) url (app ssl)" {
@@ -82,7 +82,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  assert_url "https://${TEST_APP}.dokku.me"
+  assert_url "https://${TEST_APP}.${DOKKU_DOMAIN}"
 }
 
 @test "(core) urls (wildcard ssl)" {
@@ -96,20 +96,20 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  assert_urls "https://${TEST_APP}.dokku.me"
+  assert_urls "https://${TEST_APP}.${DOKKU_DOMAIN}"
 
-  run /bin/bash -c "dokku domains:add $TEST_APP test.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP test.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  assert_urls "http://${TEST_APP}.dokku.me" "https://${TEST_APP}.dokku.me" "https://test.dokku.me" "http://test.dokku.me"
+  assert_urls "http://${TEST_APP}.${DOKKU_DOMAIN}" "https://${TEST_APP}.${DOKKU_DOMAIN}" "https://test.${DOKKU_DOMAIN}" "http://test.${DOKKU_DOMAIN}"
 
   run /bin/bash -c "dokku domains:add $TEST_APP dokku.example.com"
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_urls "http://dokku.example.com" "http://${TEST_APP}.dokku.me" "https://dokku.example.com" "https://${TEST_APP}.dokku.me" "https://test.dokku.me" "http://test.dokku.me"
+  assert_urls "http://dokku.example.com" "http://${TEST_APP}.${DOKKU_DOMAIN}" "https://dokku.example.com" "https://${TEST_APP}.${DOKKU_DOMAIN}" "https://test.${DOKKU_DOMAIN}" "http://test.${DOKKU_DOMAIN}"
 }
 
 @test "(core) git-remote (off-port)" {

--- a/tests/unit/cron.bats
+++ b/tests/unit/cron.bats
@@ -45,28 +45,28 @@ teardown() {
 }
 
 @test "(cron) invalid [missing-keys]" {
-  run deploy_app python dokku@dokku.me:$TEST_APP template_cron_file_invalid
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP template_cron_file_invalid
   echo "output: $output"
   echo "status: $status"
   assert_failure
 }
 
 @test "(cron) invalid [schedule]" {
-  run deploy_app python dokku@dokku.me:$TEST_APP template_cron_file_invalid_schedule
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP template_cron_file_invalid_schedule
   echo "output: $output"
   echo "status: $status"
   assert_failure
 }
 
 @test "(cron) invalid [seconds]" {
-  run deploy_app python dokku@dokku.me:$TEST_APP template_cron_file_invalid_schedule_seconds
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP template_cron_file_invalid_schedule_seconds
   echo "output: $output"
   echo "status: $status"
   assert_failure
 }
 
 @test "(cron) create [empty]" {
-  run deploy_app python dokku@dokku.me:$TEST_APP
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -78,7 +78,7 @@ teardown() {
 }
 
 @test "(cron) create [single-verbose]" {
-  run deploy_app python dokku@dokku.me:$TEST_APP template_cron_file_valid_single
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP template_cron_file_valid_single
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -91,7 +91,7 @@ teardown() {
 }
 
 @test "(cron) create [single-short]" {
-  run deploy_app python dokku@dokku.me:$TEST_APP template_cron_file_valid_short
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP template_cron_file_valid_short
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -104,7 +104,7 @@ teardown() {
 }
 
 @test "(cron) create [multiple]" {
-  run deploy_app python dokku@dokku.me:$TEST_APP template_cron_file_valid_multiple
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP template_cron_file_valid_multiple
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -178,7 +178,7 @@ teardown() {
 }
 
 @test "(cron) cron:list --format json" {
-  run deploy_app python dokku@dokku.me:$TEST_APP template_cron_file_valid
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP template_cron_file_valid
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -198,7 +198,7 @@ teardown() {
 }
 
 @test "(cron) cron:run" {
-  run deploy_app python dokku@dokku.me:$TEST_APP template_cron_file_valid
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP template_cron_file_valid
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/docker-options.bats
+++ b/tests/unit/docker-options.bats
@@ -333,7 +333,7 @@ teardown() {
 }
 
 @test "(docker-options) docker-options:add (all phases over SSH)" {
-  run ssh "dokku@$DOKKU_DOMAIN docker-options:add $TEST_APP build,deploy,run "-v /tmp"
+  run ssh "dokku@$DOKKU_DOMAIN" docker-options:add $TEST_APP build,deploy,run "-v /tmp"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/docker-options.bats
+++ b/tests/unit/docker-options.bats
@@ -333,7 +333,7 @@ teardown() {
 }
 
 @test "(docker-options) docker-options:add (all phases over SSH)" {
-  run ssh "dokku@$DOKKU_DOMAIN"docker-options:add $TEST_APP build,deploy,run "-v /tmp"
+  run ssh "dokku@$DOKKU_DOMAIN docker-options:add $TEST_APP build,deploy,run "-v /tmp"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/docker-options.bats
+++ b/tests/unit/docker-options.bats
@@ -333,7 +333,7 @@ teardown() {
 }
 
 @test "(docker-options) docker-options:add (all phases over SSH)" {
-  run ssh dokku@dokku.me docker-options:add $TEST_APP build,deploy,run "-v /tmp"
+  run ssh "dokku@$DOKKU_DOMAIN"docker-options:add $TEST_APP build,deploy,run "-v /tmp"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/domains.bats
+++ b/tests/unit/domains.bats
@@ -29,19 +29,19 @@ teardown() {
 }
 
 @test "(domains) domains" {
-  run /bin/bash -c "dokku domains:report $TEST_APP 2>/dev/null | grep ${TEST_APP}.dokku.me"
+  run /bin/bash -c "dokku domains:report $TEST_APP 2>/dev/null | grep ${TEST_APP}.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
-  assert_output_contains "${TEST_APP}.dokku.me"
+  assert_output_contains "${TEST_APP}.${DOKKU_DOMAIN}"
 }
 
 @test "(domains) domains:add" {
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP 2.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP 2.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -51,7 +51,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP .dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP .${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -65,14 +65,14 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains www.test.app.dokku.me
-  assert_output_contains 2.app.dokku.me
+  assert_output_contains "www.test.app.${DOKKU_DOMAIN}"
+  assert_output_contains "2.app.${DOKKU_DOMAIN}"
   assert_output_contains a--domain.with--hyphens
   assert_output_contains _
 }
 
 @test "(domains) domains:add (multiple)" {
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me 2.app.dokku.me a--domain.with--hyphens"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN} 2.app.${DOKKU_DOMAIN} a--domain.with--hyphens"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -81,37 +81,37 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains www.test.app.dokku.me
-  assert_output_contains 2.app.dokku.me
+  assert_output_contains "www.test.app.${DOKKU_DOMAIN}"
+  assert_output_contains "2.app.${DOKKU_DOMAIN}"
   assert_output_contains a--domain.with--hyphens
 }
 
 @test "(domains) domains:add (duplicate)" {
-  run /bin/bash -c "dokku domains:add $TEST_APP test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 }
 
 @test "(domains) domains:add (invalid)" {
-  run /bin/bash -c "dokku domains:add $TEST_APP http://test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP http://test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_failure
 }
 
 @test "(domains) domains:remove" {
-  run /bin/bash -c "dokku domains:add $TEST_APP test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:remove $TEST_APP test.app.dokku.me"
+  run /bin/bash -c "dokku domains:remove $TEST_APP test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -120,16 +120,16 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains test.app.dokku.me 0
+  assert_output_contains "test.app.${DOKKU_DOMAIN}" 0
 }
 
 @test "(domains) domains:remove (multiple)" {
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me test.app.dokku.me 2.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN} test.app.${DOKKU_DOMAIN} 2.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:remove $TEST_APP www.test.app.dokku.me test.app.dokku.me"
+  run /bin/bash -c "dokku domains:remove $TEST_APP www.test.app.${DOKKU_DOMAIN} test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -138,13 +138,13 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains www.test.app.dokku.me 0
-  assert_output_contains test.app.dokku.me 0
-  assert_output_contains 2.app.dokku.me
+  assert_output_contains "www.test.app.${DOKKU_DOMAIN}" 0
+  assert_output_contains "test.app.${DOKKU_DOMAIN}" 0
+  assert_output_contains "2.app.${DOKKU_DOMAIN}"
 }
 
 @test "(domains) domains:remove (wildcard domain)" {
-  run /bin/bash -c "dokku domains:add $TEST_APP '*.dokku.me'"
+  run /bin/bash -c "dokku domains:add $TEST_APP '*.${DOKKU_DOMAIN}'"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -153,9 +153,9 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output "$TEST_APP.dokku.me *.dokku.me"
+  assert_output "$TEST_APP.${DOKKU_DOMAIN} *.${DOKKU_DOMAIN}"
 
-  run /bin/bash -c "dokku domains:remove $TEST_APP '*.dokku.me'"
+  run /bin/bash -c "dokku domains:remove $TEST_APP '*.${DOKKU_DOMAIN}'"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -164,16 +164,16 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output "$TEST_APP.dokku.me"
+  assert_output "$TEST_APP.${DOKKU_DOMAIN}"
 }
 
 @test "(domains) domains:set" {
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN} test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:set $TEST_APP 2.app.dokku.me a--domain.with--hyphens"
+  run /bin/bash -c "dokku domains:set $TEST_APP 2.app.${DOKKU_DOMAIN} a--domain.with--hyphens"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -182,14 +182,14 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains www.test.app.dokku.me 0
-  assert_output_contains test.app.dokku.me 0
-  assert_output_contains 2.app.dokku.me
+  assert_output_contains "www.test.app.${DOKKU_DOMAIN}" 0
+  assert_output_contains "test.app.${DOKKU_DOMAIN}" 0
+  assert_output_contains "2.app.${DOKKU_DOMAIN}"
   assert_output_contains a--domain.with--hyphens
 }
 
 @test "(domains) domains:clear" {
-  run /bin/bash -c "dokku domains:add $TEST_APP test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -208,11 +208,11 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains test.app.dokku.me 0
+  assert_output_contains "test.app.${DOKKU_DOMAIN}" 0
 }
 
 @test "(domains) domains:add-global" {
-  run /bin/bash -c "dokku domains:add-global global.dokku.me"
+  run /bin/bash -c "dokku domains:add-global global.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -222,29 +222,29 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:report 2>/dev/null | grep -qw 'global.dokku.me'"
+  run /bin/bash -c "dokku domains:report 2>/dev/null | grep -qw 'global.${DOKKU_DOMAIN}'"
   echo "output: $output"
   echo "status: $status"
   assert_success
 }
 
 @test "(domains) domains:add-global (multiple)" {
-  run /bin/bash -c "dokku domains:add-global global1.dokku.me global2.dokku.me global3.dokku.me"
+  run /bin/bash -c "dokku domains:add-global global1.${DOKKU_DOMAIN} global2.${DOKKU_DOMAIN} global3.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:report 2>/dev/null | grep -q global1.dokku.me"
+  run /bin/bash -c "dokku domains:report 2>/dev/null | grep -q global1.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:report 2>/dev/null | grep -q global2.dokku.me"
+  run /bin/bash -c "dokku domains:report 2>/dev/null | grep -q global2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:report 2>/dev/null | grep -q global3.dokku.me"
+  run /bin/bash -c "dokku domains:report 2>/dev/null | grep -q global3.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -256,7 +256,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add-global global.dokku.me"
+  run /bin/bash -c "dokku domains:add-global global.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -266,23 +266,23 @@ teardown() {
   echo "status: $status"
   assert_success
   refute_line "global.dokku.invalid"
-  refute_line "global.dokku.me"
+  refute_line "global.${DOKKU_DOMAIN}"
 }
 
 @test "(domains) domains:remove-global" {
-  run /bin/bash -c "dokku domains:add-global global.dokku.me"
+  run /bin/bash -c "dokku domains:add-global global.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:remove-global global.dokku.me"
+  run /bin/bash -c "dokku domains:remove-global global.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
-  refute_line "global.dokku.me"
+  refute_line "global.${DOKKU_DOMAIN}"
 }
 
 @test "(domains) domains (multiple global domains)" {
-  run /bin/bash -c "dokku domains:add-global global1.dokku.me global2.dokku.me"
+  run /bin/bash -c "dokku domains:add-global global1.${DOKKU_DOMAIN} global2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -301,17 +301,17 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains ${TEST_APP}.global1.dokku.me
-  assert_output_contains ${TEST_APP}.global2.dokku.me
+  assert_output_contains "${TEST_APP}.global1.${DOKKU_DOMAIN}"
+  assert_output_contains "${TEST_APP}.global2.${DOKKU_DOMAIN}"
 }
 
 @test "(domains) domains:set-global" {
-  run /bin/bash -c "dokku domains:add-global global1.dokku.me global2.dokku.me"
+  run /bin/bash -c "dokku domains:add-global global1.${DOKKU_DOMAIN} global2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:set-global global3.dokku.me global4.dokku.me"
+  run /bin/bash -c "dokku domains:set-global global3.${DOKKU_DOMAIN} global4.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -330,10 +330,10 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains ${TEST_APP}.global1.dokku.me 0
-  assert_output_contains ${TEST_APP}.global2.dokku.me 0
-  assert_output_contains ${TEST_APP}.global3.dokku.me
-  assert_output_contains ${TEST_APP}.global4.dokku.me
+  assert_output_contains "${TEST_APP}.global1.${DOKKU_DOMAIN}" 0
+  assert_output_contains "${TEST_APP}.global2.${DOKKU_DOMAIN}" 0
+  assert_output_contains "${TEST_APP}.global3.${DOKKU_DOMAIN}"
+  assert_output_contains "${TEST_APP}.global4.${DOKKU_DOMAIN}"
 }
 
 @test "(domains) app name overlaps with global domain.tld" {
@@ -366,12 +366,12 @@ teardown() {
 }
 
 @test "(domains) app rename only renames domains associated with global domains" {
-  run /bin/bash -c "dokku domains:set-global dokku.me"
+  run /bin/bash -c "dokku domains:set-global ${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:set $TEST_APP $TEST_APP.dokku.me $TEST_APP.dokku.test"
+  run /bin/bash -c "dokku domains:set $TEST_APP $TEST_APP.${DOKKU_DOMAIN} $TEST_APP.dokku.test"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -385,7 +385,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output "other-name.dokku.me $TEST_APP.dokku.test"
+  assert_output "other-name.${DOKKU_DOMAIN} $TEST_APP.dokku.test"
 
   run /bin/bash -c "dokku apps:rename other-name $TEST_APP"
   echo "output: $output"

--- a/tests/unit/git_4.bats
+++ b/tests/unit/git_4.bats
@@ -83,7 +83,7 @@ teardown() {
 }
 
 @test "(git) git:from-image [failing deploy]" {
-  local CUSTOM_TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local CUSTOM_TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$CUSTOM_TMP"' INT TERM
   rmdir "$CUSTOM_TMP" && cp -r "${BATS_TEST_DIRNAME}/../../tests/apps/python" "$CUSTOM_TMP"
 
@@ -157,7 +157,7 @@ teardown() {
 }
 
 @test "(git) git:from-image [onbuild]" {
-  local TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
 
   run /bin/bash -c "dokku storage:mount $TEST_APP /var/run/docker.sock:/var/run/docker.sock"

--- a/tests/unit/git_5.bats
+++ b/tests/unit/git_5.bats
@@ -34,7 +34,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_http_success http://${TEST_APP}.dokku.me
+  assert_http_success "http://${TEST_APP}.${DOKKU_DOMAIN}"
 }
 
 @test "(git) git:from-archive [tar.gz]" {
@@ -42,7 +42,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_http_success http://${TEST_APP}.dokku.me
+  assert_http_success "http://${TEST_APP}.${DOKKU_DOMAIN}"
 }
 
 @test "(git) git:from-archive [zip]" {
@@ -50,7 +50,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_http_success http://${TEST_APP}.dokku.me
+  assert_http_success "http://${TEST_APP}.${DOKKU_DOMAIN}"
 }
 
 @test "(git) git:from-archive [stdin-file]" {
@@ -63,7 +63,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_http_success http://${TEST_APP}.dokku.me
+  assert_http_success "http://${TEST_APP}.${DOKKU_DOMAIN}"
 }
 
 @test "(git) git:from-archive [stdin-curl]" {
@@ -71,5 +71,5 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_http_success http://${TEST_APP}.dokku.me
+  assert_http_success "http://${TEST_APP}.${DOKKU_DOMAIN}"
 }

--- a/tests/unit/git_7.bats
+++ b/tests/unit/git_7.bats
@@ -103,7 +103,7 @@ teardown() {
 }
 
 @test "(git) git:load-image [failing deploy]" {
-  local CUSTOM_TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local CUSTOM_TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$CUSTOM_TMP"' INT TERM
   rmdir "$CUSTOM_TMP" && cp -r "${BATS_TEST_DIRNAME}/../../tests/apps/python" "$CUSTOM_TMP"
 
@@ -187,7 +187,7 @@ teardown() {
 }
 
 @test "(git) git:load-image [onbuild]" {
-  local TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
 
   run /bin/bash -c "dokku storage:mount $TEST_APP /var/run/docker.sock:/var/run/docker.sock"

--- a/tests/unit/haproxy.bats
+++ b/tests/unit/haproxy.bats
@@ -55,7 +55,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP convert_to_dockerfile
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP convert_to_dockerfile
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -73,28 +73,28 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP-2.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP-2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP convert_to_dockerfile
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP convert_to_dockerfile
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "curl --silent $TEST_APP.dokku.me"
+  run /bin/bash -c "curl --silent $TEST_APP.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
   assert_output "python/http.server"
 
-  run /bin/bash -c "curl --silent $TEST_APP-2.dokku.me"
+  run /bin/bash -c "curl --silent $TEST_APP-2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/logs.bats
+++ b/tests/unit/logs.bats
@@ -425,7 +425,7 @@ teardown() {
   fi
 
   driver="$(jq -r '."log-driver"' /etc/docker/daemon.json)"
-  local TMP_FILE=$(mktemp "/tmp/dokku.me.XXXX")
+  local TMP_FILE=$(mktemp "/tmp/${DOKKU_DOMAIN}.XXXX")
 
   run create_app
   echo "output: $output"

--- a/tests/unit/network.bats
+++ b/tests/unit/network.bats
@@ -36,7 +36,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_nonssl_domain "${TEST_APP}.dokku.me"
+  assert_nonssl_domain "${TEST_APP}.${DOKKU_DOMAIN}"
 
   run /bin/bash -c "dokku network:set $TEST_APP bind-all-interfaces true"
   echo "output: $output"
@@ -47,7 +47,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_http_success "${TEST_APP}.dokku.me"
+  assert_http_success "${TEST_APP}.${DOKKU_DOMAIN}"
 
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.web.*; do
     assert_external_port $(<$CID_FILE)
@@ -62,7 +62,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_http_success "${TEST_APP}.dokku.me"
+  assert_http_success "${TEST_APP}.${DOKKU_DOMAIN}"
 
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.web.*; do
     assert_not_external_port $(<$CID_FILE)
@@ -193,7 +193,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_failure
-  assert_http_success "${TEST_APP}.dokku.me"
+  assert_http_success "${TEST_APP}.${DOKKU_DOMAIN}"
 
   run /bin/bash -c "dokku network:set $TEST_APP attach-post-create create-network"
   echo "output: $output"
@@ -219,7 +219,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_http_success "${TEST_APP}.dokku.me"
+  assert_http_success "${TEST_APP}.${DOKKU_DOMAIN}"
 
   run /bin/bash -c "dokku network:set $TEST_APP attach-post-create create-network create-network-2"
   echo "output: $output"
@@ -235,7 +235,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_http_success "${TEST_APP}.dokku.me"
+  assert_http_success "${TEST_APP}.${DOKKU_DOMAIN}"
 
   run /bin/bash -c "dokku --force network:destroy create-network"
   echo "output: $output"

--- a/tests/unit/nginx-vhosts_1.bats
+++ b/tests/unit/nginx-vhosts_1.bats
@@ -51,8 +51,8 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  check_urls http://${TEST_APP}.dokku.me
-  assert_http_success http://${TEST_APP}.dokku.me
+  check_urls "http://${TEST_APP}.${DOKKU_DOMAIN}"
+  assert_http_success "http://${TEST_APP}.${DOKKU_DOMAIN}"
 }
 
 @test "(nginx-vhosts) proxy:build-config (domains:add pre deploy)" {
@@ -61,7 +61,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -72,17 +72,17 @@ teardown() {
   assert_success
   sleep 5 # wait for nginx to reload
 
-  check_urls http://www.test.app.dokku.me
-  assert_http_success http://www.test.app.dokku.me
+  check_urls "http://www.test.app.${DOKKU_DOMAIN}"
+  assert_http_success "http://www.test.app.${DOKKU_DOMAIN}"
 }
 
 @test "(nginx-vhosts) proxy:build-config (with global VHOST)" {
-  echo "dokku.me" >"$DOKKU_ROOT/VHOST"
+  echo "${DOKKU_DOMAIN}" >"$DOKKU_ROOT/VHOST"
   run deploy_app
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  check_urls http://${TEST_APP}.dokku.me
-  assert_http_success http://${TEST_APP}.dokku.me
+  check_urls "http://${TEST_APP}.${DOKKU_DOMAIN}"
+  assert_http_success "http://${TEST_APP}.${DOKKU_DOMAIN}"
 }

--- a/tests/unit/nginx-vhosts_11.bats
+++ b/tests/unit/nginx-vhosts_11.bats
@@ -163,7 +163,7 @@ teardown() {
 }
 
 @test "(nginx-vhosts) nginx:set nginx.conf.sigil" {
-  local TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
   export CUSTOM_TMP="$TMP"
 

--- a/tests/unit/nginx-vhosts_12.bats
+++ b/tests/unit/nginx-vhosts_12.bats
@@ -15,7 +15,7 @@ teardown() {
 }
 
 @test "(nginx-vhosts) git:from-image nginx.conf.sigil" {
-  local CUSTOM_TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local CUSTOM_TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$CUSTOM_TMP"' INT TERM
   rmdir "$CUSTOM_TMP" && cp -r "${BATS_TEST_DIRNAME}/../../tests/apps/python" "$CUSTOM_TMP"
 

--- a/tests/unit/nginx-vhosts_2.bats
+++ b/tests/unit/nginx-vhosts_2.bats
@@ -16,12 +16,12 @@ teardown() {
 
 @test "(nginx-vhosts) proxy:build-config (with SSL and unrelated domain)" {
   setup_test_tls
-  run /bin/bash -c "dokku domains:add $TEST_APP node-js-app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP node-js-app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP test.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP test.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -36,18 +36,18 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  assert_ssl_domain "node-js-app.dokku.me"
-  assert_http_redirect "http://test.dokku.me" "https://test.dokku.me:443/"
+  assert_ssl_domain "node-js-app.${DOKKU_DOMAIN}"
+  assert_http_redirect "http://test.${DOKKU_DOMAIN}" "https://test.${DOKKU_DOMAIN}:443/"
 }
 
 @test "(nginx-vhosts) proxy:build-config (wildcard SSL)" {
   setup_test_tls wildcard
-  run /bin/bash -c "dokku domains:add $TEST_APP wildcard1.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard1.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP wildcard2.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -62,8 +62,8 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  assert_ssl_domain "wildcard1.dokku.me"
-  assert_ssl_domain "wildcard2.dokku.me"
+  assert_ssl_domain "wildcard1.${DOKKU_DOMAIN}"
+  assert_ssl_domain "wildcard2.${DOKKU_DOMAIN}"
 }
 
 @test "(nginx-vhosts) proxy:build-config (wildcard SSL and unrelated domain) 1" {
@@ -80,7 +80,7 @@ teardown() {
 
   setup_test_tls wildcard
 
-  run deploy_app nodejs-express dokku@dokku.me:$TEST_APP
+  run deploy_app nodejs-express dokku@$DOKKU_DOMAIN:$TEST_APP
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -90,7 +90,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku nginx:show-config $TEST_APP | grep -e '*.dokku.me' | wc -l"
+  run /bin/bash -c "dokku nginx:show-config $TEST_APP | grep -e '*.${DOKKU_DOMAIN}' | wc -l"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -99,17 +99,17 @@ teardown() {
 
 @test "(nginx-vhosts) proxy:build-config (with SSL and Multiple SANs)" {
   setup_test_tls sans
-  run /bin/bash -c "dokku domains:add $TEST_APP test.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP test.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -118,7 +118,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_ssl_domain "test.dokku.me"
-  assert_ssl_domain "www.test.dokku.me"
-  assert_ssl_domain "www.test.app.dokku.me"
+  assert_ssl_domain "test.${DOKKU_DOMAIN}"
+  assert_ssl_domain "www.test.${DOKKU_DOMAIN}"
+  assert_ssl_domain "www.test.app.${DOKKU_DOMAIN}"
 }

--- a/tests/unit/nginx-vhosts_3.bats
+++ b/tests/unit/nginx-vhosts_3.bats
@@ -32,7 +32,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "docker run --rm ${TEST_APP}-docker-image /go/bin/greeter_client -address ${TEST_APP}.dokku.me:80 -name grpc"
+  run /bin/bash -c "docker run --rm ${TEST_APP}-docker-image /go/bin/greeter_client -address ${TEST_APP}.${DOKKU_DOMAIN}:80 -name grpc"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -50,7 +50,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "docker run --rm ${TEST_APP}-docker-image /go/bin/greeter_client -address ${TEST_APP}.dokku.me:8080 -name grpc8080"
+  run /bin/bash -c "docker run --rm ${TEST_APP}-docker-image /go/bin/greeter_client -address ${TEST_APP}.${DOKKU_DOMAIN}:8080 -name grpc8080"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -69,7 +69,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "docker run --rm ${TEST_APP}-docker-image /go/bin/greeter_client -address ${TEST_APP}.dokku.me:443 -name grpcs -tls"
+  run /bin/bash -c "docker run --rm ${TEST_APP}-docker-image /go/bin/greeter_client -address ${TEST_APP}.${DOKKU_DOMAIN}:443 -name grpcs -tls"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/nginx-vhosts_4.bats
+++ b/tests/unit/nginx-vhosts_4.bats
@@ -76,7 +76,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -85,7 +85,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_nonssl_domain "www.test.app.dokku.me"
+  assert_nonssl_domain "www.test.app.${DOKKU_DOMAIN}"
 }
 
 @test "(nginx-vhosts) proxy:build-config (without global VHOST and domains:add post deploy)" {
@@ -95,11 +95,11 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  check_urls http://www.test.app.dokku.me
-  assert_http_success http://www.test.app.dokku.me
+  check_urls "http://www.test.app.${DOKKU_DOMAIN}"
+  assert_http_success "http://www.test.app.${DOKKU_DOMAIN}"
 }

--- a/tests/unit/nginx-vhosts_5.bats
+++ b/tests/unit/nginx-vhosts_5.bats
@@ -16,14 +16,14 @@ teardown() {
 }
 
 @test "(nginx-vhosts) proxy:build-config (sslip.io style hostnames)" {
-  echo "127.0.0.1.sslip.io.dokku.me" >"$DOKKU_ROOT/VHOST"
+  echo "127.0.0.1.sslip.io.${DOKKU_DOMAIN}" >"$DOKKU_ROOT/VHOST"
   run deploy_app
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  check_urls http://${TEST_APP}.127.0.0.1.sslip.io.dokku.me
-  assert_http_success http://${TEST_APP}.127.0.0.1.sslip.io.dokku.me
+  check_urls "http://${TEST_APP}.127.0.0.1.sslip.io.${DOKKU_DOMAIN}"
+  assert_http_success "http://${TEST_APP}.127.0.0.1.sslip.io.${DOKKU_DOMAIN}"
 }
 
 @test "(nginx-vhosts) proxy:build-config (dockerfile expose)" {
@@ -32,19 +32,19 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  check_urls http://${TEST_APP}.dokku.me:3000
-  check_urls http://${TEST_APP}.dokku.me:3003
-  check_urls http://www.test.app.dokku.me:3000
-  check_urls http://www.test.app.dokku.me:3003
-  assert_http_localhost_success "http" "${TEST_APP}.dokku.me" "3000"
-  assert_http_localhost_success "http" "${TEST_APP}.dokku.me" "3003"
-  assert_http_localhost_success "http" "www.test.app.dokku.me" "3000"
-  assert_http_localhost_success "http" "www.test.app.dokku.me" "3003"
+  check_urls "http://${TEST_APP}.${DOKKU_DOMAIN}:3000"
+  check_urls "http://${TEST_APP}.${DOKKU_DOMAIN}:3003"
+  check_urls "http://www.test.app.${DOKKU_DOMAIN}:3000"
+  check_urls "http://www.test.app.${DOKKU_DOMAIN}:3003"
+  assert_http_localhost_success "http" "${TEST_APP}.${DOKKU_DOMAIN}" "3000"
+  assert_http_localhost_success "http" "${TEST_APP}.${DOKKU_DOMAIN}" "3003"
+  assert_http_localhost_success "http" "www.test.app.${DOKKU_DOMAIN}" "3000"
+  assert_http_localhost_success "http" "www.test.app.${DOKKU_DOMAIN}" "3003"
 }
 
 @test "(nginx-vhosts) proxy:build-config (multiple networks)" {
@@ -71,8 +71,8 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  check_urls http://${TEST_APP}.dokku.me:${GLOBAL_PORT}
-  assert_http_success http://${TEST_APP}.dokku.me:${GLOBAL_PORT}
+  check_urls "http://${TEST_APP}.${DOKKU_DOMAIN}:${GLOBAL_PORT}"
+  assert_http_success "http://${TEST_APP}.${DOKKU_DOMAIN}:${GLOBAL_PORT}"
 
   run /bin/bash -c "dokku config:unset --global DOKKU_PROXY_PORT"
   echo "output: $output"

--- a/tests/unit/nginx-vhosts_7.bats
+++ b/tests/unit/nginx-vhosts_7.bats
@@ -16,34 +16,34 @@ teardown() {
 
 @test "(nginx-vhosts) proxy:build-config (wildcard SSL and custom nginx template)" {
   setup_test_tls wildcard
-  run /bin/bash -c "dokku domains:add $TEST_APP wildcard1.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard1.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP wildcard2.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run deploy_app nodejs-express dokku@dokku.me:$TEST_APP custom_ssl_nginx_template
+  run deploy_app nodejs-express dokku@$DOKKU_DOMAIN:$TEST_APP custom_ssl_nginx_template
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  assert_ssl_domain "wildcard1.dokku.me"
-  assert_ssl_domain "wildcard2.dokku.me"
+  assert_ssl_domain "wildcard1.${DOKKU_DOMAIN}"
+  assert_ssl_domain "wildcard2.${DOKKU_DOMAIN}"
   assert_http_redirect "http://${CUSTOM_TEMPLATE_SSL_DOMAIN}" "https://${CUSTOM_TEMPLATE_SSL_DOMAIN}:443/"
   assert_http_success "https://${CUSTOM_TEMPLATE_SSL_DOMAIN}"
 }
 
 @test "(nginx-vhosts) proxy:build-config (custom nginx template - no ssl)" {
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP custom_nginx_template
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP custom_nginx_template
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -53,8 +53,8 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  assert_nonssl_domain "www.test.app.dokku.me"
-  assert_http_localhost_success "http" "customtemplate.dokku.me"
+  assert_nonssl_domain "www.test.app.${DOKKU_DOMAIN}"
+  assert_http_localhost_success "http" "customtemplate.${DOKKU_DOMAIN}"
 
   run /bin/bash -c "dokku nginx:show-config $TEST_APP"
   echo "output: $output"
@@ -68,12 +68,12 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP www.test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP custom_nginx_template
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP custom_nginx_template
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -83,7 +83,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  assert_nonssl_domain "www.test.app.dokku.me"
+  assert_nonssl_domain "www.test.app.${DOKKU_DOMAIN}"
 
   run /bin/bash -c "dokku nginx:show-config $TEST_APP"
   echo "output: $output"
@@ -92,7 +92,7 @@ teardown() {
 }
 
 @test "(nginx-vhosts) proxy:build-config (failed validate_nginx)" {
-  run deploy_app nodejs-express dokku@dokku.me:$TEST_APP bad_custom_nginx_template
+  run deploy_app nodejs-express dokku@$DOKKU_DOMAIN:$TEST_APP bad_custom_nginx_template
   echo "output: $output"
   echo "status: $status"
   assert_failure

--- a/tests/unit/nginx-vhosts_9.bats
+++ b/tests/unit/nginx-vhosts_9.bats
@@ -163,12 +163,12 @@ teardown() {
 
 @test "(nginx-vhosts) proxy:build-config (with SSL and unrelated domain)" {
   setup_test_tls
-  run /bin/bash -c "dokku domains:add $TEST_APP node-js-app.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP node-js-app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP test.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP test.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -183,18 +183,18 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  assert_ssl_domain "node-js-app.dokku.me"
-  assert_http_redirect "http://test.dokku.me" "https://test.dokku.me:443/"
+  assert_ssl_domain "node-js-app.${DOKKU_DOMAIN}"
+  assert_http_redirect "http://test.${DOKKU_DOMAIN}" "https://test.${DOKKU_DOMAIN}:443/"
 }
 
 @test "(nginx-vhosts) proxy:build-config (wildcard SSL)" {
   setup_test_tls wildcard
-  run /bin/bash -c "dokku domains:add $TEST_APP wildcard1.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard1.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP wildcard2.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP wildcard2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -209,6 +209,6 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  assert_ssl_domain "wildcard1.dokku.me"
-  assert_ssl_domain "wildcard2.dokku.me"
+  assert_ssl_domain "wildcard1.${DOKKU_DOMAIN}"
+  assert_ssl_domain "wildcard2.${DOKKU_DOMAIN}"
 }

--- a/tests/unit/ports.bats
+++ b/tests/unit/ports.bats
@@ -110,8 +110,8 @@ teardown() {
   for URL in $URLS; do
     assert_http_success $URL
   done
-  assert_http_success "http://$TEST_APP.dokku.me:8080"
-  assert_http_success "http://$TEST_APP.dokku.me:8081"
+  assert_http_success "http://$TEST_APP.${DOKKU_DOMAIN}:8080"
+  assert_http_success "http://$TEST_APP.${DOKKU_DOMAIN}:8081"
 }
 
 @test "(ports:report) herokuish tls" {
@@ -152,7 +152,7 @@ teardown() {
 }
 
 @test "(ports:report) dockerfile tls" {
-  run deploy_app python dokku@dokku.me:$TEST_APP move_expose_dockerfile_into_place
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP move_expose_dockerfile_into_place
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/proxied-app.bats
+++ b/tests/unit/proxied-app.bats
@@ -34,7 +34,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:set $TEST_APP $TEST_APP.dokku.me"
+  run /bin/bash -c "dokku domains:set $TEST_APP $TEST_APP.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/proxy.bats
+++ b/tests/unit/proxy.bats
@@ -96,7 +96,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  assert_nonssl_domain "${TEST_APP}.dokku.me"
+  assert_nonssl_domain "${TEST_APP}.${DOKKU_DOMAIN}"
 
   run /bin/bash -c "dokku proxy:disable $TEST_APP"
   echo "output: $output"
@@ -111,7 +111,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_http_success "${TEST_APP}.dokku.me"
+  assert_http_success "${TEST_APP}.${DOKKU_DOMAIN}"
 
   for CID_FILE in $DOKKU_ROOT/$TEST_APP/CONTAINER.web.*; do
     assert_not_external_port $(<$CID_FILE)

--- a/tests/unit/ps-cnb.bats
+++ b/tests/unit/ps-cnb.bats
@@ -22,7 +22,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP add_requirements_txt
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP add_requirements_txt
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/ps-general-1.bats
+++ b/tests/unit/ps-general-1.bats
@@ -63,7 +63,7 @@ EOF
 }
 
 @test "(ps:scale) update formations from Procfile" {
-  local TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  local TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   trap 'popd &>/dev/null || true; rm -rf "$TMP"' INT TERM
 
   CUSTOM_TMP="$TMP" deploy_app nodejs-express

--- a/tests/unit/run_1.bats
+++ b/tests/unit/run_1.bats
@@ -46,7 +46,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP add_requirements_txt
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP add_requirements_txt
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -73,7 +73,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP add_requirements_txt
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP add_requirements_txt
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/scheduler-docker-local.bats
+++ b/tests/unit/scheduler-docker-local.bats
@@ -38,8 +38,8 @@ teardown() {
   assert_success
 
   # the run command is equivalent to the following line, except with backslashes due to the enclosing doublequotes
-  # dokku docker-options:add test deploy '--label "some.key=Host(\`$TEST_APP.dokku.me\`)"'
-  run /bin/bash -c "dokku docker-options:add $TEST_APP deploy '--label \"some.key=Host(\\\`$TEST_APP.dokku.me\\\`)\"'"
+  # dokku docker-options:add test deploy '--label "some.key=Host(\`$TEST_APP.$DOKKU_DOMAIN\`)"'
+  run /bin/bash -c "dokku docker-options:add $TEST_APP deploy '--label \"some.key=Host(\\\`$TEST_APP.$DOKKU_DOMAIN\\\`)\"'"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -52,7 +52,7 @@ teardown() {
   run /bin/bash -c "docker inspect --format '{{ index .Config.Labels \"some.key\"}}' $TEST_APP.web.1"
   echo "output: $output"
   echo "status: $status"
-  assert_output "Host(\`$TEST_APP.dokku.me\`)"
+  assert_output "Host(\`$TEST_APP.$DOKKU_DOMAIN\`)"
   assert_success
 }
 

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -4,12 +4,13 @@
 DOKKU_ROOT=${DOKKU_ROOT:=~dokku}
 DOCKER_BIN=${DOCKER_BIN:="docker"}
 DOKKU_LIB_ROOT=${DOKKU_LIB_PATH:="/var/lib/dokku"}
+DOKKU_DOMAIN=${DOKKU_DOMAIN:="dokku.me"}
 PLUGIN_PATH=${PLUGIN_PATH:="$DOKKU_LIB_ROOT/plugins"}
 PLUGIN_AVAILABLE_PATH=${PLUGIN_AVAILABLE_PATH:="$PLUGIN_PATH/available"}
 PLUGIN_ENABLED_PATH=${PLUGIN_ENABLED_PATH:="$PLUGIN_PATH/enabled"}
 PLUGIN_CORE_PATH=${PLUGIN_CORE_PATH:="$DOKKU_LIB_ROOT/core-plugins"}
 PLUGIN_CORE_AVAILABLE_PATH=${PLUGIN_CORE_AVAILABLE_PATH:="$PLUGIN_CORE_PATH/available"}
-CUSTOM_TEMPLATE_SSL_DOMAIN=customssltemplate.dokku.me
+CUSTOM_TEMPLATE_SSL_DOMAIN="customssltemplate.${DOKKU_DOMAIN}"
 UUID=$(uuidgen)
 TEST_APP="rdmtestapp-${UUID}"
 TEST_NETWORK="test-network-${UUID}"
@@ -309,9 +310,9 @@ assert_urls() {
 deploy_app() {
   declare APP_TYPE="$1" GIT_REMOTE="$2" CUSTOM_TEMPLATE="$3" CUSTOM_PATH="$4"
   local APP_TYPE=${APP_TYPE:="python"}
-  local GIT_REMOTE=${GIT_REMOTE:="dokku@dokku.me:$TEST_APP"}
+  local GIT_REMOTE=${GIT_REMOTE:="dokku@${DOKKU_DOMAIN}:$TEST_APP"}
   local GIT_REMOTE_BRANCH=${GIT_REMOTE_BRANCH:="master"}
-  local TMP=${CUSTOM_TMP:=$(mktemp -d "/tmp/dokku.me.XXXXX")}
+  local TMP=${CUSTOM_TMP:=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")}
 
   rmdir "$TMP" && cp -r "${BATS_TEST_DIRNAME}/../../tests/apps/$APP_TYPE" "$TMP"
 
@@ -335,7 +336,7 @@ deploy_app() {
 
 setup_client_repo() {
   local TMP
-  TMP=$(mktemp -d "/tmp/dokku.me.XXXXX")
+  TMP=$(mktemp -d "/tmp/${DOKKU_DOMAIN}.XXXXX")
   rmdir "$TMP" && cp -r "${BATS_TEST_DIRNAME}/../../tests/apps/nodejs-express" "$TMP"
   cd "$TMP" || exit 1
   git init
@@ -451,7 +452,7 @@ custom_nginx_template() {
 server {
   listen      [::]:{{ \$listen_port }};
   listen      {{ \$listen_port }};
-  server_name {{ $.NOSSL_SERVER_NAME }} customtemplate.dokku.me;
+  server_name {{ $.NOSSL_SERVER_NAME }} customtemplate.${DOKKU_DOMAIN};
 
   location    / {
     proxy_pass  http://{{ $.APP }}-{{ \$upstream_port }};

--- a/tests/unit/traefik.bats
+++ b/tests/unit/traefik.bats
@@ -39,7 +39,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP convert_to_dockerfile
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP convert_to_dockerfile
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -57,28 +57,28 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP-2.dokku.me"
+  run /bin/bash -c "dokku domains:add $TEST_APP $TEST_APP-2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run deploy_app python dokku@dokku.me:$TEST_APP convert_to_dockerfile
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP convert_to_dockerfile
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "curl --silent $TEST_APP.dokku.me"
+  run /bin/bash -c "curl --silent $TEST_APP.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
   assert_output "python/http.server"
 
-  run /bin/bash -c "curl --silent $TEST_APP-2.dokku.me"
+  run /bin/bash -c "curl --silent $TEST_APP-2.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -136,7 +136,7 @@ teardown() {
   run /bin/bash -c "docker inspect traefik-traefik-1 --format '{{ index .Config.Labels \"traefik.http.routers.api.rule\" }}'"
   echo "output: $output"
   echo "status: $status"
-  assert_output "Host(\`traefik.dokku.me\`)"
+  assert_output "Host(\`traefik.$DOKKU_DOMAIN\`)"
   assert_success
 }
 


### PR DESCRIPTION
When developing Dokku, it is useful to use a real domain to test actual functionality. This is impossible if the domain is hardcoded to dokku.me in testing.