### PR TITLE
Prefer systemctl over sv when both exist while restarting nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN \
   && ln -sf /mnt/dokku/var/lib/dokku/data /var/lib/dokku/data \
   && ln -sf /mnt/dokku/var/lib/dokku/services /var/lib/dokku/services \
   && mv /etc/my_init.d/00_regen_ssh_host_keys.sh /etc/my_init.d/15_regen_ssh_host_keys \
+  && rm -f /usr/bin/systemctl \
   && rm -f /etc/nginx/sites-enabled/default /usr/share/nginx/html/index.html /etc/my_init.d/10_syslog-ng.init \
   && rm -f /usr/local/openresty/nginx/conf/sites-enabled/default /usr/share/openresty/html/index.html \
   && sed -i '/imklog/d' /etc/rsyslog.conf \

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -77,10 +77,10 @@ trigger-nginx-vhosts-install() {
       ;;
 
     ubuntu)
-      if [[ -x /usr/bin/sv ]]; then
-        echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/sv enable $NGINX_INIT_NAME, /usr/bin/sv disable $NGINX_INIT_NAME, /usr/bin/sv reload $NGINX_INIT_NAME, /usr/bin/sv start $NGINX_INIT_NAME, /usr/bin/sv stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
-      elif [[ -x /usr/bin/systemctl ]]; then
+      if [[ -x /usr/bin/systemctl ]]; then
         echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/systemctl enable $NGINX_INIT_NAME, /usr/bin/systemctl disable $NGINX_INIT_NAME, /usr/bin/systemctl reload $NGINX_INIT_NAME, /usr/bin/systemctl start $NGINX_INIT_NAME, /usr/bin/systemctl stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
+      elif [[ -x /usr/bin/sv ]]; then
+        echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/sv enable $NGINX_INIT_NAME, /usr/bin/sv disable $NGINX_INIT_NAME, /usr/bin/sv reload $NGINX_INIT_NAME, /usr/bin/sv start $NGINX_INIT_NAME, /usr/bin/sv stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       else
         echo "%dokku ALL=(ALL) NOPASSWD:/etc/init.d/$NGINX_INIT_NAME enable, /etc/init.d/$NGINX_INIT_NAME disable, /etc/init.d/$NGINX_INIT_NAME reload, /etc/init.d/$NGINX_INIT_NAME start, /etc/init.d/$NGINX_INIT_NAME stop, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       fi

--- a/plugins/nginx-vhosts/internal-functions
+++ b/plugins/nginx-vhosts/internal-functions
@@ -149,10 +149,10 @@ fn-nginx-vhosts-nginx-init-cmd() {
 
     ubuntu)
       # support docker-based installations
-      if [[ -x /usr/bin/sv ]]; then
-        sudo /usr/bin/sv "$CMD" "$NGINX_INIT_NAME"
-      elif [[ -x /usr/bin/systemctl ]]; then
+      if [[ -x /usr/bin/systemctl ]]; then
         sudo /usr/bin/systemctl "$CMD" "$NGINX_INIT_NAME"
+      elif [[ -x /usr/bin/sv ]]; then
+        sudo /usr/bin/sv "$CMD" "$NGINX_INIT_NAME"
       elif [[ "$CMD" == "enable" ]] || [[ "$CMD" == "disable" ]]; then
         dokku_log_warn "Running $CMD is not possible for init.d managed services"
       else


### PR DESCRIPTION
Fix problem when sv and systemctl exists at the same time in ubuntu core command related dokku nginx plugin will fail.

This will happend when an ubuntu server upgrade from early version.