### PR TITLE
fix: use new CallExecCommand when checking to see how help is being called

### DIFF
--- a/plugins/app-json/src/commands/commands.go
+++ b/plugins/app-json/src/commands/commands.go
@@ -32,11 +32,13 @@ func main() {
 	case "app-json", "app-json:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    app-json, Manage app-json settings for an app\n")

--- a/plugins/apps/src/commands/commands.go
+++ b/plugins/apps/src/commands/commands.go
@@ -49,11 +49,13 @@ func main() {
 	case "apps:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    apps, Manage apps\n")

--- a/plugins/builder/src/commands/commands.go
+++ b/plugins/builder/src/commands/commands.go
@@ -32,11 +32,13 @@ func main() {
 	case "builder", "builder:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    builder, Manage builder settings for an app\n")

--- a/plugins/buildpacks/src/commands/commands.go
+++ b/plugins/buildpacks/src/commands/commands.go
@@ -37,11 +37,13 @@ func main() {
 	case "buildpacks", "buildpacks:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    buildpacks, Manage buildpack settings for an app\n")

--- a/plugins/config/src/commands/commands.go
+++ b/plugins/config/src/commands/commands.go
@@ -53,11 +53,13 @@ func main() {
 	case "config:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    config, Manage global and app-specific config vars\n")

--- a/plugins/cron/src/commands/commands.go
+++ b/plugins/cron/src/commands/commands.go
@@ -33,11 +33,13 @@ func main() {
 	case "cron", "cron:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    cron, Manage scheduled cron tasks\n")

--- a/plugins/logs/src/commands/commands.go
+++ b/plugins/logs/src/commands/commands.go
@@ -59,11 +59,13 @@ func main() {
 	case "logs:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    logs, Manage log integration for an app\n")

--- a/plugins/network/src/commands/commands.go
+++ b/plugins/network/src/commands/commands.go
@@ -39,11 +39,13 @@ func main() {
 	case "network", "network:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    network, Manage network settings for an app\n")

--- a/plugins/ports/src/commands/commands.go
+++ b/plugins/ports/src/commands/commands.go
@@ -36,11 +36,13 @@ func main() {
 	case "ports", "ports:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    ports, Manage ports for an app\n")

--- a/plugins/proxy/src/commands/commands.go
+++ b/plugins/proxy/src/commands/commands.go
@@ -18,8 +18,8 @@ Manage the proxy integration for an app
 Additional commands:`
 
 	helpContent = `
-	proxy:build-config [--parallel count] [--all|<app>], (Re)builds config for a given app
-	proxy:clear-config [--all|<app>], Clears config for a given app
+    proxy:build-config [--parallel count] [--all|<app>], (Re)builds config for a given app
+    proxy:clear-config [--all|<app>], Clears config for a given app
     proxy:disable <app>, Disable proxy for app
     proxy:enable <app>, Enable proxy for app
     proxy:report [<app>] [<flag>], Displays a proxy report for one or more apps
@@ -36,11 +36,13 @@ func main() {
 	case "proxy", "proxy:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    proxy, Manage the proxy integration for an app\n")

--- a/plugins/ps/src/commands/commands.go
+++ b/plugins/ps/src/commands/commands.go
@@ -39,11 +39,13 @@ func main() {
 	case "ps", "ps:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    ps, Manage app processes\n")

--- a/plugins/registry/src/commands/commands.go
+++ b/plugins/registry/src/commands/commands.go
@@ -33,11 +33,13 @@ func main() {
 	case "registry", "registry:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    registry, Manage registry settings for an app\n")

--- a/plugins/repo/src/commands/commands.go
+++ b/plugins/repo/src/commands/commands.go
@@ -32,11 +32,13 @@ func main() {
 	case "repo", "repo:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    repo, Manage the app's repo\n")

--- a/plugins/resource/src/commands/commands.go
+++ b/plugins/resource/src/commands/commands.go
@@ -35,11 +35,13 @@ func main() {
 	case "resource", "resource:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    resource, Manage resource settings for an app\n")

--- a/plugins/scheduler-k3s/src/commands/commands.go
+++ b/plugins/scheduler-k3s/src/commands/commands.go
@@ -42,11 +42,13 @@ func main() {
 	case "scheduler-k3s", "scheduler-k3s:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    scheduler-k3s, Manage scheduler-k3s settings for an app\n")

--- a/plugins/scheduler/src/commands/commands.go
+++ b/plugins/scheduler/src/commands/commands.go
@@ -32,11 +32,13 @@ func main() {
 	case "scheduler", "scheduler:help":
 		usage()
 	case "help":
-		command := common.NewShellCmd(fmt.Sprintf("ps -o command= %d", os.Getppid()))
-		command.ShowOutput = false
-		output, err := command.Output()
-
-		if err == nil && strings.Contains(string(output), "--all") {
+		result, err := common.CallExecCommand(common.ExecCommandInput{
+			Command:       "ps",
+			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)
 		} else {
 			fmt.Print("\n    scheduler, Manage scheduler settings for an app\n")


### PR DESCRIPTION
This is part of ongoing work to remove usage of the deprecated NewShellCmd.