### PR TITLE
Remove all direct usage of go-sh outside of plugin trigger setup

### DIFF
--- a/plugins/logs/go.mod
+++ b/plugins/logs/go.mod
@@ -3,7 +3,6 @@ module github.com/dokku/dokku/plugins/logs
 go 1.21
 
 require (
-	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27
 	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/dokku/dokku/plugins/docker-options v0.0.0-00010101000000-000000000000
 	github.com/joncalhoun/qson v0.0.0-20200422171543-84433dcd3da0
@@ -13,6 +12,7 @@ require (
 require (
 	github.com/alexellis/go-execute/v2 v2.2.1 // indirect
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
+	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/plugins/logs/triggers.go
+++ b/plugins/logs/triggers.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/dokku/dokku/plugins/common"
 	dockeroptions "github.com/dokku/dokku/plugins/docker-options"
-
-	sh "github.com/codeskyblue/go-sh"
 )
 
 // TriggerDockerArgsProcessDeploy outputs the logs plugin docker options for an app
@@ -47,9 +45,14 @@ func TriggerDockerArgsProcessDeploy(appName string) error {
 	}
 
 	if !hasDriverOpt {
-		b, _ := sh.Command(common.DockerBin(), "system", "info", "--format", "{{ .LoggingDriver }}").Output()
-		output := strings.TrimSpace(string(b[:]))
-		if !allowedDrivers[output] {
+		result, _ := common.CallExecCommand(common.ExecCommandInput{
+			Command:       common.DockerBin(),
+			Args:          []string{"system", "info", "--format", "{{ .LoggingDriver }}"},
+			CaptureOutput: true,
+			StreamStdio:   false,
+		})
+
+		if !allowedDrivers[result.StdoutContents()] {
 			ignoreMaxSize = true
 		}
 	}

--- a/plugins/network/functions.go
+++ b/plugins/network/functions.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
-
-	sh "github.com/codeskyblue/go-sh"
 )
 
 // attachAppToNetwork attaches a container to a network
@@ -60,20 +58,23 @@ func attachAppToNetwork(containerID string, networkName string, appName string, 
 
 // isContainerInNetwork returns true if the container is already attached to the specified network
 func isContainerInNetwork(containerID string, networkName string) bool {
-	b, err := sh.Command(
-		common.DockerBin(),
-		"container",
-		"inspect",
-		"--format",
-		"{{range $net, $v := .NetworkSettings.Networks}}{{println $net}}{{end}}",
-		containerID,
-	).Output()
+	result, err := common.CallExecCommand(common.ExecCommandInput{
+		Command:       common.DockerBin(),
+		Args:          []string{"container", "inspect", "--format", "{{range $net, $v := .NetworkSettings.Networks}}{{println $net}}{{end}}", containerID},
+		CaptureOutput: true,
+		StreamStdio:   false,
+	})
+
 	if err != nil {
-		common.LogVerboseQuiet(fmt.Sprintf("Error checking container networking status:%v", err.Error()))
+		common.LogVerboseQuiet(fmt.Sprintf("Error checking container networking status: %v", err.Error()))
+		return false
+	}
+	if result.ExitCode != 0 {
+		common.LogVerboseQuiet(fmt.Sprintf("Error checking container networking status: %v", result.StderrContents()))
 		return false
 	}
 
-	for _, line := range strings.Split(strings.TrimSpace(string(b[:])), "\n") {
+	for _, line := range strings.Split(result.StdoutContents(), "\n") {
 		network := strings.TrimSpace(line)
 		if network == "" {
 			continue
@@ -128,15 +129,21 @@ func networkExists(networkName string) (bool, error) {
 
 // listNetworks returns a list of docker networks
 func listNetworks() ([]string, error) {
-	b, err := sh.Command(common.DockerBin(), "network", "ls", "--format", "{{ .Name }}").Output()
-	output := strings.TrimSpace(string(b[:]))
-
-	networks := []string{}
+	result, err := common.CallExecCommand(common.ExecCommandInput{
+		Command:       common.DockerBin(),
+		Args:          []string{"network", "ls", "--format", "{{ .Name }}"},
+		CaptureOutput: true,
+		StreamStdio:   false,
+	})
 	if err != nil {
-		common.LogVerboseQuiet(output)
-		return networks, err
+		common.LogVerboseQuiet(result.StderrContents())
+		return []string{}, err
+	}
+	if result.ExitCode != 0 {
+		common.LogVerboseQuiet(result.StderrContents())
+		return []string{}, fmt.Errorf("Unable to list networks")
 	}
 
-	networks = strings.Split(output, "\n")
+	networks := strings.Split(result.StdoutContents(), "\n")
 	return networks, nil
 }

--- a/plugins/network/go.mod
+++ b/plugins/network/go.mod
@@ -3,7 +3,6 @@ module github.com/dokku/dokku/plugins/network
 go 1.21
 
 require (
-	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27
 	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/spf13/pflag v1.0.5
 )
@@ -11,6 +10,7 @@ require (
 require (
 	github.com/alexellis/go-execute/v2 v2.2.1 // indirect
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
+	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/plugins/ps/go.mod
+++ b/plugins/ps/go.mod
@@ -3,7 +3,6 @@ module github.com/dokku/dokku/plugins/ps
 go 1.21
 
 require (
-	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27
 	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/dokku/dokku/plugins/config v0.0.0-00010101000000-000000000000
 	github.com/dokku/dokku/plugins/docker-options v0.0.0-00010101000000-000000000000
@@ -14,6 +13,7 @@ require (
 require (
 	github.com/alexellis/go-execute/v2 v2.2.1 // indirect
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
+	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	sh "github.com/codeskyblue/go-sh"
 	"github.com/dokku/dokku/plugins/common"
 	"github.com/dokku/dokku/plugins/config"
 	dockeroptions "github.com/dokku/dokku/plugins/docker-options"
@@ -103,8 +102,17 @@ func TriggerCorePostExtract(appName string, sourceWorkDir string) error {
 		}
 	}
 
-	if b, err := sh.Command("procfile-util", "check", "-P", processSpecificProcfile).CombinedOutput(); err != nil {
-		return fmt.Errorf(strings.TrimSpace(string(b[:])))
+	result, err := common.CallExecCommand(common.ExecCommandInput{
+		Command:       "procfile-util",
+		Args:          []string{"check", "-P", processSpecificProcfile},
+		CaptureOutput: true,
+		StreamStdio:   false,
+	})
+	if err != nil {
+		return fmt.Errorf(result.StderrContents())
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("Invalid Procfile: %s", result.StderrContents())
 	}
 	return nil
 }

--- a/plugins/registry/functions.go
+++ b/plugins/registry/functions.go
@@ -4,12 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"text/template"
 
-	"github.com/codeskyblue/go-sh"
 	"github.com/dokku/dokku/plugins/common"
 )
 
@@ -125,25 +123,23 @@ func pushToRegistry(appName string, tag int, imageID string, imageRepo string) e
 }
 
 func dockerTag(imageID string, imageTag string) bool {
-	cmd := sh.Command(common.DockerBin(), "image", "tag", imageID, imageTag)
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	if err := cmd.Run(); err != nil {
-		return false
-	}
-
-	return true
+	result, err := common.CallExecCommand(common.ExecCommandInput{
+		Command:       common.DockerBin(),
+		Args:          []string{"image", "tag", imageID, imageTag},
+		CaptureOutput: false,
+		StreamStdio:   true,
+	})
+	return err == nil && result.ExitCode == 0
 }
 
 func dockerPush(imageTag string) bool {
-	cmd := sh.Command(common.DockerBin(), "image", "push", imageTag)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return false
-	}
-
-	return true
+	result, err := common.CallExecCommand(common.ExecCommandInput{
+		Command:       common.DockerBin(),
+		Args:          []string{"image", "push", imageTag},
+		CaptureOutput: false,
+		StreamStdio:   true,
+	})
+	return err == nil && result.ExitCode == 0
 }
 
 func imageCleanup(appName string, imageRepo string, imageTag string, tag int) {

--- a/plugins/registry/go.mod
+++ b/plugins/registry/go.mod
@@ -3,7 +3,6 @@ module github.com/dokku/dokku/plugins/registry
 go 1.21
 
 require (
-	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27
 	github.com/dokku/dokku/plugins/common v0.0.0-00010101000000-000000000000
 	github.com/spf13/pflag v1.0.5
 )
@@ -11,6 +10,7 @@ require (
 require (
 	github.com/alexellis/go-execute/v2 v2.2.1 // indirect
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
+	github.com/codeskyblue/go-sh v0.0.0-20190412065543-76bd3d59ff27 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/plugins/scheduler-k3s/go.mod
+++ b/plugins/scheduler-k3s/go.mod
@@ -13,9 +13,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6
 	github.com/go-resty/resty/v2 v2.11.0
 	github.com/gofrs/flock v0.8.1
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/rancher/wharfie v0.6.5
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/spf13/pflag v1.0.5
 	github.com/traefik/traefik/v2 v2.10.7
@@ -78,7 +76,6 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/go-containerregistry v0.14.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.1 // indirect
@@ -87,6 +84,7 @@ require (
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -108,7 +106,6 @@ require (
 	github.com/melbahja/goph v1.4.0 // indirect
 	github.com/miekg/dns v1.1.55 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
@@ -149,7 +146,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.20.0 // indirect
 	go.opentelemetry.io/otel/trace v1.20.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.19.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.20.0 // indirect

--- a/plugins/scheduler-k3s/go.sum
+++ b/plugins/scheduler-k3s/go.sum
@@ -70,8 +70,6 @@ github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG
 github.com/containerd/continuity v0.4.2/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
-github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
-github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
@@ -192,8 +190,6 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-containerregistry v0.14.0 h1:z58vMqHxuwvAsVwvKEkmVBz2TlgBgH5k6koEXBtlYkw=
-github.com/google/go-containerregistry v0.14.0/go.mod h1:aiJ2fp/SXvkWgmYHioXnbMdlgB8eXiiYOY55gfN91Wk=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -297,8 +293,6 @@ github.com/miekg/dns v1.1.55/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
@@ -377,10 +371,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
-github.com/rancher/dynamiclistener v0.3.5 h1:5TaIHvkDGmZKvc96Huur16zfTKOiLhDtK4S+WV0JA6A=
-github.com/rancher/dynamiclistener v0.3.5/go.mod h1:dW/YF6/m2+uEyJ5VtEcd9THxda599HP6N9dSXk81+k0=
-github.com/rancher/wharfie v0.6.5 h1:Xxj/ki8d4BFeQBvyViW9jX8BqxaPlZwXvRD8BG2Mm/8=
-github.com/rancher/wharfie v0.6.5/go.mod h1:iGXn5Y9GEhsx1h/lPUXAklK4DoY4+6NOJF+Li1j248Y=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
@@ -426,8 +416,6 @@ github.com/traefik/paerser v0.2.0 h1:zqCLGSXoNlcBd+mzqSCLjon/I6phqIjeJL2xFB2ysgQ
 github.com/traefik/paerser v0.2.0/go.mod h1:afzaVcgF8A+MpTnPG4wBr4whjanCSYA6vK5RwaYVtRc=
 github.com/traefik/traefik/v2 v2.10.7 h1:vs91abMRVFTxBjn9hsLkqPbQ+D0oM1+bf4K8nD5PKg4=
 github.com/traefik/traefik/v2 v2.10.7/go.mod h1:TD3saYNYbcBa7qDm29fIeyaiCMVX3ltv2YuaX3ANcnc=
-github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlIME=
-github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -458,8 +446,6 @@ go.opentelemetry.io/otel/trace v1.20.0 h1:+yxVAPZPbQhbC3OfAkeIVTky6iTFpcr4SiY9om
 go.opentelemetry.io/otel/trace v1.20.0/go.mod h1:HJSK7F/hA5RlzpZ0zKDCHCDHm556LCDtKaAo6JmBFUU=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca h1:VdD38733bfYv5tUZwEIskMM93VanwNIi5bIKnDrJdEY=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
-go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
-go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
The new way is to use CallExecCommand instead.