### PR TITLE
Deprecate the builder-specific pre-build-* triggers in favor of a global pre-build trigger

### DIFF
--- a/docs/appendices/0.32.0-migration-guide.md
+++ b/docs/appendices/0.32.0-migration-guide.md
@@ -2,4 +2,10 @@
 
 ## Deprecations
 
+- The following `pre-build-*` plugin triggers have been deprecated and will be removed in the next release. Users should instead trigger the `pre-build` plugin trigger.
+    - pre-build-buildpack
+    - pre-build-dockerfile
+    - pre-build-lambda
+    - pre-build-pack
+
 ## Removals

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1659,7 +1659,24 @@ APP="$1";
 dokku config:set --no-restart $APP MANUALLY_STOPPED=1
 ```
 
+### `pre-build`
+
+- Description: Allows you to run commands before the build image is created for a given app. For instance, this can be useful to add env vars to your container.
+- Invoked by: `internal function dokku_build() (build phase)`
+- Arguments: `$BUILDER_TYPE $APP $SOURCECODE_WORK_DIR`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+# TODO
+```
+
 ### `pre-build-buildpack`
+
+> Warning: Deprecated, please use `pre-build` instead
 
 - Description: Allows you to run commands before the build image is created for a given app. For instance, this can be useful to add env vars to your container. Only applies to apps using buildpacks.
 - Invoked by: `internal function dokku_build() (build phase)`
@@ -1676,8 +1693,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 ### `pre-build-pack`
 
-> Warning: The pack plugin trigger apis are under development and may change
-> between minor releases until the 1.0 release.
+> Warning: Deprecated, please use `pre-build` instead
 
 - Description: Allows you to run commands before the build image is created for a given app. For instance, this can be useful to add env vars to your container. Only applies to apps using pack.
 - Invoked by: `internal function dokku_build() (build phase)`
@@ -1693,6 +1709,8 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 ```
 
 ### `pre-build-dockerfile`
+
+> Warning: Deprecated, please use `pre-build` instead
 
 - Description: Allows you to run commands before the build image is created for a given app. For instance, this can be useful to add env vars to your container. Only applies to apps using a dockerfile.
 - Invoked by: `internal function dokku_build() (build phase)`

--- a/plugins/builder-dockerfile/builder-build
+++ b/plugins/builder-dockerfile/builder-build
@@ -23,7 +23,11 @@ trigger-builder-dockerfile-builder-build() {
 
   pushd "$SOURCECODE_WORK_DIR" &>/dev/null
 
-  plugn trigger pre-build-dockerfile "$APP"
+  if fn-plugn-trigger-exists "pre-build-dockerfile"; then
+    dokku_log_warn "Deprecated: please upgrade plugin to use 'pre-build' plugin trigger instead of pre-build-dockerfile"
+    plugn trigger pre-build-dockerfile "$APP"
+  fi
+  plugn trigger pre-build "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
 
   [[ "$DOKKU_DOCKERFILE_CACHE_BUILD" == "false" ]] && DOKKU_DOCKER_BUILD_OPTS="$DOKKU_DOCKER_BUILD_OPTS --no-cache"
   local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$BUILDER_TYPE")

--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -57,7 +57,11 @@ trigger-builder-herokuish-builder-build() {
   "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$TAR_CID" "$IMAGE" >/dev/null
   DOKKU_SKIP_IMAGE_CLEANUP_REGISTRATION=1 plugn trigger scheduler-register-retired "$APP" "$TAR_CID"
 
-  plugn trigger pre-build-buildpack "$APP" "$SOURCECODE_WORK_DIR"
+  if fn-plugn-trigger-exists "pre-build-buildpack"; then
+    dokku_log_warn "Deprecated: please upgrade plugin to use 'pre-build' plugin trigger instead of pre-build-buildpack"
+    plugn trigger pre-build-buildpack "$APP" "$SOURCECODE_WORK_DIR"
+  fi
+  plugn trigger pre-build "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
 
   local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$BUILDER_TYPE")
   [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" --env=TRACE=true "

--- a/plugins/builder-lambda/builder-build
+++ b/plugins/builder-lambda/builder-build
@@ -18,7 +18,11 @@ trigger-builder-lambda-builder-build() {
 
   pushd "$SOURCECODE_WORK_DIR" &>/dev/null
 
-  plugn trigger pre-build-lambda "$APP"
+  if fn-plugn-trigger-exists "pre-build-lambda"; then
+    dokku_log_warn "Deprecated: please upgrade plugin to use 'pre-build' plugin trigger instead of pre-build-lambda"
+    plugn trigger pre-build-lambda "$APP"
+  fi
+  plugn trigger pre-build "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
 
   lambda-builder build --generate-image --write-procfile --image-env=DOCKER_LAMBDA_STAY_OPEN=1 --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.image-stage=build --label=com.dokku.builder-type=lambda "--label=com.dokku.app-name=$APP" $DOKKU_GLOBAL_BUILD_ARGS --port 5000 --tag "$IMAGE" --working-directory "$SOURCECODE_WORK_DIR"
   if [[ ! -f "$SOURCECODE_WORK_DIR/lambda.zip" ]]; then

--- a/plugins/builder-pack/builder-build
+++ b/plugins/builder-pack/builder-build
@@ -31,7 +31,12 @@ trigger-builder-pack-builder-build() {
   ENV_ARGS=($(config_export app "$APP" --format pack-keys --merged))
   eval "$(config_export app "$APP" --merged)"
 
-  plugn trigger pre-build-pack "$APP" "$SOURCECODE_WORK_DIR"
+  if fn-plugn-trigger-exists "pre-build-pack"; then
+    dokku_log_warn "Deprecated: please upgrade plugin to use 'pre-build' plugin trigger instead of pre-build-pack"
+    plugn trigger pre-build-pack "$APP" "$SOURCECODE_WORK_DIR"
+  fi
+  plugn trigger pre-build "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
+
   pack build "$IMAGE" --builder "$DOKKU_CNB_BUILDER" --path "$SOURCECODE_WORK_DIR" --default-process web "${ENV_ARGS[@]}"
   docker-image-labeler --label=dokku --label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.image-stage=build --label=com.dokku.builder-type=pack --label=com.dokku.app-name=$APP "$IMAGE"
 


### PR DESCRIPTION
The pre-build trigger takes a `BUILDER_TYPE` parameter, allowing folks to perform specific actions as needed.