### PR TITLE
Run ps:restore in parallel by default

### DIFF
--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -18,7 +18,7 @@ start on filesystem and started docker
 
 script
   sleep 2 # give docker some time
-  sudo -i -u dokku $dokku_path ps:restore
+  sudo -i -u dokku $dokku_path ps:restore --parallel -1
 end script
 EOF
 fi
@@ -33,7 +33,7 @@ After=docker.service
 [Service]
 Type=simple
 User=dokku
-ExecStart=$dokku_path ps:restore
+ExecStart=$dokku_path ps:restore --parallel -1
 
 [Install]
 WantedBy=docker.service


### PR DESCRIPTION
This will speed up restores in cases where app containers disappear on reboot or have new IPs, which primarily impacts the docker-local scheduler in conjunction with nginx.

Closes #4967