### PR TITLE
Add the dokku logo as the chart icon

### DIFF
--- a/plugins/scheduler-k3s/functions.go
+++ b/plugins/scheduler-k3s/functions.go
@@ -126,6 +126,7 @@ func applyClusterIssuers(ctx context.Context) error {
 	chart := &Chart{
 		ApiVersion: "v2",
 		AppVersion: "1.0.0",
+		Icon:       "https://dokku.com/assets/dokku-logo.svg",
 		Name:       "cluster-issuers",
 		Version:    "0.0.1",
 	}

--- a/plugins/scheduler-k3s/template.go
+++ b/plugins/scheduler-k3s/template.go
@@ -20,6 +20,7 @@ type Chart struct {
 	AppVersion string `yaml:"appVersion"`
 	Name       string `yaml:"name"`
 	Version    string `yaml:"version"`
+	Icon       string `yaml:"icon"`
 }
 
 type ClusterIssuerValues struct {

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -318,6 +318,7 @@ func TriggerSchedulerDeploy(scheduler string, appName string, imageTag string) e
 		ApiVersion: "v2",
 		AppVersion: "1.0.0",
 		Name:       appName,
+		Icon:       "https://dokku.com/assets/dokku-logo.svg",
 		Version:    fmt.Sprintf("0.0.%d", deploymentId),
 	}
 


### PR DESCRIPTION
Note for anyone asking: The logo may _only_ be used to represent charts managed by Dokku.