### PR TITLE
feat: timeout docker image builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: build docker image
+        timeout-minutes: 20
         run: |
           docker buildx build \
                 --platform ${{ matrix.architecture }} \


### PR DESCRIPTION
ARM usually takes quite a while to build. If it takes more than ~15 minutes, then it is usually going to fail anyways, so timeout early.

AMD64 takes ~3 minutes, and ARM64 appears to take 15 minutes.