### PR TITLE
Remove all calls to common.NewShellCmd

### DIFF
--- a/plugins/common/io.go
+++ b/plugins/common/io.go
@@ -38,15 +38,16 @@ func Copy(src, dst string) error {
 	}
 
 	// ensure file has the correct line endings
-	dos2unixCmd := NewShellCmd(strings.Join([]string{
-		"dos2unix",
-		"-l",
-		"-n",
-		src,
-		dst,
-	}, " "))
-	dos2unixCmd.ShowOutput = false
-	dos2unixCmd.Execute()
+	result, err := CallExecCommand(ExecCommandInput{
+		Command: "dos2unix",
+		Args:    []string{"-l", "-n", src, dst},
+	})
+	if err != nil {
+		return fmt.Errorf("Error running dos2unix: %s", err)
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("Error running dos2unix: %s", result.StderrContents())
+	}
 
 	// ensure file permissions are correct
 	b, err := os.ReadFile(dst)

--- a/plugins/registry/subcommands.go
+++ b/plugins/registry/subcommands.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -35,25 +36,23 @@ func CommandLogin(server string, username string, password string, passwordStdin
 		server = "docker.io"
 	}
 
-	command := []string{
-		common.DockerBin(),
-		"login",
-		"--username",
-		username,
-		"--password-stdin",
-		server,
-	}
-
 	buffer := bytes.Buffer{}
 	buffer.Write([]byte(password + "\n"))
 
-	loginCmd := common.NewShellCmd(strings.Join(command, " "))
-	loginCmd.Command.Stdin = &buffer
-	if !loginCmd.Execute() {
-		return errors.New("Failed to log into registry")
+	result, err := common.CallExecCommand(common.ExecCommandInput{
+		Command:      common.DockerBin(),
+		Args:         []string{"login", "--username", username, "--password-stdin", server},
+		Stdin:        &buffer,
+		StreamStderr: true,
+	})
+	if err != nil {
+		return fmt.Errorf("Unable to run docker login: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("Unable to run docker login: %s", result.StderrContents())
 	}
 
-	_, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
+	_, err = common.CallPlugnTrigger(common.PlugnTriggerInput{
 		Trigger:     "post-registry-login",
 		Args:        []string{server, username},
 		StreamStdio: true,

--- a/plugins/repo/subcommands.go
+++ b/plugins/repo/subcommands.go
@@ -1,6 +1,8 @@
 package repo
 
 import (
+	"fmt"
+
 	"github.com/dokku/dokku/plugins/common"
 )
 
@@ -14,9 +16,20 @@ func CommandGc(appName string) error {
 	cmdEnv := map[string]string{
 		"GIT_DIR": appRoot,
 	}
-	gitGcCmd := common.NewShellCmd("git gc --aggressive")
-	gitGcCmd.Env = cmdEnv
-	gitGcCmd.Execute()
+
+	result, err := common.CallExecCommand(common.ExecCommandInput{
+		Command:     "git",
+		Args:        []string{"gc", "--aggressive"},
+		Env:         cmdEnv,
+		StreamStdio: true,
+	})
+	if err != nil {
+		return fmt.Errorf("Unable to run git gc: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("Unable to run git gc: %s", result.StderrContents())
+	}
+
 	return nil
 }
 

--- a/plugins/scheduler-docker-local/functions.go
+++ b/plugins/scheduler-docker-local/functions.go
@@ -15,17 +15,28 @@ import (
 )
 
 func deleteCrontab() error {
-	command := common.NewShellCmd("sudo /usr/bin/crontab -l -u dokku")
-	command.ShowOutput = false
-	if !command.Execute() {
-		return nil
+	result, err := common.CallExecCommand(common.ExecCommandInput{
+		Command: "/usr/bin/crontab",
+		Args:    []string{"-l", "-u", "dokku"},
+		Sudo:    true,
+	})
+	if err != nil {
+		return fmt.Errorf("Unable to remove schedule file: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("Unable to remove schedule file: %s", result.StderrContents())
 	}
 
-	command = common.NewShellCmd("sudo /usr/bin/crontab -r -u dokku")
-	command.ShowOutput = false
-	out, err := command.CombinedOutput()
+	result, err = common.CallExecCommand(common.ExecCommandInput{
+		Command: "/usr/bin/crontab",
+		Args:    []string{"-r", "-u", "dokku"},
+		Sudo:    true,
+	})
 	if err != nil {
-		return fmt.Errorf("Unable to remove schedule file: %v", string(out))
+		return fmt.Errorf("Unable to remove schedule file: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("Unable to remove schedule file: %s", result.StderrContents())
 	}
 
 	common.LogInfo1("Removed")
@@ -139,11 +150,16 @@ func writeCronEntries() error {
 		return fmt.Errorf("Unable to template out schedule file: %v", err)
 	}
 
-	command := common.NewShellCmd(fmt.Sprintf("sudo /usr/bin/crontab -u dokku %s", tmpFile.Name()))
-	command.ShowOutput = false
-	out, err := command.CombinedOutput()
+	result, err := common.CallExecCommand(common.ExecCommandInput{
+		Command: "/usr/bin/crontab",
+		Args:    []string{"-u", "dokku", tmpFile.Name()},
+		Sudo:    true,
+	})
 	if err != nil {
-		return fmt.Errorf("Unable to update schedule file: %s", string(out))
+		return fmt.Errorf("Unable to update schedule file: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("Unable to update schedule file: %s", result.StderrContents())
 	}
 
 	common.LogInfo1("Updated schedule file")


### PR DESCRIPTION
At this point, the only usage of go-sh should be by plugin trigger calls.