### PR TITLE
Clean up local build images immediately after an image is released

### DIFF
--- a/plugins/builder/functions.go
+++ b/plugins/builder/functions.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -11,30 +10,6 @@ import (
 
 	"github.com/dokku/dokku/plugins/common"
 )
-
-func listImagesByAppLabel(appName string) ([]string, error) {
-	command := []string{
-		common.DockerBin(),
-		"image",
-		"ls",
-		"--quiet",
-		"--filter",
-		fmt.Sprintf("label=com.dokku.app-name=%v", appName),
-	}
-
-	var stderr bytes.Buffer
-	listCmd := common.NewShellCmd(strings.Join(command, " "))
-	listCmd.ShowOutput = false
-	listCmd.Command.Stderr = &stderr
-	b, err := listCmd.Output()
-
-	if err != nil {
-		return []string{}, errors.New(strings.TrimSpace(stderr.String()))
-	}
-
-	output := strings.Split(strings.TrimSpace(string(b[:])), "\n")
-	return output, nil
-}
 
 func listImagesByImageRepo(imageRepo string) ([]string, error) {
 	command := []string{

--- a/plugins/builder/src/triggers/triggers.go
+++ b/plugins/builder/src/triggers/triggers.go
@@ -50,6 +50,10 @@ func main() {
 	case "post-delete":
 		appName := flag.Arg(0)
 		err = builder.TriggerPostDelete(appName)
+	case "post-release-builder":
+		builderType := flag.Arg(0)
+		appName := flag.Arg(1)
+		err = builder.TriggerPostReleaseBuilder(builderType, appName)
 	case "report":
 		appName := flag.Arg(0)
 		err = builder.ReportSingleApp(appName, "", "")

--- a/plugins/builder/triggers.go
+++ b/plugins/builder/triggers.go
@@ -133,7 +133,9 @@ func TriggerPostDelete(appName string) error {
 		return err
 	}
 
-	imagesByAppLabel, err := listImagesByAppLabel(appName)
+	imagesByAppLabel, err := common.DockerFilterImages([]string{
+		fmt.Sprintf("label=com.dokku.app-name=%s", appName),
+	})
 	if err != nil {
 		common.LogWarn(err.Error())
 	}
@@ -146,6 +148,20 @@ func TriggerPostDelete(appName string) error {
 
 	images := append(imagesByAppLabel, imagesByRepo...)
 	common.RemoveImages(images)
+
+	return nil
+}
+
+// TriggerPostReleaseBuilder deletes unused build images
+func TriggerPostReleaseBuilder(builderType string, appName string) error {
+	images, _ := common.DockerFilterImages([]string{
+		"label=com.dokku.image-stage=build",
+		fmt.Sprintf("label=com.dokku.app-name=%s", appName),
+	})
+
+	if err := common.RemoveImages(images); err != nil {
+		common.LogWarn(err.Error())
+	}
 
 	return nil
 }


### PR DESCRIPTION
In some cases, we might hold onto intermediate images until the next deploy. While these images are generally part of newer images - and are therefore cleaned up when the child images are no longer in use - they cruft up the 'docker image ls' output, causing some folks to believe Dokku is not cleaning up images.

Refs #6272