### PR TITLE
Allow specifying an ingress class via chart value

### DIFF
--- a/plugins/scheduler-k3s/template.go
+++ b/plugins/scheduler-k3s/template.go
@@ -36,7 +36,7 @@ type GlobalValues struct {
 	DeploymentID string            `yaml:"deploment_id"`
 	Image        GlobalImage       `yaml:"image"`
 	Namespace    string            `yaml:"namespace"`
-	PrimaryPort  int32             `yaml:"primary_port"`
+	Network      GlobalNetwork     `yaml:"network"`
 	Secrets      map[string]string `yaml:"secrets,omitempty"`
 }
 
@@ -45,6 +45,11 @@ type GlobalImage struct {
 	Name             string `yaml:"name"`
 	Type             string `yaml:"type"`
 	WorkingDir       string `yaml:"working_dir"`
+}
+
+type GlobalNetwork struct {
+	IngressClass string `yaml:"ingress_class"`
+	PrimaryPort  int32  `yaml:"primary_port"`
 }
 
 type ProcessValues struct {

--- a/plugins/scheduler-k3s/templates/chart/deployment.yaml
+++ b/plugins/scheduler-k3s/templates/chart/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         {{- if eq $processName "web" }}
         env:
         - name: PORT
-          value: "{{ $.Values.global.primary_port }}"
+          value: "{{ $.Values.global.network.primary_port }}"
         {{- end }}
         envFrom:
         - secretRef:

--- a/plugins/scheduler-k3s/templates/chart/https-redirect-middleware.yaml
+++ b/plugins/scheduler-k3s/templates/chart/https-redirect-middleware.yaml
@@ -1,6 +1,6 @@
 {{- $processName := "PROCESS_NAME" }}
 {{- $config := .Values.processes.PROCESS_NAME }}
-{{- if $config.web.domains }}
+{{- if and $config.web.domains (eq $.Values.global.network.ingress_class "traefik") }}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: Middleware

--- a/plugins/scheduler-k3s/templates/chart/ingress-route.yaml
+++ b/plugins/scheduler-k3s/templates/chart/ingress-route.yaml
@@ -1,6 +1,6 @@
 {{- $processName := "PROCESS_NAME" }}
 {{- $config := .Values.processes.PROCESS_NAME }}
-{{- if $config.web.domains }}
+{{- if and $config.web.domains (eq $.Values.global.network.ingress_class "traefik") }}
 {{- range $pdx, $port_map := $config.web.port_maps }}
 ---
 apiVersion: traefik.io/v1alpha1

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -339,9 +339,12 @@ func TriggerSchedulerDeploy(scheduler string, appName string, imageTag string) e
 				Type:             imageSourceType,
 				WorkingDir:       workingDir,
 			},
-			Namespace:   namespace,
-			PrimaryPort: primaryPort,
-			Secrets:     map[string]string{},
+			Namespace: namespace,
+			Network: GlobalNetwork{
+				IngressClass: "traefik",
+				PrimaryPort:  primaryPort,
+			},
+			Secrets: map[string]string{},
 		},
 		Processes: map[string]ProcessValues{},
 	}


### PR DESCRIPTION
While Dokku currently only supports traefik, providing this setting will allow swapping out the ingress to another fairly easily.