### PR TITLE
Fix docs app-exists plugin trigger description

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -61,7 +61,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 ### `app-exists`
 
-- Description: Creates an app
+- Description: Checks if an app exists
 - Invoked by:
 - Arguments: `$APP`
 - Example:


### PR DESCRIPTION
Fix the the description of the `app-exists` plugin trigger docs. I used the description displayed in `dokku apps --help` as reference.

![image](https://github.com/dokku/dokku/assets/451059/c6b3dbc4-3cb9-469e-9b31-9777c4715037)