### PR TITLE
Ensure all k3s traefik middleware resources are scoped to the process

### DIFF
--- a/plugins/scheduler-k3s/templates/chart/https-redirect-middleware.yaml
+++ b/plugins/scheduler-k3s/templates/chart/https-redirect-middleware.yaml
@@ -1,3 +1,6 @@
+{{- $processName := "PROCESS_NAME" }}
+{{- $config := .Values.processes.PROCESS_NAME }}
+{{- if $config.web.domains }}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
@@ -5,11 +8,13 @@ metadata:
   annotations:
     dokku.com/managed: "true"
   labels:
-    app.kubernetes.io/instance: {{ $.Values.global.app_name }}-redirect-to-https
+    app.kubernetes.io/instance: {{ $.Values.global.app_name }}-{{ $processName }}-redirect-to-https
+    app.kubernetes.io/name: {{ $processName }}
     app.kubernetes.io/part-of: {{ $.Values.global.app_name }}
-  name: {{ $.Values.global.app_name}}-redirect-to-https
+  name: {{ $.Values.global.app_name}}-{{ $processName }}-redirect-to-https
   namespace: {{ $.Values.global.namespace }}
 spec:
   redirectScheme:
     scheme: https
     permanent: true
+{{- end }}

--- a/plugins/scheduler-k3s/templates/chart/ingress-route.yaml
+++ b/plugins/scheduler-k3s/templates/chart/ingress-route.yaml
@@ -27,7 +27,7 @@ spec:
       match: Host(`{{ $domain }}`)
       {{- if and $config.web.tls.enabled (and (eq $port_map.scheme "http") $port_map.redirect_to_https) }}
       middlewares:
-        - name: {{ $.Values.global.app_name}}-redirect-to-https
+        - name: {{ $.Values.global.app_name}}-{{ $processName }}-redirect-to-https
           namespace: {{ $.Values.global.namespace }}
       {{- end }}
       services:


### PR DESCRIPTION
While we currently only create the middleware for the web process, scoping it by process will allow us to expand this in the future.