### PR TITLE
Remove pack installation from builder-lambda tests

### DIFF
--- a/tests/unit/builder-lambda.bats
+++ b/tests/unit/builder-lambda.bats
@@ -2,10 +2,6 @@
 
 load test_helper
 
-setup_file() {
-  install_pack
-}
-
 setup() {
   create_app
 }


### PR DESCRIPTION
It isn't necessary and causes false-negatives when pack isn't able to be installed.