### PR TITLE
Always capture stdout/stderr when executing subprocesses

### DIFF
--- a/plugins/app-json/src/commands/commands.go
+++ b/plugins/app-json/src/commands/commands.go
@@ -36,7 +36,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/app-json/src/commands/commands.go
+++ b/plugins/app-json/src/commands/commands.go
@@ -33,9 +33,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/apps/src/commands/commands.go
+++ b/plugins/apps/src/commands/commands.go
@@ -53,7 +53,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/apps/src/commands/commands.go
+++ b/plugins/apps/src/commands/commands.go
@@ -50,9 +50,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/builder/src/commands/commands.go
+++ b/plugins/builder/src/commands/commands.go
@@ -36,7 +36,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/builder/src/commands/commands.go
+++ b/plugins/builder/src/commands/commands.go
@@ -33,9 +33,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/buildpacks/src/commands/commands.go
+++ b/plugins/buildpacks/src/commands/commands.go
@@ -38,9 +38,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/buildpacks/src/commands/commands.go
+++ b/plugins/buildpacks/src/commands/commands.go
@@ -41,7 +41,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/common/docker.go
+++ b/plugins/common/docker.go
@@ -132,9 +132,8 @@ func CopyFromImage(appName string, image string, source string, destination stri
 
 	// add trailing newline for certain places where file parsing depends on it
 	result, err := CallExecCommand(ExecCommandInput{
-		Command:       "tail",
-		Args:          []string{"-c1", destination},
-		CaptureOutput: true,
+		Command: "tail",
+		Args:    []string{"-c1", destination},
 	})
 	if err != nil || result.ExitCode != 0 {
 		return fmt.Errorf("Unable to append trailing newline to copied file: %v", result.Stderr)
@@ -243,9 +242,8 @@ func DockerContainerCreate(image string, containerCreateArgs []string) (string, 
 // DockerInspect runs an inspect command with a given format against a container or image ID
 func DockerInspect(containerOrImageID, format string) (output string, err error) {
 	result, err := CallExecCommand(ExecCommandInput{
-		Command:       DockerBin(),
-		Args:          []string{"inspect", "--format", format, containerOrImageID},
-		CaptureOutput: true,
+		Command: DockerBin(),
+		Args:    []string{"inspect", "--format", format, containerOrImageID},
 	})
 	if err != nil {
 		return "", err
@@ -272,9 +270,8 @@ func GetWorkingDir(appName string, image string) string {
 
 func IsComposeInstalled() bool {
 	result, err := CallExecCommand(ExecCommandInput{
-		Command:       DockerBin(),
-		Args:          []string{"info", "--format", "{{range .ClientInfo.Plugins}}{{if eq .Name \"compose\"}}true{{end}}{{end}}')"},
-		CaptureOutput: true,
+		Command: DockerBin(),
+		Args:    []string{"info", "--format", "{{range .ClientInfo.Plugins}}{{if eq .Name \"compose\"}}true{{end}}{{end}}')"},
 	})
 	return err == nil && result.ExitCode == 0
 }

--- a/plugins/common/docker.go
+++ b/plugins/common/docker.go
@@ -21,10 +21,9 @@ func ContainerIsRunning(containerID string) bool {
 // ContainerRemove runs 'docker container remove' against an existing container
 func ContainerRemove(containerID string) bool {
 	result, err := CallExecCommand(ExecCommandInput{
-		Command:       DockerBin(),
-		Args:          []string{"container", "remove", "-f", containerID},
-		CaptureOutput: false,
-		StreamStdio:   false,
+		Command:      DockerBin(),
+		Args:         []string{"container", "remove", "-f", containerID},
+		StreamStderr: true,
 	})
 	if err != nil {
 		return false
@@ -35,10 +34,8 @@ func ContainerRemove(containerID string) bool {
 // ContainerExists checks to see if a container exists
 func ContainerExists(containerID string) bool {
 	result, err := CallExecCommand(ExecCommandInput{
-		Command:       DockerBin(),
-		Args:          []string{"container", "inspect", containerID},
-		CaptureOutput: false,
-		StreamStdio:   false,
+		Command: DockerBin(),
+		Args:    []string{"container", "inspect", containerID},
 	})
 	if err != nil {
 		return false
@@ -138,7 +135,6 @@ func CopyFromImage(appName string, image string, source string, destination stri
 		Command:       "tail",
 		Args:          []string{"-c1", destination},
 		CaptureOutput: true,
-		StreamStdio:   false,
 	})
 	if err != nil || result.ExitCode != 0 {
 		return fmt.Errorf("Unable to append trailing newline to copied file: %v", result.Stderr)
@@ -250,7 +246,6 @@ func DockerInspect(containerOrImageID, format string) (output string, err error)
 		Command:       DockerBin(),
 		Args:          []string{"inspect", "--format", format, containerOrImageID},
 		CaptureOutput: true,
-		StreamStdio:   false,
 	})
 	if err != nil {
 		return "", err

--- a/plugins/common/exec.go
+++ b/plugins/common/exec.go
@@ -23,8 +23,8 @@ type ExecCommandInput struct {
 	// Args are the arguments to pass to the command
 	Args []string
 
-	// CaptureOutput determines whether to capture the output of the command
-	CaptureOutput bool
+	// DisableStdioBuffer disables the stdio buffer
+	DisableStdioBuffer bool
 
 	// Env is the environment variables to pass to the command
 	Env map[string]string
@@ -95,7 +95,7 @@ func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (Ex
 	// being captured, then color output can be forced.
 	isatty := !color.NoColor
 	env := os.Environ()
-	if isatty && !input.CaptureOutput {
+	if isatty && input.DisableStdioBuffer {
 		env = append(env, "FORCE_TTY=1")
 	}
 	if input.Env != nil {
@@ -115,7 +115,7 @@ func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (Ex
 		Command:            command,
 		Args:               commandArgs,
 		Env:                env,
-		DisableStdioBuffer: !input.CaptureOutput,
+		DisableStdioBuffer: input.DisableStdioBuffer,
 	}
 
 	if os.Getenv("DOKKU_TRACE") == "1" {

--- a/plugins/common/plugn.go
+++ b/plugins/common/plugn.go
@@ -10,8 +10,8 @@ type PlugnTriggerInput struct {
 	// Args are the arguments to pass to the trigger
 	Args []string
 
-	// CaptureOutput determines whether to capture the output of the trigger
-	CaptureOutput bool
+	// DisableStdioBuffer disables the stdio buffer
+	DisableStdioBuffer bool
 
 	// Env is the environment variables to pass to the trigger
 	Env map[string]string
@@ -42,13 +42,13 @@ func CallPlugnTriggerWithContext(ctx context.Context, input PlugnTriggerInput) (
 	args := []string{"trigger", input.Trigger}
 	args = append(args, input.Args...)
 	return CallExecCommandWithContext(ctx, ExecCommandInput{
-		Command:       "plugn",
-		Args:          args,
-		CaptureOutput: input.CaptureOutput,
-		Env:           input.Env,
-		Stdin:         input.Stdin,
-		StreamStdio:   input.StreamStdio,
-		StreamStdout:  input.StreamStdout,
-		StreamStderr:  input.StreamStderr,
+		Command:            "plugn",
+		Args:               args,
+		DisableStdioBuffer: input.DisableStdioBuffer,
+		Env:                input.Env,
+		Stdin:              input.Stdin,
+		StreamStdio:        input.StreamStdio,
+		StreamStdout:       input.StreamStdout,
+		StreamStderr:       input.StreamStderr,
 	})
 }

--- a/plugins/common/ssh.go
+++ b/plugins/common/ssh.go
@@ -31,8 +31,8 @@ type SshCommandInput struct {
 	// Args are the arguments to pass to the command.
 	Args []string
 
-	// CaptureOutput saves any output from in the TaskResult
-	CaptureOutput bool
+	// DisableStdioBuffer disables the stdio buffer
+	DisableStdioBuffer bool
 
 	// Env is a list of environment variables to add to the current environment
 	Env map[string]string
@@ -137,7 +137,7 @@ func CallSshCommandWithContext(ctx context.Context, input SshCommandInput) (SshR
 		Command:            input.Command,
 		Args:               input.Args,
 		Env:                env,
-		DisableStdioBuffer: !input.CaptureOutput,
+		DisableStdioBuffer: input.DisableStdioBuffer,
 		AllowUknownHosts:   input.AllowUknownHosts,
 		Hostname:           u.Hostname(),
 		Port:               uint(port),

--- a/plugins/config/src/commands/commands.go
+++ b/plugins/config/src/commands/commands.go
@@ -57,7 +57,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/config/src/commands/commands.go
+++ b/plugins/config/src/commands/commands.go
@@ -54,9 +54,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/cron/src/commands/commands.go
+++ b/plugins/cron/src/commands/commands.go
@@ -34,9 +34,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/cron/src/commands/commands.go
+++ b/plugins/cron/src/commands/commands.go
@@ -37,7 +37,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/logs/functions.go
+++ b/plugins/logs/functions.go
@@ -38,8 +38,7 @@ const vectorOldContainerName = "vector"
 
 func getComposeFile() ([]byte, error) {
 	result, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
-		Trigger:       "vector-template-source",
-		CaptureOutput: true,
+		Trigger: "vector-template-source",
 	})
 	if err == nil && result.ExitCode == 0 && strings.TrimSpace(result.Stdout) != "" {
 		contents, err := os.ReadFile(strings.TrimSpace(result.Stdout))

--- a/plugins/logs/src/commands/commands.go
+++ b/plugins/logs/src/commands/commands.go
@@ -60,9 +60,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/logs/src/commands/commands.go
+++ b/plugins/logs/src/commands/commands.go
@@ -63,7 +63,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/logs/triggers.go
+++ b/plugins/logs/triggers.go
@@ -46,9 +46,8 @@ func TriggerDockerArgsProcessDeploy(appName string) error {
 
 	if !hasDriverOpt {
 		result, _ := common.CallExecCommand(common.ExecCommandInput{
-			Command:       common.DockerBin(),
-			Args:          []string{"system", "info", "--format", "{{ .LoggingDriver }}"},
-			CaptureOutput: true,
+			Command: common.DockerBin(),
+			Args:    []string{"system", "info", "--format", "{{ .LoggingDriver }}"},
 		})
 
 		if !allowedDrivers[result.StdoutContents()] {

--- a/plugins/logs/triggers.go
+++ b/plugins/logs/triggers.go
@@ -49,7 +49,6 @@ func TriggerDockerArgsProcessDeploy(appName string) error {
 			Command:       common.DockerBin(),
 			Args:          []string{"system", "info", "--format", "{{ .LoggingDriver }}"},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 
 		if !allowedDrivers[result.StdoutContents()] {

--- a/plugins/network/functions.go
+++ b/plugins/network/functions.go
@@ -59,9 +59,8 @@ func attachAppToNetwork(containerID string, networkName string, appName string, 
 // isContainerInNetwork returns true if the container is already attached to the specified network
 func isContainerInNetwork(containerID string, networkName string) bool {
 	result, err := common.CallExecCommand(common.ExecCommandInput{
-		Command:       common.DockerBin(),
-		Args:          []string{"container", "inspect", "--format", "{{range $net, $v := .NetworkSettings.Networks}}{{println $net}}{{end}}", containerID},
-		CaptureOutput: true,
+		Command: common.DockerBin(),
+		Args:    []string{"container", "inspect", "--format", "{{range $net, $v := .NetworkSettings.Networks}}{{println $net}}{{end}}", containerID},
 	})
 
 	if err != nil {
@@ -129,9 +128,8 @@ func networkExists(networkName string) (bool, error) {
 // listNetworks returns a list of docker networks
 func listNetworks() ([]string, error) {
 	result, err := common.CallExecCommand(common.ExecCommandInput{
-		Command:       common.DockerBin(),
-		Args:          []string{"network", "ls", "--format", "{{ .Name }}"},
-		CaptureOutput: true,
+		Command: common.DockerBin(),
+		Args:    []string{"network", "ls", "--format", "{{ .Name }}"},
 	})
 	if err != nil {
 		common.LogVerboseQuiet(result.StderrContents())

--- a/plugins/network/functions.go
+++ b/plugins/network/functions.go
@@ -62,7 +62,6 @@ func isContainerInNetwork(containerID string, networkName string) bool {
 		Command:       common.DockerBin(),
 		Args:          []string{"container", "inspect", "--format", "{{range $net, $v := .NetworkSettings.Networks}}{{println $net}}{{end}}", containerID},
 		CaptureOutput: true,
-		StreamStdio:   false,
 	})
 
 	if err != nil {
@@ -133,7 +132,6 @@ func listNetworks() ([]string, error) {
 		Command:       common.DockerBin(),
 		Args:          []string{"network", "ls", "--format", "{{ .Name }}"},
 		CaptureOutput: true,
-		StreamStdio:   false,
 	})
 	if err != nil {
 		common.LogVerboseQuiet(result.StderrContents())

--- a/plugins/network/src/commands/commands.go
+++ b/plugins/network/src/commands/commands.go
@@ -43,7 +43,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/network/src/commands/commands.go
+++ b/plugins/network/src/commands/commands.go
@@ -40,9 +40,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/ports/src/commands/commands.go
+++ b/plugins/ports/src/commands/commands.go
@@ -40,7 +40,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/ports/src/commands/commands.go
+++ b/plugins/ports/src/commands/commands.go
@@ -37,9 +37,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/proxy/src/commands/commands.go
+++ b/plugins/proxy/src/commands/commands.go
@@ -40,7 +40,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/proxy/src/commands/commands.go
+++ b/plugins/proxy/src/commands/commands.go
@@ -37,9 +37,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/ps/src/commands/commands.go
+++ b/plugins/ps/src/commands/commands.go
@@ -43,7 +43,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/ps/src/commands/commands.go
+++ b/plugins/ps/src/commands/commands.go
@@ -40,9 +40,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -103,9 +103,8 @@ func TriggerCorePostExtract(appName string, sourceWorkDir string) error {
 	}
 
 	result, err := common.CallExecCommand(common.ExecCommandInput{
-		Command:       "procfile-util",
-		Args:          []string{"check", "-P", processSpecificProcfile},
-		CaptureOutput: true,
+		Command: "procfile-util",
+		Args:    []string{"check", "-P", processSpecificProcfile},
 	})
 	if err != nil {
 		return fmt.Errorf(result.StderrContents())

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -106,7 +106,6 @@ func TriggerCorePostExtract(appName string, sourceWorkDir string) error {
 		Command:       "procfile-util",
 		Args:          []string{"check", "-P", processSpecificProcfile},
 		CaptureOutput: true,
-		StreamStdio:   false,
 	})
 	if err != nil {
 		return fmt.Errorf(result.StderrContents())

--- a/plugins/registry/functions.go
+++ b/plugins/registry/functions.go
@@ -124,20 +124,18 @@ func pushToRegistry(appName string, tag int, imageID string, imageRepo string) e
 
 func dockerTag(imageID string, imageTag string) bool {
 	result, err := common.CallExecCommand(common.ExecCommandInput{
-		Command:       common.DockerBin(),
-		Args:          []string{"image", "tag", imageID, imageTag},
-		CaptureOutput: false,
-		StreamStdio:   true,
+		Command:     common.DockerBin(),
+		Args:        []string{"image", "tag", imageID, imageTag},
+		StreamStdio: true,
 	})
 	return err == nil && result.ExitCode == 0
 }
 
 func dockerPush(imageTag string) bool {
 	result, err := common.CallExecCommand(common.ExecCommandInput{
-		Command:       common.DockerBin(),
-		Args:          []string{"image", "push", imageTag},
-		CaptureOutput: false,
-		StreamStdio:   true,
+		Command:     common.DockerBin(),
+		Args:        []string{"image", "push", imageTag},
+		StreamStdio: true,
 	})
 	return err == nil && result.ExitCode == 0
 }

--- a/plugins/registry/src/commands/commands.go
+++ b/plugins/registry/src/commands/commands.go
@@ -34,9 +34,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/registry/src/commands/commands.go
+++ b/plugins/registry/src/commands/commands.go
@@ -37,7 +37,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/registry/subcommands.go
+++ b/plugins/registry/subcommands.go
@@ -54,10 +54,9 @@ func CommandLogin(server string, username string, password string, passwordStdin
 	}
 
 	_, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
-		Trigger:       "post-registry-login",
-		Args:          []string{server, username},
-		StreamStdio:   true,
-		CaptureOutput: false,
+		Trigger:     "post-registry-login",
+		Args:        []string{server, username},
+		StreamStdio: true,
 		Env: map[string]string{
 			"DOCKER_REGISTRY_PASS": password,
 		},

--- a/plugins/repo/src/commands/commands.go
+++ b/plugins/repo/src/commands/commands.go
@@ -36,7 +36,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/repo/src/commands/commands.go
+++ b/plugins/repo/src/commands/commands.go
@@ -33,9 +33,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/resource/src/commands/commands.go
+++ b/plugins/resource/src/commands/commands.go
@@ -39,7 +39,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/resource/src/commands/commands.go
+++ b/plugins/resource/src/commands/commands.go
@@ -36,9 +36,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/scheduler-k3s/functions.go
+++ b/plugins/scheduler-k3s/functions.go
@@ -335,9 +335,8 @@ func extractStartCommand(input StartCommandInput) string {
 	}
 
 	resp, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
-		Trigger:       "config-get",
-		Args:          []string{input.AppName, "DOKKU_START_CMD"},
-		CaptureOutput: true,
+		Trigger: "config-get",
+		Args:    []string{input.AppName, "DOKKU_START_CMD"},
 	})
 	if err == nil && resp.ExitCode == 0 && len(resp.Stdout) > 0 {
 		command = strings.TrimSpace(resp.Stdout)
@@ -345,9 +344,8 @@ func extractStartCommand(input StartCommandInput) string {
 
 	if input.ImageSourceType == "dockerfile" {
 		resp, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
-			Trigger:       "config-get",
-			Args:          []string{input.AppName, "DOKKU_DOCKERFILE_START_CMD"},
-			CaptureOutput: true,
+			Trigger: "config-get",
+			Args:    []string{input.AppName, "DOKKU_DOCKERFILE_START_CMD"},
 		})
 		if err == nil && resp.ExitCode == 0 && len(resp.Stdout) > 0 {
 			command = strings.TrimSpace(resp.Stdout)

--- a/plugins/scheduler-k3s/functions.go
+++ b/plugins/scheduler-k3s/functions.go
@@ -338,7 +338,6 @@ func extractStartCommand(input StartCommandInput) string {
 		Trigger:       "config-get",
 		Args:          []string{input.AppName, "DOKKU_START_CMD"},
 		CaptureOutput: true,
-		StreamStdio:   false,
 	})
 	if err == nil && resp.ExitCode == 0 && len(resp.Stdout) > 0 {
 		command = strings.TrimSpace(resp.Stdout)
@@ -349,7 +348,6 @@ func extractStartCommand(input StartCommandInput) string {
 			Trigger:       "config-get",
 			Args:          []string{input.AppName, "DOKKU_DOCKERFILE_START_CMD"},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && resp.ExitCode == 0 && len(resp.Stdout) > 0 {
 			command = strings.TrimSpace(resp.Stdout)

--- a/plugins/scheduler-k3s/src/commands/commands.go
+++ b/plugins/scheduler-k3s/src/commands/commands.go
@@ -46,7 +46,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/scheduler-k3s/src/commands/commands.go
+++ b/plugins/scheduler-k3s/src/commands/commands.go
@@ -43,9 +43,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/scheduler-k3s/subcommands.go
+++ b/plugins/scheduler-k3s/subcommands.go
@@ -356,10 +356,7 @@ func CommandClusterAdd(role string, remoteHost string, serverIP string, allowUkn
 
 	k3sVersionCmd, err := common.CallExecCommand(common.ExecCommandInput{
 		Command: "k3s",
-		Args: []string{
-			"--version",
-		},
-		CaptureOutput: true,
+		Args:    []string{"--version"},
 	})
 	if err != nil {
 		return fmt.Errorf("Unable to call k3s version command: %w", err)

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -531,20 +531,18 @@ func TriggerSchedulerDeploy(scheduler string, appName string, imageTag string) e
 
 	common.LogInfo1("Running post-deploy")
 	_, err = common.CallPlugnTrigger(common.PlugnTriggerInput{
-		Args:          []string{appName, "", "", imageTag},
-		CaptureOutput: false,
-		StreamStdio:   true,
-		Trigger:       "core-post-deploy",
+		Args:        []string{appName, "", "", imageTag},
+		StreamStdio: true,
+		Trigger:     "core-post-deploy",
 	})
 	if err != nil {
 		return fmt.Errorf("Error running core-post-deploy: %w", err)
 
 	}
 	_, err = common.CallPlugnTrigger(common.PlugnTriggerInput{
-		Args:          []string{appName, "", "", imageTag},
-		CaptureOutput: false,
-		StreamStdio:   true,
-		Trigger:       "post-deploy",
+		Args:        []string{appName, "", "", imageTag},
+		StreamStdio: true,
+		Trigger:     "post-deploy",
 	})
 	if err != nil {
 		return fmt.Errorf("Error running post-deploy: %w", err)
@@ -806,14 +804,12 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 			Trigger:       "config-get",
 			Args:          []string{appName, "DOKKU_RM_CONTAINER"},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err != nil {
 			resp, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
 				Trigger:       "config-get-global",
 				Args:          []string{"DOKKU_RM_CONTAINER"},
 				CaptureOutput: true,
-				StreamStdio:   false,
 			})
 			if err == nil {
 				dokkuRmContainer = strings.TrimSpace(resp.Stdout)
@@ -865,7 +861,6 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 			Trigger:       "procfile-get-command",
 			Args:          []string{appName, args[0], "5000"},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && resp.Stdout != "" {
 			common.LogInfo1Quiet(fmt.Sprintf("Found '%s' in Procfile, running that command", args[0]))

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -801,15 +801,13 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 	dokkuRmContainer := os.Getenv("DOKKU_RM_CONTAINER")
 	if dokkuRmContainer == "" {
 		resp, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
-			Trigger:       "config-get",
-			Args:          []string{appName, "DOKKU_RM_CONTAINER"},
-			CaptureOutput: true,
+			Trigger: "config-get",
+			Args:    []string{appName, "DOKKU_RM_CONTAINER"},
 		})
 		if err != nil {
 			resp, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
-				Trigger:       "config-get-global",
-				Args:          []string{"DOKKU_RM_CONTAINER"},
-				CaptureOutput: true,
+				Trigger: "config-get-global",
+				Args:    []string{"DOKKU_RM_CONTAINER"},
 			})
 			if err == nil {
 				dokkuRmContainer = strings.TrimSpace(resp.Stdout)
@@ -858,9 +856,8 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 		}
 	} else if len(args) == 1 {
 		resp, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
-			Trigger:       "procfile-get-command",
-			Args:          []string{appName, args[0], "5000"},
-			CaptureOutput: true,
+			Trigger: "procfile-get-command",
+			Args:    []string{appName, args[0], "5000"},
 		})
 		if err == nil && resp.Stdout != "" {
 			common.LogInfo1Quiet(fmt.Sprintf("Found '%s' in Procfile, running that command", args[0]))

--- a/plugins/scheduler/src/commands/commands.go
+++ b/plugins/scheduler/src/commands/commands.go
@@ -36,7 +36,6 @@ func main() {
 			Command:       "ps",
 			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 			CaptureOutput: true,
-			StreamStdio:   false,
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)

--- a/plugins/scheduler/src/commands/commands.go
+++ b/plugins/scheduler/src/commands/commands.go
@@ -33,9 +33,8 @@ func main() {
 		usage()
 	case "help":
 		result, err := common.CallExecCommand(common.ExecCommandInput{
-			Command:       "ps",
-			Args:          []string{"-o", "command=", strconv.Itoa(os.Getppid())},
-			CaptureOutput: true,
+			Command: "ps",
+			Args:    []string{"-o", "command=", strconv.Itoa(os.Getppid())},
 		})
 		if err == nil && strings.Contains(result.StdoutContents(), "--all") {
 			fmt.Println(helpContent)


### PR DESCRIPTION
This is almost certainly the correct default for Dokku. While it's a BC break and might cause an increase in memory usage, the api is mostly internal and therefore this is safe to use.
