### PR TITLE
Add support for specifying annotations on kubernetes resources

### DIFF
--- a/docs/deployment/schedulers/k3s.md
+++ b/docs/deployment/schedulers/k3s.md
@@ -4,6 +4,7 @@
 > New as of 0.33.0
 
 ```
+scheduler-k3s:annotations:set <app|--global> <property> (<value>) [--process-type PROCESS_TYPE] <--resource-type RESOURCE_TYPE>, Set or clear an annotation for a given app/process-type/resource-type combination
 scheduler-k3s:cluster-add [ssh://user@host:port]    # Adds a server node to a Dokku-managed cluster
 scheduler-k3s:cluster-list                          # Lists all nodes in a Dokku-managed cluster
 scheduler-k3s:cluster-remove [node-id]              # Removes client node to a Dokku-managed cluster
@@ -261,6 +262,44 @@ The default value may be set by passing an empty value for the option.
 ```shell
 dokku scheduler-k3s:set --global letsencrypt-server staging
 ```
+
+### Customizing Resource Annotations
+
+Dokku injects certain resources into each created resource by default, but it may be necessary to inject others for tighter integration with third-party tools. The `scheduler-k3s:annotations:set` command can be used to perform this task. The command takes an app name and a required `--resource-type` flag.
+
+```shell
+dokku scheduler-k3s:annotations:set node-js-app annotation.key annotation.value --resource-type deployment
+```
+
+If not specified, the annotation will be applied to all processes within an app, though it may be further scoped to a specific process type via the `--process-type` flag. 
+
+> [!NOTE]
+> The cron ID is used as the process type if your app deploys any cron tasks
+
+```shell
+dokku scheduler-k3s:annotations:set node-js-app annotation.key annotation.value --resource-type deployment --process-type web
+```
+
+To unset an annotation, pass an empty value:
+
+```shell
+dokku scheduler-k3s:annotations:set node-js-app annotation.key --resource-type deployment
+dokku scheduler-k3s:annotations:set node-js-app annotation.key --resource-type deployment --process-type web
+```
+
+The following resource types are supported:
+
+- `certificate`
+- `cronjob`
+- `deployment`
+- `ingress`
+- `job`
+- `pod`
+- `secret`
+- `service`
+- `serviceaccount`
+- `traefik_ingressroute`
+- `traefik_middleware`
 
 ### Using kubectl remotely
 

--- a/plugins/scheduler-k3s/functions.go
+++ b/plugins/scheduler-k3s/functions.go
@@ -363,6 +363,103 @@ func extractStartCommand(input StartCommandInput) string {
 	return command
 }
 
+// getAnnotations retrieves annotations for a given app and process type
+func getAnnotations(appName string, processType string) (ProcessAnnotations, error) {
+	annotations := ProcessAnnotations{}
+	certificateAnnotations, err := getAnnotation(appName, processType, "certificate")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.CertificateAnnotations = certificateAnnotations
+
+	cronJobAnnotations, err := getAnnotation(appName, processType, "cronjob")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.CronJobAnnotations = cronJobAnnotations
+
+	deploymentAnnotations, err := getAnnotation(appName, processType, "deployment")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.DeploymentAnnotations = deploymentAnnotations
+
+	ingressAnnotations, err := getAnnotation(appName, processType, "ingress")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.IngressAnnotations = ingressAnnotations
+
+	jobAnnotations, err := getAnnotation(appName, processType, "job")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.JobAnnotations = jobAnnotations
+
+	podAnnotations, err := getAnnotation(appName, processType, "pod")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.PodAnnotations = podAnnotations
+
+	secretAnnotations, err := getAnnotation(appName, processType, "secret")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.SecretAnnotations = secretAnnotations
+
+	serviceAnnotations, err := getAnnotation(appName, processType, "service")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.ServiceAnnotations = serviceAnnotations
+
+	serviceAccountAnnotations, err := getAnnotation(appName, processType, "serviceaccount")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.ServiceAccountAnnotations = serviceAccountAnnotations
+
+	traefikIngressRouteAnnotations, err := getAnnotation(appName, processType, "traefik_ingressroute")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.TraefikIngressRouteAnnotations = traefikIngressRouteAnnotations
+
+	traefikMiddlewareAnnotations, err := getAnnotation(appName, processType, "traefik_middleware")
+	if err != nil {
+		return annotations, err
+	}
+	annotations.TraefikMiddlewareAnnotations = traefikMiddlewareAnnotations
+
+	return annotations, nil
+}
+
+// getGlobalAnnotations retrieves global annotations for a given app
+func getGlobalAnnotations(appName string) (ProcessAnnotations, error) {
+	return getAnnotations(appName, GlobalProcessType)
+}
+
+// getAnnotation retrieves an annotation for a given app, process type, and resource type
+func getAnnotation(appName string, processType string, resourceType string) (map[string]string, error) {
+	annotations := map[string]string{}
+	annotationsList, err := common.PropertyListGet("scheduler-k3s", appName, fmt.Sprintf("%s.%s", processType, resourceType))
+	if err != nil {
+		return annotations, err
+	}
+
+	for _, annotation := range annotationsList {
+		parts := strings.SplitN(annotation, ": ", 2)
+		if len(parts) != 2 {
+			return annotations, fmt.Errorf("Invalid annotation format: %s", annotation)
+		}
+
+		annotations[parts[0]] = parts[1]
+	}
+
+	return annotations, nil
+}
+
 func getDeployTimeout(appName string) string {
 	return common.PropertyGetDefault("scheduler-k3s", appName, "deploy-timeout", "")
 }

--- a/plugins/scheduler-k3s/k8s.go
+++ b/plugins/scheduler-k3s/k8s.go
@@ -117,6 +117,9 @@ func (k KubernetesClient) ApplyKubernetesManifest(ctx context.Context, input App
 			"-f",
 			input.Manifest,
 		},
+		Env: map[string]string{
+			"KUBECONFIG": KubeConfigPath,
+		},
 		StreamStdio: true,
 	})
 	if err != nil {

--- a/plugins/scheduler-k3s/scheduler_k3s.go
+++ b/plugins/scheduler-k3s/scheduler_k3s.go
@@ -42,6 +42,8 @@ const KubeConfigPath = "/etc/rancher/k3s/k3s.yaml"
 
 const RegistryConfigPath = "/etc/rancher/k3s/registries.yaml"
 
+const GlobalProcessType = "--global"
+
 var (
 	runtimeScheme  = runtime.NewScheme()
 	codecs         = serializer.NewCodecFactory(runtimeScheme)

--- a/plugins/scheduler-k3s/templates/chart/certificate.yaml
+++ b/plugins/scheduler-k3s/templates/chart/certificate.yaml
@@ -7,6 +7,16 @@ kind: Certificate
 metadata:
   annotations:
     dokku.com/managed: "true"
+    {{- if and $.Values.global.annotations $.Values.global.annotations.certificate }}
+    {{- range $k, $v := $.Values.global.annotations.certificate }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if and $config.annotations $config.annotations.certificate }}
+    {{- range $k, $v := $config.annotations.certificate }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ $.Values.global.app_name }}-{{ $processName }}
     app.kubernetes.io/part-of: {{ $.Values.global.app_name }}

--- a/plugins/scheduler-k3s/templates/chart/cron-job.yaml
+++ b/plugins/scheduler-k3s/templates/chart/cron-job.yaml
@@ -11,6 +11,16 @@ metadata:
     dokku.com/job-suffix: {{ $config.cron.suffix }}
     dokku.com/managed: "true"
     kubectl.kubernetes.io/default-container: {{ $.Values.global.app_name }}-cron
+    {{- if and $.Values.global.annotations $.Values.global.annotations.cronjob }}
+    {{- range $k, $v := $.Values.global.annotations.cronjob }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if and $config.annotations $config.annotations.cronjob }}
+    {{- range $k, $v := $config.annotations.cronjob }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     app.kubernetes.io/instance: {{ $.Values.global.app_name }}-cron-{{ $config.cron.suffix }}
     app.kubernetes.io/name: cron
@@ -30,6 +40,16 @@ spec:
         dokku.com/job-suffix: {{ $config.cron.suffix }}
         dokku.com/managed: "true"
         kubectl.kubernetes.io/default-container: {{ $.Values.global.app_name }}-cron
+        {{- if and $.Values.global.annotations $.Values.global.annotations.pod }}
+        {{- range $k, $v := $.Values.global.annotations.pod }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
+        {{- end }}
+        {{- if and $config.annotations $config.annotations.pod }}
+        {{- range $k, $v := $config.annotations.pod }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
+        {{- end }}
       labels:
         app.kubernetes.io/instance: {{ $.Values.global.app_name }}-cron-{{ $config.cron.suffix }}
         app.kubernetes.io/name: cron

--- a/plugins/scheduler-k3s/templates/chart/deployment.yaml
+++ b/plugins/scheduler-k3s/templates/chart/deployment.yaml
@@ -9,6 +9,16 @@ metadata:
     dokku.com/builder-type: {{ $.Values.global.image.type }}
     dokku.com/managed: "true"
     kubectl.kubernetes.io/default-container: {{ $.Values.global.app_name }}-{{ $processName }}
+    {{- if and $.Values.global.annotations $.Values.global.annotations.deployment }}
+    {{- range $k, $v := $.Values.global.annotations.deployment }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if and $config.annotations $config.annotations.deployment }}
+    {{- range $k, $v := $config.annotations.deployment }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     app.kubernetes.io/instance: {{ $.Values.global.app_name }}-{{ $processName }}
     app.kubernetes.io/name: {{ $processName }}
@@ -31,6 +41,16 @@ spec:
         dokku.com/builder-type: {{ $.Values.global.image.type }}
         dokku.com/managed: "true"
         kubectl.kubernetes.io/default-container: {{ $.Values.global.app_name }}-{{ $processName }}
+        {{- if and $.Values.global.annotations $.Values.global.annotations.pod }}
+        {{- range $k, $v := $.Values.global.annotations.pod }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
+        {{- end }}
+        {{- if and $config.annotations $config.annotations.pod }}
+        {{- range $k, $v := $config.annotations.pod }}
+        {{ $k }}: {{ $v | quote }}
+        {{- end }}
+        {{- end }}
       labels:
         app.kubernetes.io/instance: {{ $.Values.global.app_name }}-{{ $processName }}
         app.kubernetes.io/name: {{ $processName }}

--- a/plugins/scheduler-k3s/templates/chart/https-redirect-middleware.yaml
+++ b/plugins/scheduler-k3s/templates/chart/https-redirect-middleware.yaml
@@ -7,6 +7,16 @@ kind: Middleware
 metadata:
   annotations:
     dokku.com/managed: "true"
+    {{- if and $.Values.global.annotations $.Values.global.annotations.traefik_middleware }}
+    {{- range $k, $v := $.Values.global.annotations.traefik_middleware }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if and $config.annotations $config.annotations.traefik_middleware }}
+    {{- range $k, $v := $config.annotations.traefik_middleware }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     app.kubernetes.io/instance: {{ $.Values.global.app_name }}-{{ $processName }}-redirect-to-https
     app.kubernetes.io/name: {{ $processName }}

--- a/plugins/scheduler-k3s/templates/chart/ingress-route.yaml
+++ b/plugins/scheduler-k3s/templates/chart/ingress-route.yaml
@@ -8,6 +8,16 @@ kind: IngressRoute
 metadata:
   annotations:
     dokku.com/managed: "true"
+    {{- if and $.Values.global.annotations $.Values.global.annotations.traefik_ingressroute }}
+    {{- range $k, $v := $.Values.global.annotations.traefik_ingressroute }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if and $config.annotations $config.annotations.traefik_ingressroute }}
+    {{- range $k, $v := $config.annotations.traefik_ingressroute }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     app.kubernetes.io/instance: {{ $.Values.global.app_name }}-{{ $processName }}
     app.kubernetes.io/name: {{ $processName }}

--- a/plugins/scheduler-k3s/templates/chart/secret.yaml
+++ b/plugins/scheduler-k3s/templates/chart/secret.yaml
@@ -4,6 +4,11 @@ metadata:
   annotations:
     app.kubernetes.io/version: {{ $.Values.global.deploment_id | quote }}
     dokku.com/managed: "true"
+    {{- if and $.Values.global.annotations $.Values.global.annotations.secret }}
+    {{- range $k, $v := $.Values.global.annotations.secret }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     app.kubernetes.io/instance: env-{{ $.Values.global.app_name }}.{{ $.Values.global.deploment_id }}
     app.kubernetes.io/name: env-{{ $.Values.global.app_name }}

--- a/plugins/scheduler-k3s/templates/chart/service-account.yaml
+++ b/plugins/scheduler-k3s/templates/chart/service-account.yaml
@@ -1,6 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    dokku.com/managed: "true"
+    {{- if and $.Values.global.annotations $.Values.global.annotations.serviceaccount }}
+    {{- range $k, $v := $.Values.global.annotations.serviceaccount }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     app.kubernetes.io/instance: service-account
     app.kubernetes.io/name: service-account

--- a/plugins/scheduler-k3s/templates/chart/service.yaml
+++ b/plugins/scheduler-k3s/templates/chart/service.yaml
@@ -6,6 +6,16 @@ kind: Service
 metadata:
   annotations:
     dokku.com/managed: "true"
+    {{- if and $.Values.global.annotations $.Values.global.annotations.service }}
+    {{- range $k, $v := $.Values.global.annotations.service }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if and $config.annotations $config.annotations.service }}
+    {{- range $k, $v := $config.annotations.service }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     app.kubernetes.io/instance: {{ $.Values.global.app_name }}-{{ $processName }}
     app.kubernetes.io/name: {{ $processName }}

--- a/tests/unit/scheduler-k3s.bats
+++ b/tests/unit/scheduler-k3s.bats
@@ -27,7 +27,7 @@ install_k3s() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku registry:set --global image-repo-template 'savant/{{ .AppName }}'"
+  run /bin/bash -c "dokku registry:set --global image-repo-template '$DOCKERHUB_USERNAME/{{ .AppName }}'"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/scheduler-k3s.bats
+++ b/tests/unit/scheduler-k3s.bats
@@ -8,6 +8,7 @@ setup() {
   uninstall_k3s || true
   global_setup
   dokku nginx:stop
+  export KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
 }
 
 teardown_() {

--- a/tests/unit/scheduler-k3s.bats
+++ b/tests/unit/scheduler-k3s.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+TEST_APP="rdmtestapp"
+
+setup() {
+  uninstall_k3s || true
+  global_setup
+  dokku nginx:stop
+}
+
+teardown_() {
+  global_teardown
+  dokku nginx:start
+  uninstall_k3s || true
+}
+
+install_k3s() {
+  run /bin/bash -c "dokku proxy:set --global k3s"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku registry:set --global server hub.docker.com"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku registry:set --global image-repo-template 'savant/{{ .AppName }}'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku registry:set --global push-on-release true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler:set --global selected k3s"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku registry:login docker.io $DOCKERHUB_USERNAME $DOCKERHUB_TOKEN"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "Login Succeeded"
+
+  run /bin/bash -c "dokku scheduler-k3s:initialize"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
+uninstall_k3s() {
+  run /bin/bash -c "dokku scheduler-k3s:uninstall"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
+@test "(scheduler-k3s) install" {
+  if [[ -z "$DOCKERHUB_USERNAME" ]] || [[ -z "$DOCKERHUB_TOKEN" ]]; then
+    skip "skipping due to missing docker.io credentials DOCKERHUB_USERNAME:DOCKERHUB_TOKEN"
+  fi
+
+  install_k3s
+}
+
+@test "(scheduler-k3s) deploy" {
+  if [[ -z "$DOCKERHUB_USERNAME" ]] || [[ -z "$DOCKERHUB_TOKEN" ]]; then
+    skip "skipping due to missing docker.io credentials DOCKERHUB_USERNAME:DOCKERHUB_TOKEN"
+  fi
+
+  install_k3s
+
+  run /bin/bash -c "dokku apps:create $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:set $TEST_APP $TEST_APP.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:sync --build $TEST_APP https://github.com/dokku/smoke-test-app.git"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "sleep 20"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  assert_http_localhost_response "http" "$TEST_APP.dokku.me" "80" "" "python/http.server"
+}
+
+@test "(scheduler-k3s) deploy annotations" {
+  if [[ -z "$DOCKERHUB_USERNAME" ]] || [[ -z "$DOCKERHUB_TOKEN" ]]; then
+    skip "skipping due to missing docker.io credentials DOCKERHUB_USERNAME:DOCKERHUB_TOKEN"
+  fi
+
+  install_k3s
+
+  run /bin/bash -c "dokku apps:create $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:set $TEST_APP $TEST_APP.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-k3s:annotations:set $TEST_APP --resource-type secret test.dokku.com/resource-type secret"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-k3s:annotations:set $TEST_APP --resource-type pod test.dokku.com/resource-type pod"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-k3s:annotations:set $TEST_APP --resource-type deployment test.dokku.com/resource-type deployment"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-k3s:annotations:set $TEST_APP --process-type web --resource-type deployment test.dokku.com/resource-type deployment-web"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:sync --build $TEST_APP https://github.com/dokku/smoke-test-app.git"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "sleep 20"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  assert_http_localhost_response "http" "$TEST_APP.dokku.me" "80" "" "python/http.server"
+
+  run /bin/bash -c "kubectl get deployment $TEST_APP-web -o json | jq -r '.metadata.annotations.\"test.dokku.com/resource-type\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "deployment-web"
+
+  run /bin/bash -c "kubectl get deployment $TEST_APP-web -o json | jq -r '.spec.template.metadata.annotations.\"test.dokku.com/resource-type\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "pod"
+
+  run /bin/bash -c "kubectl get cronjob -o json | jq -r '.items[0].metadata.annotations.\"test.dokku.com/resource-type\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "null"
+
+  run /bin/bash -c "kubectl get cronjob -o json | jq -r '.items[0].spec.jobTemplate.metadata.annotations.\"test.dokku.com/resource-type\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "pod"
+
+  run /bin/bash -c "kubectl get secret -o json | jq -r '.items[0].metadata.annotations.\"test.dokku.com/resource-type\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "secret"
+}


### PR DESCRIPTION
As the command contains a colon, it must be handled in the commands binary as opposed to subcommands.

Also include a simple bats test.