### PR TITLE
Replace deprecated `io/ioutil` functions

### DIFF
--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -85,7 +84,7 @@ func getAppJSON(appName string) (AppJSON, error) {
 		return AppJSON{}, nil
 	}
 
-	b, err := ioutil.ReadFile(getProcessSpecificAppJSONPath(appName))
+	b, err := os.ReadFile(getProcessSpecificAppJSONPath(appName))
 	if err != nil {
 		return AppJSON{}, fmt.Errorf("Cannot read app.json file: %v", err)
 	}

--- a/plugins/builder/functions.go
+++ b/plugins/builder/functions.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -35,7 +34,7 @@ func listImagesByImageRepo(imageRepo string) ([]string, error) {
 }
 
 func removeAllContents(basePath string) error {
-	dir, err := ioutil.ReadDir(basePath)
+	dir, err := os.ReadDir(basePath)
 	if err != nil {
 		return err
 	}

--- a/plugins/builder/triggers.go
+++ b/plugins/builder/triggers.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,7 +70,7 @@ func TriggerCorePostExtract(appName string, sourceWorkDir string) error {
 		return fmt.Errorf("Specified build-dir not found in sourcecode working directory: %v", buildDir)
 	}
 
-	tmpWorkDir, err := ioutil.TempDir(os.TempDir(), fmt.Sprintf("dokku-%s-%s", common.MustGetEnv("DOKKU_PID"), "CorePostExtract"))
+	tmpWorkDir, err := os.MkdirTemp(os.TempDir(), fmt.Sprintf("dokku-%s-%s", common.MustGetEnv("DOKKU_PID"), "CorePostExtract"))
 	if err != nil {
 		return fmt.Errorf("Unable to create temporary working directory: %v", err.Error())
 	}

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -280,7 +280,7 @@ func DokkuApps() ([]string, error) {
 func UnfilteredDokkuApps() ([]string, error) {
 	apps := []string{}
 	dokkuRoot := MustGetEnv("DOKKU_ROOT")
-	files, err := ioutil.ReadDir(dokkuRoot)
+	files, err := os.ReadDir(dokkuRoot)
 	if err != nil {
 		return apps, fmt.Errorf("You haven't deployed any applications yet")
 	}
@@ -517,7 +517,7 @@ func SuppressOutput(f errfunc) error {
 	err := f()
 
 	w.Close()
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	os.Stdout = rescueStdout
 
 	if err != nil {

--- a/plugins/common/common_test.go
+++ b/plugins/common/common_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -31,7 +30,7 @@ func setupTests() (err error) {
 func setupTestApp() (err error) {
 	Expect(os.MkdirAll(testAppDir, 0644)).To(Succeed())
 	b := []byte(testEnvLine + "\n")
-	if err = ioutil.WriteFile(testEnvFile, b, 0644); err != nil {
+	if err = os.WriteFile(testEnvFile, b, 0644); err != nil {
 		return
 	}
 	return
@@ -40,7 +39,7 @@ func setupTestApp() (err error) {
 func setupTestApp2() (err error) {
 	Expect(os.MkdirAll(testAppDir2, 0644)).To(Succeed())
 	b := []byte(testEnvLine2 + "\n")
-	if err = ioutil.WriteFile(testEnvFile2, b, 0644); err != nil {
+	if err = os.WriteFile(testEnvFile2, b, 0644); err != nil {
 		return
 	}
 	return

--- a/plugins/common/docker.go
+++ b/plugins/common/docker.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -79,7 +78,7 @@ func CopyFromImage(appName string, image string, source string, destination stri
 		}
 	}
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("dokku-%s-%s", MustGetEnv("DOKKU_PID"), "CopyFromImage"))
+	tmpFile, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("dokku-%s-%s", MustGetEnv("DOKKU_PID"), "CopyFromImage"))
 	if err != nil {
 		return fmt.Errorf("Cannot create temporary file: %v", err)
 	}

--- a/plugins/common/io.go
+++ b/plugins/common/io.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"strconv"
@@ -133,7 +132,7 @@ func IsAbsPath(path string) bool {
 
 // ListFilesWithPrefix lists files within a given path that have a given prefix
 func ListFilesWithPrefix(path string, prefix string) []string {
-	names, err := ioutil.ReadDir(path)
+	names, err := os.ReadDir(path)
 	if err != nil {
 		return []string{}
 	}
@@ -144,7 +143,7 @@ func ListFilesWithPrefix(path string, prefix string) []string {
 			continue
 		}
 
-		if f.Mode().IsRegular() {
+		if f.Type().IsRegular() {
 			files = append(files, fmt.Sprintf("%s/%s", path, f.Name()))
 		}
 	}

--- a/plugins/common/properties.go
+++ b/plugins/common/properties.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -115,7 +114,7 @@ func PropertyGetAll(pluginName string, appName string) (map[string]string, error
 		return properties, errors.New("Specified property path is not a directory")
 	}
 
-	files, err := ioutil.ReadDir(pluginAppConfigRoot)
+	files, err := os.ReadDir(pluginAppConfigRoot)
 	if err != nil {
 		return properties, err
 	}
@@ -139,7 +138,7 @@ func PropertyGetDefault(pluginName, appName, property, defaultValue string) (val
 	}
 
 	propertyPath := getPropertyPath(pluginName, appName, property)
-	b, err := ioutil.ReadFile(propertyPath)
+	b, err := os.ReadFile(propertyPath)
 	if err != nil {
 		LogWarn(fmt.Sprintf("Unable to read %s property %s.%s", pluginName, appName, property))
 		return

--- a/plugins/common/subprocess.go
+++ b/plugins/common/subprocess.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -104,8 +104,8 @@ func PlugnTriggerOutput(triggerName string, args ...string) ([]byte, error) {
 	wE.Close()
 	wO.Close()
 
-	readStderr, _ := ioutil.ReadAll(rE)
-	readStdout, _ := ioutil.ReadAll(rO)
+	readStderr, _ := io.ReadAll(rE)
+	readStdout, _ := io.ReadAll(rO)
 
 	stderr := string(readStderr[:])
 	if err != nil {

--- a/plugins/config/config_test.go
+++ b/plugins/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -29,12 +28,12 @@ func setupTests() (err error) {
 func setupTestApp() (err error) {
 	Expect(os.MkdirAll(testAppDir, 0766)).To(Succeed())
 	b := []byte("export testKey=TESTING\n")
-	if err = ioutil.WriteFile(strings.Join([]string{testAppDir, "/ENV"}, ""), b, 0644); err != nil {
+	if err = os.WriteFile(strings.Join([]string{testAppDir, "/ENV"}, ""), b, 0644); err != nil {
 		return
 	}
 
 	b = []byte("export testKey=GLOBAL_TESTING\nexport globalKey=GLOBAL_VALUE")
-	if err = ioutil.WriteFile(globalConfigFile, b, 0644); err != nil {
+	if err = os.WriteFile(globalConfigFile, b, 0644); err != nil {
 		return
 	}
 	return
@@ -179,7 +178,7 @@ func TestInvalidEnvOnDisk(t *testing.T) {
 
 	appConfigFile := strings.Join([]string{testAppDir, "/ENV"}, "")
 	b := []byte("export --invalid-key=TESTING\nexport valid_key=value\n")
-	if err := ioutil.WriteFile(appConfigFile, b, 0644); err != nil {
+	if err := os.WriteFile(appConfigFile, b, 0644); err != nil {
 		return
 	}
 
@@ -192,7 +191,7 @@ func TestInvalidEnvOnDisk(t *testing.T) {
 	Expect(value).To(Equal("value"))
 
 	//LoadAppEnv eliminates it from the file
-	content, err := ioutil.ReadFile(appConfigFile)
+	content, err := os.ReadFile(appConfigFile)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(strings.Contains(string(content), "--invalid-key")).To(BeFalse())
 

--- a/plugins/cron/cron.go
+++ b/plugins/cron/cron.go
@@ -3,7 +3,7 @@ package cron
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	appjson "github.com/dokku/dokku/plugins/app-json"
@@ -52,7 +52,7 @@ func FetchCronEntries(appName string) ([]TemplateCommand, error) {
 		return commands, nil
 	}
 
-	b, err := ioutil.ReadFile(appjsonPath)
+	b, err := os.ReadFile(appjsonPath)
 	if err != nil {
 		return commands, fmt.Errorf("Cannot read app.json file for %s: %v", appName, err)
 	}

--- a/plugins/logs/triggers.go
+++ b/plugins/logs/triggers.go
@@ -3,7 +3,7 @@ package logs
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,7 +16,7 @@ import (
 
 // TriggerDockerArgsProcessDeploy outputs the logs plugin docker options for an app
 func TriggerDockerArgsProcessDeploy(appName string) error {
-	stdin, err := ioutil.ReadAll(os.Stdin)
+	stdin, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/plugins/network/triggers.go
+++ b/plugins/network/triggers.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -11,7 +11,7 @@ import (
 
 // TriggerDockerArgsProcess outputs the network plugin docker options for an app
 func TriggerDockerArgsProcess(appName string) error {
-	stdin, err := ioutil.ReadAll(os.Stdin)
+	stdin, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/plugins/registry/subcommands.go
+++ b/plugins/registry/subcommands.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -13,7 +13,7 @@ import (
 // CommandLogin logs a user into the specified server
 func CommandLogin(server string, username string, password string, passwordStdin bool) error {
 	if passwordStdin {
-		stdin, err := ioutil.ReadAll(os.Stdin)
+		stdin, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/plugins/resource/triggers.go
+++ b/plugins/resource/triggers.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -11,7 +11,7 @@ import (
 
 // TriggerDockerArgsProcessDeploy outputs the process-specific docker options
 func TriggerDockerArgsProcessDeploy(appName string, processType string) error {
-	stdin, err := ioutil.ReadAll(os.Stdin)
+	stdin, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/plugins/scheduler-docker-local/functions.go
+++ b/plugins/scheduler-docker-local/functions.go
@@ -2,7 +2,6 @@ package schedulerdockerlocal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -128,7 +127,7 @@ func writeCronEntries() error {
 		return err
 	}
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("dokku-%s-%s", common.MustGetEnv("DOKKU_PID"), "WriteCronEntries"))
+	tmpFile, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("dokku-%s-%s", common.MustGetEnv("DOKKU_PID"), "WriteCronEntries"))
 	if err != nil {
 		return fmt.Errorf("Cannot create temporary schedule file: %v", err)
 	}
@@ -156,7 +155,7 @@ func getCronTemplate() (*template.Template, error) {
 	t := template.New("cron")
 
 	templatePath := filepath.Join(common.MustGetEnv("PLUGIN_ENABLED_PATH"), "cron", "templates", "cron.tmpl")
-	b, err := ioutil.ReadFile(templatePath)
+	b, err := os.ReadFile(templatePath)
 	if err != nil {
 		return t, fmt.Errorf("Cannot read template file: %v", err)
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated as of Go 1.16 [^1]. This commit replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

[^1]: https://golang.org/doc/go1.16#ioutil