### PR TITLE
Manage vector container via compose

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -2950,3 +2950,18 @@ main() {
 
 main "$@"
 ```
+
+### `vector-template-source`
+
+- Description: Retrieves an alternative template for the vector compose config
+- Invoked by: caddy-vhosts
+- Arguments:
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+# TODO
+```

--- a/plugins/common/docker.go
+++ b/plugins/common/docker.go
@@ -33,6 +33,18 @@ func ContainerStart(containerID string) bool {
 	return true
 }
 
+// ContainerRemove runs 'docker container remove' against an existing container
+func ContainerRemove(containerID string) bool {
+	cmd := sh.Command(DockerBin(), "container", "remove", "-f", containerID)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+
+	return true
+}
+
 // ContainerExists checks to see if a container exists
 func ContainerExists(containerID string) bool {
 	cmd := sh.Command(DockerBin(), "container", "inspect", containerID)
@@ -257,6 +269,15 @@ func GetWorkingDir(appName string, image string) string {
 
 	workDir, _ := DockerInspect(image, "{{.Config.WorkingDir}}")
 	return workDir
+}
+
+func IsComposeInstalled() bool {
+	result, err := CallExecCommand(ExecCommandInput{
+		Command:       DockerBin(),
+		Args:          []string{"info", "--format", "{{range .ClientInfo.Plugins}}{{if eq .Name \"compose\"}}true{{end}}{{end}}')"},
+		CaptureOutput: true,
+	})
+	return err == nil && result.ExitCode == 0
 }
 
 // IsImageCnbBased returns true if app image is based on cnb

--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"embed"
 	"fmt"
 
 	"github.com/dokku/dokku/plugins/common"
@@ -29,6 +30,9 @@ const VectorImage = "timberio/vector:0.35.X-debian"
 
 // VectorDefaultSink contains the default sink in use for vector log shipping
 const VectorDefaultSink = "blackhole://?print_interval_secs=1"
+
+//go:embed templates/*
+var templates embed.FS
 
 // GetFailedLogs outputs failed deploy logs for a given app
 func GetFailedLogs(appName string) error {

--- a/plugins/logs/subcommands.go
+++ b/plugins/logs/subcommands.go
@@ -107,20 +107,9 @@ func CommandVectorStart(vectorImage string) error {
 		vectorImage = common.PropertyGetDefault("logs", "--global", "vector-image", VectorImage)
 	}
 
-	if common.ContainerExists(vectorContainerName) {
-		if common.ContainerIsRunning(vectorContainerName) {
-			common.LogVerbose("Vector container is running")
-			return nil
-		}
-
-		common.LogVerbose("Starting vector container")
-		if !common.ContainerStart(vectorContainerName) {
-			return errors.New("Unable to start vector container")
-		}
-	} else {
-		if err := startVectorContainer(vectorImage); err != nil {
-			return err
-		}
+	common.LogVerbose("Starting vector container")
+	if err := startVectorContainer(vectorImage); err != nil {
+		return err
 	}
 
 	common.LogVerbose("Waiting for 10 seconds")
@@ -134,6 +123,6 @@ func CommandVectorStart(vectorImage string) error {
 
 // CommandVectorStop stops and removes an existing vector container
 func CommandVectorStop() error {
-	common.LogInfo2Quiet("Stopping and removing vector container")
-	return killVectorContainer()
+	common.LogInfo2Quiet("Stopping and removing vector container")
+	return stopVectorContainer()
 }

--- a/plugins/logs/templates/compose.yml.tmpl
+++ b/plugins/logs/templates/compose.yml.tmpl
@@ -1,0 +1,25 @@
+---
+version: "3.7"
+
+services:
+  vector:
+    image: "{{ $.VectorImage }}"
+
+    command:
+      - "--config"
+      - "/etc/vector/vector.json"
+      - "--watch-config"
+
+    labels:
+      dokku: ""
+      org.label-schema.schema-version: "1.0"
+      org.label-schema.vendor: dokku
+
+    network_mode: bridge
+
+    restart: unless-stopped
+
+    volumes:
+      - "{{ $.DokkuLibRoot }}/data/logs:/etc/vector"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "{{ $.DokkuLogsDir }}/apps:/var/log/dokku/apps"

--- a/tests/unit/logs.bats
+++ b/tests/unit/logs.bats
@@ -553,7 +553,7 @@ teardown() {
   assert_success
   assert_output_contains "Vector container is running"
 
-  run /bin/bash -c "sudo docker inspect --format='{{.HostConfig.RestartPolicy.Name}}' vector"
+  run /bin/bash -c "sudo docker inspect --format='{{.HostConfig.RestartPolicy.Name}}' vector-vector-1"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -586,7 +586,7 @@ teardown() {
   assert_output_contains "vector:" 5
   assert_line_count 6
 
-  run /bin/bash -c "docker stop vector"
+  run /bin/bash -c "docker stop vector-vector-1"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -602,5 +602,5 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains "Stopping and removing vector container"
+  assert_output_contains "Stopping and removing vector container"
 }


### PR DESCRIPTION
Using compose instead of manual docker calls allows folks to customize the vector container by using a custom compose.yml template file. This opens us up to more customizations while aligning container management with how we do other external containers (such as for the proxy plugins).

Refs #5784