### PR TITLE
Upgrade ruby to fix the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
 
       - name: login to docker hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Without this, package_cloud doesn't get installed due to an issue with the domain_name pacakge requiring Ruby 2.7.