### PR TITLE
Guard against missing healthcheck config

### DIFF
--- a/plugins/scheduler-k3s/functions.go
+++ b/plugins/scheduler-k3s/functions.go
@@ -115,7 +115,7 @@ type WaitForPodToExistInput struct {
 	LabelSelector string
 }
 
-func applyClusterIssuers(ctx context.Context, appName string) error {
+func applyClusterIssuers(ctx context.Context) error {
 	chartDir, err := os.MkdirTemp("", "cluster-issuer-chart-")
 	if err != nil {
 		return fmt.Errorf("Error creating cluster-issuer chart directory: %w", err)
@@ -126,7 +126,7 @@ func applyClusterIssuers(ctx context.Context, appName string) error {
 	chart := &Chart{
 		ApiVersion: "v2",
 		AppVersion: "1.0.0",
-		Name:       appName,
+		Name:       "cluster-issuers",
 		Version:    "0.0.1",
 	}
 

--- a/plugins/scheduler-k3s/templates/chart/deployment.yaml
+++ b/plugins/scheduler-k3s/templates/chart/deployment.yaml
@@ -82,9 +82,17 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
-        {{- if $config.healthchecks.startup }}
+        {{- if and $config.healthchecks $config.healthchecks.startup }}
         startupProbe:
           {{ $config.healthchecks.startup | toJson | indent 10 }}
+        {{- end }}
+        {{- if and $config.healthchecks $config.healthchecks.liveness }}
+        livenessProbe:
+          {{ $config.healthchecks.liveness | toJson | indent 10 }}
+        {{- end }}
+        {{- if and $config.healthchecks $config.healthchecks.readiness }}
+        readinessProbe:
+          {{ $config.healthchecks.readiness | toJson | indent 10 }}
         {{- end }}
         {{- if $.Values.global.image.working_dir }}
         workingDir: {{ $.Values.global.image.working_dir }}

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -222,7 +222,7 @@ func TriggerSchedulerDeploy(scheduler string, appName string, imageTag string) e
 		return fmt.Errorf("Error loading environment for deployment: %w", err)
 	}
 
-	err = applyClusterIssuers(ctx, appName)
+	err = applyClusterIssuers(ctx)
 	if err != nil {
 		return fmt.Errorf("Error applying cluster issuers: %w", err)
 	}


### PR DESCRIPTION
Also add support for liveness and readiness probes.

Finally, actually fix the cluster-issuers chart name.