### PR TITLE
Deprecate ARM as a build target

### DIFF
--- a/docs/appendices/0.31.0-migration-guide.md
+++ b/docs/appendices/0.31.0-migration-guide.md
@@ -19,6 +19,7 @@
 - The `common#get_exposed_ports_from_image()` function is deprecated and will be removed in the next release. There is no replacement for this as it's only use in Dokku core was during the build process.
 - The environment variable `DOKKU_PROXY_PORT_MAP` has been migrated to the properties system. Direct changes to the value will be ignored, and users should interact with port maps via the `ports` plugin.
 - The `CHECKS` file is deprecated in favor of defining healthchecks in the `app.json` file. The [docker-container-healthchecker](https://github.com/dokku/docker-container-healthchecker) tool can be used to generate healthcheck entries in `app.json` format from existing `CHECKS` files. See the [zero-downtime deploy documentation](/docs/deployment/zero-downtime-deploys.md) for more information on how the new zero downtime check format works.
+- ARM support is now deprecated, and will be removed in the next minor release. ARM releases are not tested in CI and do not get testing locally. Users of ARM installations on platforms such as the Raspberry PI should consider migrating to ARM64. ARM64 will continue to be supported by Dokku, and there are no plans to remove support for ARM64.
 
 ## Un-Deprecations
 


### PR DESCRIPTION
AMD64 and ARM64 continue to be supported, but ARM in CI is not currently supported and doesn't get local testing either, so deprecating it now and removing it in the future makes most sense for the project.