### PR TITLE
Lock deploys immediately upon starting a deploy process

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -945,6 +945,10 @@ acquire_app_deploy_lock() {
   local LOCK_WAITING_MSG="$APP currently has a deploy lock in place. Waiting..."
   local LOCK_FAILED_MSG="$APP currently has a deploy lock in place. Exiting..."
 
+  if [[ -n "$DOKKU_LOCK_ACQUIRED" ]]; then
+    return
+  fi
+
   acquire_advisory_lock "$APP_DEPLOY_LOCK_FILE" "$LOCK_TYPE" "$LOCK_WAITING_MSG" "$LOCK_FAILED_MSG"
 }
 
@@ -986,6 +990,10 @@ release_advisory_lock() {
   declare desc="release advisory lock"
   local LOCK_FILE="$1"
   local LOCK_FD="200"
+
+  if [[ ! -f "$LOCK_FILE" ]]; then
+    return
+  fi
 
   flock -u "$LOCK_FD" && rm -f "$LOCK_FILE" &>/dev/null
 }

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -45,6 +45,18 @@ cmd-git-from-archive() {
   USER_EMAIL="${ARGS[3]}"
 
   verify_app_name "$APP"
+
+  local exit_code=0
+  acquire_app_deploy_lock "$APP" "exclusive"
+  export DOKKU_LOCK_ACQUIRED=1
+  fn-git-from-archive "$APP" "$ARCHIVE_URL" "$ARCHIVE_TYPE" "$USER_NAME" "$USER_EMAIL" || exit_code="$?"
+  release_app_deploy_lock "$APP"
+  return "$exit_code"
+}
+
+fn-git-from-archive() {
+  declare APP="$1" ARCHIVE_URL="$2" ARCHIVE_TYPE="$3" USER_NAME="$4" USER_EMAIL="$5"
+
   [[ -z "$ARCHIVE_URL" ]] && dokku_log_fail "Please specify an archive url or -- to fetch the archive from stdin"
 
   local VALID_ARCHIVE_TYPES=("tar" "tar.gz" "zip")
@@ -111,6 +123,16 @@ cmd-git-load-image() {
   [[ -z "$DOCKER_IMAGE" ]] && dokku_log_fail "Please specify a docker image"
   [[ ! -t 0 ]] || dokku_log_fail "Expecting tar archive containing docker image on STDIN"
 
+  local exit_code=0
+  acquire_app_deploy_lock "$APP" "exclusive"
+  export DOKKU_LOCK_ACQUIRED=1
+  fn-git-load-image "$APP" "$DOCKER_IMAGE" "$BUILD_DIR" "$USER_NAME" "$USER_EMAIL" || exit_code="$?"
+  release_app_deploy_lock "$APP"
+  return "$exit_code"
+}
+
+fn-git-load-image() {
+  declare APP="$1" DOCKER_IMAGE="$2" BUILD_DIR="$3" USER_NAME="$4" USER_EMAIL="$5"
   cat | docker load
 
   if ! verify_image "$DOCKER_IMAGE"; then
@@ -155,6 +177,17 @@ cmd-git-from-image() {
   verify_app_name "$APP"
   [[ -z "$DOCKER_IMAGE" ]] && dokku_log_fail "Please specify a docker image"
 
+  local exit_code=0
+  acquire_app_deploy_lock "$APP" "exclusive"
+  export DOKKU_LOCK_ACQUIRED=1
+  fn-git-load-image "$APP" "$DOCKER_IMAGE" "$BUILD_DIR" "$USER_NAME" "$USER_EMAIL" || exit_code="$?"
+  release_app_deploy_lock "$APP"
+  return "$exit_code"
+}
+
+fn-git-from-image() {
+  declare APP="$1" DOCKER_IMAGE="$2" BUILD_DIR="$3" USER_NAME="$4" USER_EMAIL="$5"
+
   if ! plugn trigger git-from-image "$APP" "$DOCKER_IMAGE" "$BUILD_DIR" "$USER_NAME" "$USER_EMAIL"; then
     return 1
   fi
@@ -165,7 +198,7 @@ cmd-git-sync() {
   declare desc="clone or fetch an app from remote git repo"
   local cmd="git:sync"
   [[ "$1" == "$cmd" ]] && shift 1
-  declare APP GIT_REMOTE GIT_REF FLAG
+  local APP GIT_REMOTE GIT_REF FLAG
 
   ARGS=()
   for arg in "$@"; do
@@ -182,6 +215,17 @@ cmd-git-sync() {
   GIT_REF="${ARGS[2]}"
 
   verify_app_name "$APP"
+
+  local exit_code=0
+  acquire_app_deploy_lock "$APP" "exclusive"
+  export DOKKU_LOCK_ACQUIRED=1
+  fn-git-sync "$APP" "$GIT_REMOTE" "$GIT_REF" "$FLAG" || exit_code="$?"
+  release_app_deploy_lock "$APP"
+  return "$exit_code"
+}
+
+fn-git-sync() {
+  declare APP="$1" GIT_REMOTE="$2" GIT_REF="$3" FLAG="$4"
 
   if [[ -d "$DOKKU_LIB_ROOT/data/git/$APP" ]]; then
     if has_tty eq 0; then


### PR DESCRIPTION
Previously, some attempts to trigger a deploy would lock much later than desired, making it possible to trigger race conditions during deploys. We now lock as soon as possible for all cases where receive-app might be called in the request chain.