### PR TITLE
feat: use go.work for development purposes

### DIFF
--- a/.devcontainer/bin/setup-dev-env
+++ b/.devcontainer/bin/setup-dev-env
@@ -5,27 +5,6 @@ install-go-devtools() {
   go install honnef.co/go/tools/cmd/staticcheck@latest
 }
 
-install-go-mods() {
-  local plugin_root="/root/go/src/github.com/dokku/dokku/plugins"
-
-  export GO111MODULE=off
-  echo "-----> Fetching onsi/gomega dependency for tests"
-  go get github.com/onsi/gomega || true
-
-  echo "-----> Fetching spf13/pflag dependency for subcommands"
-  go get github.com/spf13/pflag || true
-  pushd "$plugin_root" >/dev/null || true
-  find "$plugin_root/" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read -r plugin; do
-    pushd "$plugin_root/$plugin" >/dev/null || true
-    if [[ -f "go.mod" ]]; then
-      echo "-----> Fetching dependencies for $plugin plugin"
-      go get || true
-    fi
-    popd >/dev/null || true
-  done
-  popd >/dev/null || true
-}
-
 setup-ci() {
   local dokku_root="/root/go/src/github.com/dokku/dokku"
   pushd "$plugin_root" >/dev/null || true
@@ -34,7 +13,6 @@ setup-ci() {
 }
 
 main() {
-  install-go-mods
   install-go-devtools
   setup-ci
 }

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,6 +44,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # workaround for https://github.com/github/codeql/issues/14235
+      - name: Remove go.work file
+        run: rm go.work
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -65,10 +69,6 @@ jobs:
       # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
       #    and modify them (or add more) to build your code if your project
       #    uses a compiled language
-
-      # workaround for https://github.com/github/codeql/issues/14235
-      - name: Remove go.work file
-        run: rm go.work
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,9 +66,9 @@ jobs:
       #    and modify them (or add more) to build your code if your project
       #    uses a compiled language
 
-      # - run: |
-      #   make bootstrap
-      #   make release
+      # workaround for https://github.com/github/codeql/issues/14235
+      - name: Remove go.work file
+        run: rm go.work
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/common.mk
+++ b/common.mk
@@ -21,7 +21,7 @@ build-in-docker: clean
 		-e GO111MODULE=on \
 		-w $(GO_REPO_ROOT)/plugins/$(PLUGIN_NAME) \
 		$(BUILD_IMAGE) \
-		bash -c "GO_ARGS='$(GO_ARGS)' CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) make -j4 $(GO_PLUGIN_MAKE_TARGET)" || exit $$?
+		bash -c "GO_ARGS='$(GO_ARGS)' CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) GOWORK=off make -j4 $(GO_PLUGIN_MAKE_TARGET)" || exit $$?
 
 clean:
 	rm -rf $(BUILD)

--- a/go.work
+++ b/go.work
@@ -1,0 +1,24 @@
+go 1.21.3
+
+use (
+	./plugins/app-json
+	./plugins/apps
+	./plugins/builder
+	./plugins/buildpacks
+	./plugins/common
+	./plugins/config
+	./plugins/cron
+	./plugins/docker-options
+	./plugins/logs
+	./plugins/network
+	./plugins/nginx-vhosts
+	./plugins/ports
+	./plugins/proxy
+	./plugins/ps
+	./plugins/registry
+	./plugins/repo
+	./plugins/resource
+	./plugins/scheduler
+	./plugins/scheduler-docker-local
+	./plugins/scheduler-k3s
+)

--- a/go.work
+++ b/go.work
@@ -20,5 +20,4 @@ use (
 	./plugins/resource
 	./plugins/scheduler
 	./plugins/scheduler-docker-local
-	./plugins/scheduler-k3s
 )

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21.3
+go 1.21
 
 use (
 	./plugins/app-json


### PR DESCRIPTION
This makes it so we don't have to fake download dependencies for development, allowing for a better experience in your local editor.