### PR TITLE
Index the process map to ensure the correct config is pulled

### DIFF
--- a/plugins/scheduler-k3s/templates/chart/certificate.yaml
+++ b/plugins/scheduler-k3s/templates/chart/certificate.yaml
@@ -1,5 +1,5 @@
 {{- $processName := "PROCESS_NAME" }}
-{{- $config := .Values.processes.PROCESS_NAME }}
+{{- $config := index .Values.processes "PROCESS_NAME" }}
 {{- if and $config.web.tls.enabled $config.web.domains }}
 ---
 apiVersion: cert-manager.io/v1

--- a/plugins/scheduler-k3s/templates/chart/cron-job.yaml
+++ b/plugins/scheduler-k3s/templates/chart/cron-job.yaml
@@ -1,5 +1,5 @@
 {{- $processName := "CRON_ID" }}
-{{- $config := .Values.processes.CRON_ID }}
+{{- $config := index .Values.processes "CRON_ID" }}
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/plugins/scheduler-k3s/templates/chart/deployment.yaml
+++ b/plugins/scheduler-k3s/templates/chart/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $processName := "PROCESS_NAME" }}
-{{- $config := .Values.processes.PROCESS_NAME }}
+{{- $config := index .Values.processes "PROCESS_NAME" }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/plugins/scheduler-k3s/templates/chart/https-redirect-middleware.yaml
+++ b/plugins/scheduler-k3s/templates/chart/https-redirect-middleware.yaml
@@ -1,5 +1,5 @@
 {{- $processName := "PROCESS_NAME" }}
-{{- $config := .Values.processes.PROCESS_NAME }}
+{{- $config := index .Values.processes "PROCESS_NAME" }}
 {{- if and $config.web.domains (eq $.Values.global.network.ingress_class "traefik") }}
 ---
 apiVersion: traefik.io/v1alpha1

--- a/plugins/scheduler-k3s/templates/chart/ingress-route.yaml
+++ b/plugins/scheduler-k3s/templates/chart/ingress-route.yaml
@@ -1,5 +1,5 @@
 {{- $processName := "PROCESS_NAME" }}
-{{- $config := .Values.processes.PROCESS_NAME }}
+{{- $config := index .Values.processes "PROCESS_NAME" }}
 {{- if and $config.web.domains (eq $.Values.global.network.ingress_class "traefik") }}
 {{- range $pdx, $port_map := $config.web.port_maps }}
 ---

--- a/plugins/scheduler-k3s/templates/chart/service.yaml
+++ b/plugins/scheduler-k3s/templates/chart/service.yaml
@@ -1,5 +1,5 @@
 {{- $processName := "PROCESS_NAME" }}
-{{- $config := .Values.processes.PROCESS_NAME }}
+{{- $config := index .Values.processes "PROCESS_NAME" }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Without this change, certain generated process names - like those for a cron job - may be incorrectly handled when indexing the process map.