### PR TITLE
Use correct path for openresty letsencrypt data

### DIFF
--- a/plugins/openresty-vhosts/install
+++ b/plugins/openresty-vhosts/install
@@ -8,8 +8,8 @@ trigger-openresty-install() {
   declare desc="installs the openresty plugin"
   declare trigger="install"
 
-  mkdir -p "${DOKKU_LIB_ROOT}/data/openresty" "${DOKKU_LIB_ROOT}/data/openresty/.docker-letsencrypt"
-  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/openresty"
+  mkdir -p "${DOKKU_LIB_ROOT}/data/openresty-vhosts" "${DOKKU_LIB_ROOT}/data/openresty-vhosts/.docker-letsencrypt"
+  chown -R "${DOKKU_SYSTEM_USER}:${DOKKU_SYSTEM_GROUP}" "${DOKKU_LIB_ROOT}/data/openresty-vhosts"
 
   fn-plugin-property-setup "openresty"
 }

--- a/plugins/openresty-vhosts/internal-functions
+++ b/plugins/openresty-vhosts/internal-functions
@@ -201,7 +201,7 @@ fn-openresty-template-compose-file() {
     COMPOSE_TEMPLATE="$CUSTOM_COMPOSE_TEMPLATE"
   fi
 
-  local SIGIL_PARAMS=(OPENRESTY_DATA_DIR="${DOKKU_LIB_ROOT}/data/openresty/.docker-letsencrypt"
+  local SIGIL_PARAMS=(OPENRESTY_DATA_DIR="${DOKKU_LIB_ROOT}/data/openresty-vhosts/.docker-letsencrypt"
     OPENRESTY_IMAGE="$(fn-openresty-image)"
     OPENRESTY_LETSENCRYPT_EMAIL="$(fn-openresty-letsencrypt-email)"
     OPENRESTY_LETSENCRYPT_SERVER="$(fn-openresty-letsencrypt-server)")


### PR DESCRIPTION
Paths are plugin-specific, and the previous path used the plugin alias, not the actual plugin name.