### PR TITLE
Upgrade vector image to 0.35.x

### DIFF
--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -25,7 +25,7 @@ var (
 )
 
 // VectorImage contains the default vector image to run
-const VectorImage = "timberio/vector:0.31.X-debian"
+const VectorImage = "timberio/vector:0.35.X-debian"
 
 // VectorDefaultSink contains the default sink in use for vector log shipping
 const VectorDefaultSink = "blackhole://?print_interval_secs=1"


### PR DESCRIPTION
This is backwards compatible for Dokku's usage, so should be fine to ship.