### PR TITLE
Add support for global-only environment properties

### DIFF
--- a/plugins/common/properties.go
+++ b/plugins/common/properties.go
@@ -25,6 +25,12 @@ func CommandPropertySet(pluginName, appName, property, value string, properties 
 		LogFail("No property specified")
 	}
 
+	for k := range globalProperties {
+		if _, ok := properties[k]; !ok {
+			properties[k] = ""
+		}
+	}
+
 	if _, ok := properties[property]; !ok {
 		properties := reflect.ValueOf(properties).MapKeys()
 		validPropertyList := make([]string, len(properties))


### PR DESCRIPTION
If a property is only specified globally, it would otherwise be caught later in the check for valid properties.