### PR TITLE
Allow generating an ssh deploy key via the git plugin

### DIFF
--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -50,7 +50,6 @@ The following plugins are available and provided by Dokku maintainers.  Please f
 | [Scheduler Kubernetes](https://github.com/dokku/dokku-scheduler-kubernetes)                       | [dokku][]             | 0.4.0+                |
 | [Scheduler Nomad](https://github.com/dokku/dokku-scheduler-nomad)                                 | [dokku][]             | 0.4.0+                |
 | [Solr](https://github.com/dokku/dokku-solr)                                                       | [dokku][]             | 0.4.0+                |
-| [SSH Deployment Keys](https://github.com/cedricziel/dokku-deployment-keys)                        | [dokku][]             | 0.4.0+                |
 | [SSH Hostkeys](https://github.com/cedricziel/dokku-hostkeys-plugin)                               | [dokku][]             | 0.4.0+                 |
 | [Typesense](https://github.com/dokku/dokku-typesense)                                             | [dokku][]             | 0.4.0+                |
 
@@ -202,6 +201,7 @@ The following plugins have been removed as their functionality is now in Dokku C
 | [Process Manager: Supervisord](https://github.com/statianzo/dokku-supervisord)                    | [statianzo][]         | v0.3.14/0.7.0 (ps plugin)                 |
 | [Rebuild application](https://github.com/scottatron/dokku-rebuild)                                | [scottatron][]        | v0.3.14 (ps plugin)                       |
 | [Reset mtime](https://github.com/mixxorz/dokku-docker-reset-mtime)                                | [mixxorz][]           | Docker 1.8+                               |
+| [SSH Deployment Keys](https://github.com/cedricziel/dokku-deployment-keys)                        | [dokku][]             | v0.33.0 (git plugin)                      |
 | [Supply env vars to buildpacks](https://github.com/cameron-martin/dokku-build-env)<sup>2</sup>    | [cameron-martin][]    | v0.3.9 (build-env plugin)                 |
 | [Slack Notifications](https://github.com/ribot/dokku-slack)                                       | [ribot][]             | v0.5.0 (deployment tasks)                 |
 | [Telegram Notifications](https://github.com/m0rth1um/dokku-telegram)                              | [m0rth1um][]          | v0.5.0 (deployment tasks)                 |

--- a/docs/deployment/methods/git.md
+++ b/docs/deployment/methods/git.md
@@ -8,6 +8,7 @@ git:allow-host <host>                             # Adds a host to known_hosts
 git:auth <host> [<username> <password>]           # Configures netrc authentication for a given git server
 git:from-archive [--archive-type ARCHIVE_TYPE] <app> <archive-url> [<git-username> <git-email>] # Updates an app's git repository with a given archive file
 git:from-image [--build-dir DIRECTORY] <app> <docker-image> [<git-username> <git-email>] # Updates an app's git repository with a given docker image
+git:generate-deploy-key                           # Generates a deploy ssh key
 git:load-image [--build-dir DIRECTORY] <app> <docker-image> [<git-username> <git-email>] # Updates an app's git repository with a docker image loaded from stdin
 git:sync [--build] <app> <repository> [<git-ref>] # Clone or fetch an app from remote git repo
 git:initialize <app>                              # Initialize a git repository for an app
@@ -189,9 +190,40 @@ dokku git:allow-host github.com
 
 Note that this command is currently not idempotent and may add duplicate entries to the `~dokku/.ssh/known_hosts` file.
 
+### Creating a cloning ssh key pair
+
+> [!IMPORTANT]
+> New as of 0.33.0
+
+While most repositories can be authenticated to via the `git:auth` command, some users may prefer to use an ssh key. This can be generated via the `git:generate-deploy-key` command, which generates a passwordless ed25519 key-pair.
+
+```shell
+dokku git:generate-deploy-key
+```
+
+```
+Generating public/private ed25519 key pair.
+Your identification has been saved in /home/dokku/.ssh/id_ed25519
+Your public key has been saved in /home/dokku/.ssh/id_ed25519.pub
+The key fingerprint is:
+SHA256:PvlvVfbpYvkmA87rTfLUq07e3GarRN1BcLqDSjod+p8 dokku@ubuntu
+The key's randomart image is:
++--[ED25519 256]--+
+|             ..o |
+|              +  |
+|             . . |
+|            . o =|
+|        So . + ++|
+|       .=.o.. +..|
+|       ++oo..*o. |
+|        oo o%*oo=|
+|         .+E=BOOo|
++----[SHA256]-----+
+```
+
 ### Verifying the cloning public key
 
-In order to clone a remote repository, the remote server should have the Dokku host's public key configured. This plugin does not currently create this key, but if there is one available, it can be shown via the `git:public-key` command.
+In order to clone a remote repository, the remote server should have the Dokku host's public key configured. This plugin does not currently create this key, but if can be shown via the `git:public-key` command.
 
 ```shell
 dokku git:public-key

--- a/plugins/git/help-functions
+++ b/plugins/git/help-functions
@@ -34,6 +34,7 @@ fn-help-content() {
     git:load-image <app> <docker-image> [<git-username> <git-email>], Updates an app's git repository with a docker image loaded from stdin
     git:sync [--build] <app> <repository> [<git-ref>], Clone or fetch an app from remote git repo
     git:initialize <app>, Initialize a git repository for an app
+    git:generate-deploy-key, Generates a deploy ssh key
     git:public-key, Outputs the dokku public deploy key
     git:report [<app>] [<flag>], Displays a git report for one or more apps
     git:set <app> <property> (<value>), Set or clear a git property for an app

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -56,6 +56,19 @@ cmd-git-from-archive() {
   plugn trigger deploy-source-set "$APP" "$ARCHIVE_TYPE" "$ARCHIVE_URL"
 }
 
+cmd-git-generate-deploy-key() {
+  declare desc="generates a deploy ssh key"
+  local cmd="git:generate-deploy-key"
+  [[ "$1" == "$cmd" ]] && shift 1
+
+  if [[ -f "$DOKKU_ROOT/.ssh/id_ed25519.pub" ]] || [[ -f "$DOKKU_ROOT/.ssh/id_rsa.pub" ]]; then
+    dokku_log_exclaim_quiet "A deploy key already exists for this host"
+    return
+  fi
+
+  ssh-keygen -t ed25519 -C "dokku@$(hostname)" -N "" -f "$DOKKU_ROOT/.ssh/id_ed25519"
+}
+
 cmd-git-auth() {
   declare desc="configures netrc authentication for a given git server"
   local cmd="git:auth"
@@ -349,8 +362,8 @@ cmd-git-status() {
 
 fn-git-auth-error() {
   dokku_log_warn "There is no deploy key associated with the $DOKKU_SYSTEM_USER user."
-  dokku_log_warn "Generate an ssh key with the following command (do not specify a password):"
-  dokku_log_warn "  ssh-keygen -t ed25519 -C 'example@example.com'"
+  dokku_log_warn "Generate an ssh key with the following command:"
+  dokku_log_warn "  dokku git:generate-deploy-key"
   dokku_log_fail "As an alternative, configure the netrc authentication via the git:auth command"
 }
 

--- a/plugins/git/subcommands/generate-deploy-key
+++ b/plugins/git/subcommands/generate-deploy-key
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/git/internal-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-git-generate-deploy-key "$@"


### PR DESCRIPTION
While this might not seem super intuitive, the key is mostly related to git management, not the ssh-keys we currently use to add/remove access to push to dokku.