### PR TITLE
Document future removal of deprecated CHECKS file format

### DIFF
--- a/docs/appendices/0.32.0-migration-guide.md
+++ b/docs/appendices/0.32.0-migration-guide.md
@@ -17,6 +17,7 @@
     - post-build-dockerfile
     - post-build-lambda
     - post-build-pack
+- The `CHECKS` file was deprecated in the previous release in favor of defining healthchecks in the `app.json` file. It's support and auto-migration to healthchecks in the `app.json` file will be removed in the next release. See the [zero-downtime deploy documentation](/docs/deployment/zero-downtime-deploys.md) for more information on how the new zero downtime check format works.
 
 ## Removals
 


### PR DESCRIPTION
This will be removed in the future in favor of defining healthchecks in the app.json file.