### PR TITLE
fix: whitespace breaking `SIGIL_PARAMS` (NGINX)

### DIFF
--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -382,7 +382,7 @@ nginx_build_config() {
         PROXY_X_FORWARDED_SSL="$PROXY_X_FORWARDED_SSL")
 
       while read -r line || [[ -n "$line" ]]; do
-        PROC_TYPE=${line%%=*}
+        PROC_TYPE=$(echo "${line%%=*}" | xargs)
         LISTENERS="$(plugn trigger network-get-listeners "$APP" "$PROC_TYPE" | xargs)"
         UPP_PROC_TYPE="${PROC_TYPE^^}"
         UPP_PROC_TYPE="${UPP_PROC_TYPE//-/_}"


### PR DESCRIPTION
Opening a draft PR with fix for the issue as detailed in this Slack thread: https://gliderlabs.slack.com/archives/C0FP0R13J/p1707611187420929

This replicates the change I've made manually on the server experiencing the issue which resolved it.

The crux is this is what's currently produced:
```
'DOKKU_APP_RELEASE                                                                         _LISTENERS=' 
```

Instead of this:
```
'DOKKU_APP_RELEASE_LISTENERS=' 
```

Have no idea why I haven't experienced this before now as the code I've adjusted was written years ago!

Will open a proper issue tomorrow morning with details extracted from that thread and link this PR up to it 👍🏻 