### PR TITLE
Set the platform flag in order to run amd64 images on arm64 deploy targets

### DIFF
--- a/docs/deployment/schedulers/docker-local.md
+++ b/docs/deployment/schedulers/docker-local.md
@@ -25,6 +25,12 @@ dokku config:unset node-js-app DOCKER_SCHEDULER
 
 ## Usage
 
+### Deploying amd64 images on arm64
+
+> New as of 0.33.0
+
+Many builders only produce amd64-compatible images. The docker-local scheduler will automatically detect these and run them via the `--platform=linux/amd64` on arm64 deploy targets.
+
 ### Disabling chown of persistent storage
 
 The `scheduler-docker-local` plugin will ensure your storage mounts are owned by either `herokuishuser` or the overridden value you have set in `DOKKU_APP_USER`. You may disable this by running the following `scheduler-docker-local:set` command for your application:

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process-container
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process-container
@@ -49,6 +49,12 @@ main() {
 
   DOCKER_ARGS+=" --env=PORT=$DOKKU_PORT"
 
+  local DOKKU_IMAGE_ARCHITECTURE="$("$DOCKER_BIN" image inspect --format '{{.Architecture}}' "$IMAGE")"
+  if [[ "$DOKKU_IMAGE_ARCHITECTURE" == "amd64" ]] && [[ "$(dpkg --print-architecture 2>/dev/null || true)" != "amd64" ]]; then
+    dokku_log_warn "Detected linux/amd64 image, forcing --platform=linux/amd64"
+    DOCKER_ARGS+=" --platform=linux/amd64"
+  fi
+
   START_CMD=$(fn-scheduler-docker-local-extract-start-cmd "$APP" "$PROC_TYPE" "$START_CMD" "$DOKKU_HEROKUISH" "$DOKKU_PORT")
   DOCKER_ARGS+=" $IMAGE"
   DOCKER_ARGS+=" $START_CMD"

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -83,6 +83,12 @@ trigger-scheduler-docker-local-scheduler-run() {
     fi
   fi
 
+  local DOKKU_IMAGE_ARCHITECTURE="$("$DOCKER_BIN" image inspect --format '{{.Architecture}}' "$IMAGE")"
+  if [[ "$DOKKU_IMAGE_ARCHITECTURE" == "amd64" ]] && [[ "$(dpkg --print-architecture 2>/dev/null || true)" != "amd64" ]]; then
+    dokku_log_warn "Detected linux/amd64 image, forcing --platform=linux/amd64"
+    DOCKER_ARGS+=" --platform=linux/amd64"
+  fi
+
   # shellcheck disable=SC2124
   DOCKER_ARGS+=" --label=com.dokku.container-type=$PROCESS_TYPE"
   DOCKER_ARGS+=" --label=com.dokku.app-name=$APP"


### PR DESCRIPTION
This allows folks to use herokuish, pack, and lambda built-images on arm64 servers.

Closes #6312