### PR TITLE
Deprecate the builder-specific post-build-* triggers in favor of a global post-build trigger

### DIFF
--- a/docs/appendices/0.32.0-migration-guide.md
+++ b/docs/appendices/0.32.0-migration-guide.md
@@ -2,4 +2,10 @@
 
 ## Deprecations
 
+- The following `post-build-*` plugin triggers have been deprecated and will be removed in the next release. Users should instead trigger the `post-build` plugin trigger.
+    - post-build-buildpack
+    - post-build-dockerfile
+    - post-build-lambda
+    - post-build-pack
+
 ## Removals

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1393,7 +1393,24 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 ```
 
+### `post-build`
+
+- Description: Allows you to run commands after the build image is create for a given app.
+- Invoked by: `internal function dokku_build() (build phase)`
+- Arguments: `$BUILDER_TYPE $APP $SOURCECODE_WORK_DIR`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+# TODO
+```
+
 ### `post-build-buildpack`
+
+> Warning: Deprecated, please use `post-build` instead
 
 - Description: Allows you to run commands after the build image is create for a given app. Only applies to apps using buildpacks.
 - Invoked by: `internal function dokku_build() (build phase)`
@@ -1410,8 +1427,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 ### `post-build-pack`
 
-> Warning: The pack plugin trigger apis are under development and may change
-> between minor releases until the 1.0 release.
+> Warning: Deprecated, please use `post-build` instead
 
 - Description: Allows you to run commands after the build image is create for a given app. Only applies to apps using pack.
 - Invoked by: `internal function dokku_build() (build phase)`
@@ -1427,6 +1443,8 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 ```
 
 ### `post-build-dockerfile`
+
+> Warning: Deprecated, please use `post-build` instead
 
 - Description: Allows you to run commands after the build image is create for a given app. Only applies to apps using a dockerfile.
 - Invoked by: `internal function dokku_build() (build phase)`

--- a/plugins/builder-dockerfile/builder-build
+++ b/plugins/builder-dockerfile/builder-build
@@ -38,7 +38,11 @@ trigger-builder-dockerfile-builder-build() {
   "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS "${ARG_ARRAY[@]}" ${DOKKU_DOCKER_BUILD_OPTS} -t $IMAGE .
 
   plugn trigger ports-set-detected "$APP" "$(fn-builder-dockerfile-get-detect-port-map "$APP" "$IMAGE" "$SOURCECODE_WORK_DIR/Dockerfile")"
-  plugn trigger post-build-dockerfile "$APP"
+  if fn-plugn-trigger-exists "post-build-dockerfile"; then
+    dokku_log_warn "Deprecated: please upgrade plugin to use 'post-build' plugin trigger instead of post-build-dockerfile"
+    plugn trigger post-build-dockerfile "$APP"
+  fi
+  plugn trigger post-build "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
 }
 
 trigger-builder-dockerfile-builder-build "$@"

--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -95,7 +95,11 @@ trigger-builder-herokuish-builder-build() {
   # ensure we have a port mapping
   plugn trigger ports-configure "$APP"
   plugn trigger ports-set-detected "$APP" "http:$(plugn trigger ports-get-property "$APP" proxy-port):5000"
-  plugn trigger post-build-buildpack "$APP" "$SOURCECODE_WORK_DIR"
+  if fn-plugn-trigger-exists "post-build-buildpack"; then
+    dokku_log_warn "Deprecated: please upgrade plugin to use 'post-build' plugin trigger instead of post-build-buildpack"
+    plugn trigger post-build-buildpack "$APP" "$SOURCECODE_WORK_DIR"
+  fi
+  plugn trigger post-build "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
 }
 
 trigger-builder-herokuish-builder-build "$@"

--- a/plugins/builder-lambda/builder-build
+++ b/plugins/builder-lambda/builder-build
@@ -39,7 +39,11 @@ trigger-builder-lambda-builder-build() {
   # ensure we have a port mapping
   plugn trigger ports-configure "$APP"
   plugn trigger ports-set-detected "$APP" "http:$(plugn trigger ports-get-property "$APP" proxy-port):5000"
-  plugn trigger post-build-lambda "$APP"
+  if fn-plugn-trigger-exists "post-build-lambda"; then
+    dokku_log_warn "Deprecated: please upgrade plugin to use 'post-build' plugin trigger instead of post-build-lambda"
+    plugn trigger post-build-lambda "$APP"
+  fi
+  plugn trigger post-build "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
 }
 
 trigger-builder-lambda-builder-build "$@"

--- a/plugins/builder-pack/builder-build
+++ b/plugins/builder-pack/builder-build
@@ -38,7 +38,12 @@ trigger-builder-pack-builder-build() {
   # ensure we have a port mapping
   plugn trigger ports-configure "$APP"
   plugn trigger ports-set-detected "$APP" "http:$(plugn trigger ports-get-property "$APP" proxy-port):5000"
-  plugn trigger post-build-pack "$APP" "$SOURCECODE_WORK_DIR"
+
+  if fn-plugn-trigger-exists "post-build-pack"; then
+    dokku_log_warn "Deprecated: please upgrade plugin to use 'post-build' plugin trigger instead of post-build-pack"
+    plugn trigger post-build-pack "$APP" "$SOURCECODE_WORK_DIR"
+  fi
+  plugn trigger post-build "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
 }
 
 trigger-builder-pack-builder-build "$@"


### PR DESCRIPTION
The pre-build trigger takes a `BUILDER_TYPE` parameter, allowing folks to perform specific actions as needed.