### PR TITLE
Scope the delete of symlinked plugins in debian post-install to the plugin folders

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -84,7 +84,8 @@ setup-plugins() {
       PLUGIN_PATH="${DOKKU_LIB_ROOT}/plugins" plugn enable "$plugin"
     fi
   done
-  find -L "${DOKKU_LIB_ROOT}" -type l -delete
+  find -L "${DOKKU_LIB_ROOT}/core-plugins" -type l -delete
+  find -L "${DOKKU_LIB_ROOT}/plugins" -type l -delete
   chown dokku:dokku -R "${DOKKU_LIB_ROOT}/plugins" "${DOKKU_LIB_ROOT}/core-plugins"
 
   echo "Install all core plugins"


### PR DESCRIPTION
Previously, we would try and traverse the entire dokku lib directory, causing extremely slow updates for installations with lots of data. This would also potentially cause issues for anyone using symlinks in their data directories.

Instead, just remove symlinks in the plugin directories.