### PR TITLE
Remove ARM support

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -25,15 +25,7 @@ runs:
     - name: build docker image
       shell: bash
       run: |
-        if [[ "${{ inputs.architecture }}" == "linux/arm" ]]; then
-          docker buildx build \
-                --platform linux/arm \
+        docker buildx build \
                 --progress plain \
                 --tag "dokku/dokku:latest" \
                 .
-        else
-          docker buildx build \
-                  --progress plain \
-                  --tag "dokku/dokku:latest" \
-                  .
-        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,23 +94,6 @@ jobs:
         with:
           architecture: linux/amd64
 
-  build-image-arm:
-    name: build-image.linux/arm
-    needs: build
-    runs-on: buildjet-4vcpu-ubuntu-2204-arm
-    timeout-minutes: 20
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: set up qemu
-        uses: docker/setup-qemu-action@v2
-
-      - name: build-image
-        uses: ./.github/actions/build-image
-        with:
-          architecture: linux/arm
-
   build-image-arm64:
     name: build-image.linux/arm64
     needs: build

--- a/contrib/build-dokku.Dockerfile
+++ b/contrib/build-dokku.Dockerfile
@@ -36,29 +36,9 @@ RUN PLUGIN_MAKE_TARGET=${PLUGIN_MAKE_TARGET} \
   make version copyfiles \
   && make deb-dokku
 
-FROM builder as armhf
-
-COPY --from=amd64 /tmp /tmp
-COPY --from=amd64 /usr/local/share/man/man1/dokku.1 /usr/local/share/man/man1/dokku.1-generated
-
-RUN rm -rf /tmp/build-dokku
-
-ARG PLUGIN_MAKE_TARGET
-ARG DOKKU_VERSION=master
-ARG DOKKU_GIT_REV
-ARG IS_RELEASE=false
-
-RUN PLUGIN_MAKE_TARGET=${PLUGIN_MAKE_TARGET} \
-  DOKKU_VERSION=${DOKKU_VERSION} \
-  DOKKU_GIT_REV=${DOKKU_GIT_REV} \
-  IS_RELEASE=${IS_RELEASE} \
-  SKIP_GO_CLEAN=true \
-  GOARCH=arm make version copyfiles \
-  && DOKKU_ARCHITECTURE=armhf GOARCH=arm make deb-dokku
-
 FROM builder as arm64
 
-COPY --from=armhf /tmp /tmp
+COPY --from=amd64 /tmp /tmp
 COPY --from=amd64 /usr/local/share/man/man1/dokku.1 /usr/local/share/man/man1/dokku.1-generated
 
 RUN rm -rf /tmp/build-dokku

--- a/contrib/release-dokku
+++ b/contrib/release-dokku
@@ -387,14 +387,14 @@ fn-build-docker-image() {
 
   if [[ "$IS_RELEASE" == "true" ]]; then
     docker buildx build \
-      --platform linux/arm,linux/arm64,linux/amd64 \
+      --platform linux/arm64,linux/amd64 \
       --progress plain \
       --push \
       --tag "dokku/dokku:latest" \
       --tag "dokku/dokku:$VERSION" .
   elif [[ "$SKIP_IMAGE_BUILD" != "true" ]]; then
     docker buildx build \
-      --platform linux/arm,linux/arm64,linux/amd64 \
+      --platform linux/arm64,linux/amd64 \
       --progress plain \
       --tag "dokku/dokku:latest" \
       --tag "dokku/dokku:$(echo "$VERSION" | tr + -)" .
@@ -443,16 +443,13 @@ main() {
 
   fn-repo-update "$IS_RELEASE" "$CURRENT_VERSION" "$NEXT_VERSION" "$IS_PATCH"
   fn-build-dokku "$IS_RELEASE" "$NEXT_VERSION" || log-fail "Error building package"
-  fn-extract-package "$IS_RELEASE" "dokku_${NEXT_VERSION}_armhf.deb" || log-fail "Error extracting deb package"
   fn-extract-package "$IS_RELEASE" "dokku_${NEXT_VERSION}_arm64.deb" || log-fail "Error extracting deb package"
   fn-extract-package "$IS_RELEASE" "dokku_${NEXT_VERSION}_amd64.deb" || log-fail "Error extracting deb package"
   mkdir -p build/package
   cp -f "build/dokku_${NEXT_VERSION}_amd64.deb" build/package/dokku-amd64.deb
   cp -f "build/dokku_${NEXT_VERSION}_arm64.deb" build/package/dokku-arm64.deb
-  cp -f "build/dokku_${NEXT_VERSION}_armhf.deb" build/package/dokku-armhf.deb
 
   if [[ "$RELEASE" != "build" ]]; then
-    fn-publish-package "$IS_RELEASE" "raspbian" "build/dokku_${NEXT_VERSION}_armhf.deb" || log-fail "Error publishing deb package"
     fn-publish-package "$IS_RELEASE" "deb" "build/dokku_${NEXT_VERSION}_arm64.deb" || log-fail "Error publishing deb package"
     fn-publish-package "$IS_RELEASE" "deb" "build/dokku_${NEXT_VERSION}_amd64.deb" || log-fail "Error publishing deb package"
     fn-build-docker-image "$NEXT_VERSION" "$IS_RELEASE" || log-fail "Error building docker image"

--- a/docs/appendices/0.32.0-migration-guide.md
+++ b/docs/appendices/0.32.0-migration-guide.md
@@ -19,3 +19,5 @@
     - post-build-pack
 
 ## Removals
+
+- ARM support has been removed. Users of ARM installations on platforms such as the Raspberry PI should consider migrating to ARM64. ARM64 will continue to be supported by Dokku, and there are no plans to remove support for ARM64.

--- a/docs/deployment/builders/herokuish-buildpacks.md
+++ b/docs/deployment/builders/herokuish-buildpacks.md
@@ -181,7 +181,7 @@ dokku buildpacks:set-property --global stack
 > [!IMPORTANT]
 > New as of 0.29.0
 
-By default, the builder-herokuish plugin is not enabled for non-amd64 platforms, and attempting to use it is blocked. This is because the majority of buildpacks are not cross-platform compatible, and thus building apps will either be considerably slower - due to emulating the amd64 platform - or won't work - due to building amd64 packages on arm/arm64 platforms.
+By default, the builder-herokuish plugin is not enabled for non-amd64 platforms, and attempting to use it is blocked. This is because the majority of buildpacks are not cross-platform compatible, and thus building apps will either be considerably slower - due to emulating the amd64 platform - or won't work - due to building amd64 packages on arm64 platforms.
 
 To force-enable herokuish on non-amd64 platforms, the `allowed` property can be set via `builder-herokuish:set`. The default value depends on the host platform architecture (`true` on amd64, `false` otherwise).
 

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -13,7 +13,6 @@ To start using Dokku, you'll need a system that meets the following minimum requ
     - [Debian 10+ x64](https://www.debian.org/distrib/)
 - A server with one of the following architectures
     - AMD64 (alternatively known as `x86_64`), commonly used for Intel cloud servers
-    - ARMV7 (alternatively known as `armhf`), commonly used for Raspberry PI
     - ARMV8 (alternatively known as `arm64`), commonly used for Raspberry PI and AWS Graviton
 
 To avoid memory pressure during builds or runtime of your applications, we suggest the following:

--- a/plugins/00_dokku-standard/subcommands/report
+++ b/plugins/00_dokku-standard/subcommands/report
@@ -24,7 +24,7 @@ cmd-report() {
   dokku_log_info1 "git version: $(git --version)"
   dokku_log_info1 "sigil version: $(sigil -v)"
   dokku_log_info1 "herokuish version: "
-  if [[ "$ARCHITECTURE" == "armhf" ]] || [[ "$ARCHITECTURE" == "arm64" ]]; then
+  if [[ "$ARCHITECTURE" == "arm64" ]]; then
     dokku_log_warn "herokuish not supported on $ARCHITECTURE architecture"
   elif verify_image "$DOKKU_IMAGE"; then
     "$DOCKER_BIN" container run $DOKKU_GLOBAL_RUN_ARGS --rm "$DOKKU_IMAGE" herokuish version | sed "s/^/       /"

--- a/plugins/builder-herokuish/builder-detect
+++ b/plugins/builder-herokuish/builder-detect
@@ -10,10 +10,8 @@ trigger-builder-herokuish-builder-detect() {
   declare APP="$1" SOURCECODE_WORK_DIR="$2"
   local ARCHITECTURE="$(dpkg --print-architecture 2>/dev/null || true)"
 
-  if [[ "$ARCHITECTURE" == "armhf" ]] || [[ "$ARCHITECTURE" == "arm64" ]]; then
-    if [[ "$(fn-builder-herokuish-computed-allowed "$APP")" != "true" ]]; then
-      return
-    fi
+  if [[ "$ARCHITECTURE" == "arm64" ]] && [[ "$(fn-builder-herokuish-computed-allowed "$APP")" != "true" ]]; then
+    return
   fi
 
   if fn-has-buildpacks-file "$SOURCECODE_WORK_DIR"; then

--- a/plugins/builder-lambda/builder-detect
+++ b/plugins/builder-lambda/builder-detect
@@ -9,10 +9,6 @@ trigger-builder-lambda-builder-detect() {
   declare APP="$1" SOURCECODE_WORK_DIR="$2"
   local ARCHITECTURE="$(dpkg --print-architecture 2>/dev/null || true)"
 
-  if [[ "$ARCHITECTURE" == "armhf" ]]; then
-    return
-  fi
-
   if [[ -f "$SOURCECODE_WORK_DIR/lambda.yml" ]]; then
     echo "lambda"
     return

--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -57,10 +57,6 @@ git_trigger_build() {
         dokku_log_warn "Herokuish builder not supported on $ARCHITECTURE servers."
         dokku_log_warn "Switching to pack builder."
         BUILDER="pack"
-      elif [[ "$ARCHITECTURE" == "armhf" ]]; then
-        dokku_log_warn "Herokuish builder not supported on $ARCHITECTURE servers."
-        dokku_log_warn "Consider using a Dockerfile to build your app."
-        return 1
       fi
     fi
   fi

--- a/tests/unit/builder-herokuish.bats
+++ b/tests/unit/builder-herokuish.bats
@@ -20,7 +20,7 @@ teardown() {
 
 @test "(builder-herokuish) builder-herokuish:set allowed" {
   if [[ "$(dpkg --print-architecture 2>/dev/null || true)" == "amd64" ]]; then
-    skip "this test cannot be performed accurately on amd64 as it tests whether we can enable the plugin on armhf/arm64"
+    skip "this test cannot be performed accurately on amd64 as it tests whether we can enable the plugin on arm64"
   fi
 
   run /bin/bash -c "dokku builder-herokuish:set --global allowed"


### PR DESCRIPTION
Building/testing for ARM does not happen often - the only runtime environment is Raspberry PI, which supports ARM64 - and complicates support for a ton of features. Aside from that, CI runs are much longer for ARM Dokku images, often reaching 15-20 minutes or just timing out completely.

Rather than support an architecture that doesn't have much usage by maintainers and has a lot of maintenance burden, we're removing the platform.