### PR TITLE
Add ability for users to specify alternative kubeconfig and kubecontext

### DIFF
--- a/docs/deployment/schedulers/k3s.md
+++ b/docs/deployment/schedulers/k3s.md
@@ -320,6 +320,38 @@ By default, Dokku assumes that all it controls all actions on the cluster, and t
 dokku scheduler-k3s:show-kubeconfig
 ```
 
+### Interacting with an external Kubernetes cluster
+
+While the k3s scheduler plugin is designed to work with a Dokku-managed k3s cluster, Dokku can be configured to interact with any Kubernetes cluster by setting the global `kubeconfig-path` to a path to a custom kubeconfig on the Dokku server. This property is only available at a global level.
+
+```shell
+dokku scheduler-k3s:set --global kubeconfig-path /path/to/custom/kubeconfig
+```
+
+To set the default value, omit the value from the `scheduler-k3s:set` call:
+
+```shell
+dokku scheduler-k3s:set --global kubeconfig-path
+```
+
+The default value for the `kubeconfig-path` is the k3s kubeconfig located at `/etc/rancher/k3s/k3s.yaml`.
+
+### Customizing the Kubernetes context
+
+When interacting with a custom Kubeconfig, the `kube-context` property can be set to specify a specific context within the kubeconfig to use. This property is available only at the global leve.
+
+```shell
+dokku scheduler-k3s:set --global kube-context lollipop
+```
+
+To set the default value, omit the value from the `scheduler-k3s:set` call:
+
+```shell
+dokku scheduler-k3s:set --global kube-context
+```
+
+The default value for the `kube-context` is an empty string, and will result in Dokku using the current context within the kubeconfig.
+
 ## Scheduler Interface
 
 The following sections describe implemented and unimplemented scheduler functionality for the `k3s` scheduler.

--- a/plugins/scheduler-k3s/functions.go
+++ b/plugins/scheduler-k3s/functions.go
@@ -1142,12 +1142,25 @@ func installHelm(ctx context.Context) error {
 	return nil
 }
 
+func isKubernetesAvailable() error {
+	client, err := NewKubernetesClient()
+	if err != nil {
+		return fmt.Errorf("Error creating kubernetes client: %w", err)
+	}
+
+	if err := client.Ping(); err != nil {
+		return fmt.Errorf("Error pinging kubernetes: %w", err)
+	}
+
+	return nil
+}
+
 func isK3sInstalled() error {
 	if !common.FileExists("/usr/local/bin/k3s") {
 		return fmt.Errorf("k3s binary is not available")
 	}
 
-	if !common.FileExists(KubeConfigPath) {
+	if !common.FileExists(getKubeconfigPath()) {
 		return fmt.Errorf("k3s kubeconfig is not available")
 	}
 

--- a/plugins/scheduler-k3s/functions.go
+++ b/plugins/scheduler-k3s/functions.go
@@ -1142,6 +1142,7 @@ func installHelm(ctx context.Context) error {
 	return nil
 }
 
+// isKubernetesAvailable returns an error if kubernetes api is not available
 func isKubernetesAvailable() error {
 	client, err := NewKubernetesClient()
 	if err != nil {
@@ -1155,6 +1156,7 @@ func isKubernetesAvailable() error {
 	return nil
 }
 
+// isK3sInstalled returns an error if k3s is not installed
 func isK3sInstalled() error {
 	if !common.FileExists("/usr/local/bin/k3s") {
 		return fmt.Errorf("k3s binary is not available")
@@ -1165,6 +1167,11 @@ func isK3sInstalled() error {
 	}
 
 	return nil
+}
+
+// isK3sKubernetes returns true if the current kubernetes cluster is configured to be k3s
+func isK3sKubernetes() bool {
+	return getKubeconfigPath() == KubeConfigPath
 }
 
 func isPodReady(ctx context.Context, clientset KubernetesClient, podName, namespace string) wait.ConditionWithContextFunc {

--- a/plugins/scheduler-k3s/helm.go
+++ b/plugins/scheduler-k3s/helm.go
@@ -75,7 +75,9 @@ func NewHelmAgent(namespace string, logger action.DebugLog) (*HelmAgent, error) 
 		helmDriver = "secrets"
 	}
 
-	kubeConfig := kube.GetConfig(KubeConfigPath, "", namespace)
+	kubeconfigPath := getKubeconfigPath()
+	kubeContext := getKubeContext()
+	kubeConfig := kube.GetConfig(kubeconfigPath, kubeContext, namespace)
 	if err := actionConfig.Init(kubeConfig, namespace, helmDriver, logger); err != nil {
 		return nil, err
 	}

--- a/plugins/scheduler-k3s/report.go
+++ b/plugins/scheduler-k3s/report.go
@@ -17,6 +17,8 @@ func ReportSingleApp(appName string, format string, infoFlag string) error {
 		"--scheduler-k3s-computed-image-pull-secrets":   reportComputedImagePullSecrets,
 		"--scheduler-k3s-image-pull-secrets":            reportImagePullSecrets,
 		"--scheduler-k3s-global-image-pull-secrets":     reportGlobalImagePullSecrets,
+		"--scheduler-k3s-global-kubeconfig-path":        reportGlobalKubeconfigPath,
+		"--scheduler-k3s-global-kube-context":           reportGlobalKubeContext,
 		"--scheduler-k3s-computed-letsencrypt-server":   reportComputedLetsencryptServer,
 		"--scheduler-k3s-letsencrypt-server":            reportLetsencryptServer,
 		"--scheduler-k3s-global-letsencrypt-server":     reportGlobalLetsencryptServer,
@@ -71,6 +73,13 @@ func reportGlobalIngressClass(appName string) string {
 	return getGlobalIngressClass()
 }
 
+func reportGlobalKubeconfigPath(appName string) string {
+	return getKubeconfigPath()
+}
+
+func reportGlobalKubeContext(appName string) string {
+	return getKubeContext()
+}
 func reportComputedLetsencryptServer(appName string) string {
 	return getComputedLetsencryptServer(appName)
 }

--- a/plugins/scheduler-k3s/scheduler_k3s.go
+++ b/plugins/scheduler-k3s/scheduler_k3s.go
@@ -29,6 +29,8 @@ var (
 		"deploy-timeout":         true,
 		"image-pull-secrets":     true,
 		"ingress-class":          true,
+		"kube-context":           true,
+		"kubeconfig-path":        true,
 		"letsencrypt-server":     true,
 		"letsencrypt-email-prod": true,
 		"letsencrypt-email-stag": true,
@@ -42,6 +44,7 @@ var (
 const DefaultIngressClass = "traefik"
 const GlobalProcessType = "--global"
 const KubeConfigPath = "/etc/rancher/k3s/k3s.yaml"
+const DefaultKubeContext = ""
 
 var (
 	runtimeScheme  = runtime.NewScheme()

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -414,6 +414,10 @@ func TriggerSchedulerDeploy(scheduler string, appName string, imageTag string) e
 		return fmt.Errorf("Error creating kubernetes client: %w", err)
 	}
 
+	if err := clientset.Ping(); err != nil {
+		return fmt.Errorf("kubernetes api not available: %w", err)
+	}
+
 	cronJobs, err := clientset.ListCronJobs(ctx, ListCronJobsInput{
 		LabelSelector: fmt.Sprintf("app.kubernetes.io/part-of=%s", appName),
 		Namespace:     namespace,
@@ -573,6 +577,10 @@ func TriggerSchedulerEnter(scheduler string, appName string, processType string,
 		return fmt.Errorf("Error creating kubernetes client: %w", err)
 	}
 
+	if err := clientset.Ping(); err != nil {
+		return fmt.Errorf("kubernetes api not available: %w", err)
+	}
+
 	namespace := getComputedNamespace(appName)
 	labelSelector := []string{fmt.Sprintf("app.kubernetes.io/part-of=%s", appName)}
 	processIndex := 1
@@ -662,6 +670,10 @@ func TriggerSchedulerLogs(scheduler string, appName string, processType string, 
 	clientset, err := NewKubernetesClient()
 	if err != nil {
 		return fmt.Errorf("Error creating kubernetes client: %w", err)
+	}
+
+	if err := clientset.Ping(); err != nil {
+		return fmt.Errorf("kubernetes api not available: %w", err)
 	}
 
 	labelSelector := []string{fmt.Sprintf("app.kubernetes.io/part-of=%s", appName)}
@@ -926,6 +938,10 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 		return fmt.Errorf("Error creating kubernetes client: %w", err)
 	}
 
+	if err := clientset.Ping(); err != nil {
+		return fmt.Errorf("kubernetes api not available: %w", err)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGHUP,
@@ -1078,6 +1094,10 @@ func TriggerSchedulerRunList(scheduler string, appName string, format string) er
 		return fmt.Errorf("Error creating kubernetes client: %w", err)
 	}
 
+	if err := clientset.Ping(); err != nil {
+		return fmt.Errorf("kubernetes api not available: %w", err)
+	}
+
 	namespace := getComputedNamespace(appName)
 	cronJobs, err := clientset.ListCronJobs(ctx, ListCronJobsInput{
 		LabelSelector: fmt.Sprintf("app.kubernetes.io/part-of=%s", appName),
@@ -1139,9 +1159,8 @@ func TriggerSchedulerPostDelete(scheduler string, appName string) error {
 		return nil
 	}
 
-	if err := isK3sInstalled(); err != nil {
-		common.LogWarn(fmt.Sprintf("Skipping app deletion: %s", err.Error()))
-		return nil
+	if err := isKubernetesAvailable(); err != nil {
+		return fmt.Errorf("kubernetes api not available: %w", err)
 	}
 
 	namespace := getComputedNamespace(appName)
@@ -1164,11 +1183,6 @@ func TriggerSchedulerStop(scheduler string, appName string) error {
 		return nil
 	}
 
-	if err := isK3sInstalled(); err != nil {
-		common.LogWarn(fmt.Sprintf("Skipping app stop: %s", err.Error()))
-		return nil
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGHUP,
@@ -1183,6 +1197,10 @@ func TriggerSchedulerStop(scheduler string, appName string) error {
 	clientset, err := NewKubernetesClient()
 	if err != nil {
 		return fmt.Errorf("Error creating kubernetes client: %w", err)
+	}
+
+	if err := clientset.Ping(); err != nil {
+		return fmt.Errorf("kubernetes api not available: %w", err)
 	}
 
 	namespace := getComputedNamespace(appName)

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -1159,6 +1159,24 @@ func TriggerSchedulerPostDelete(scheduler string, appName string) error {
 		return nil
 	}
 
+	dataErr := common.RemoveAppDataDirectory("logs", appName)
+	propertyErr := common.PropertyDestroy("logs", appName)
+
+	if dataErr != nil {
+		return dataErr
+	}
+
+	if propertyErr != nil {
+		return propertyErr
+	}
+
+	if isK3sKubernetes() {
+		if err := isK3sInstalled(); err != nil {
+			common.LogWarn("k3s is not installed, skipping")
+			return nil
+		}
+	}
+
 	if err := isKubernetesAvailable(); err != nil {
 		return fmt.Errorf("kubernetes api not available: %w", err)
 	}

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -1214,6 +1214,12 @@ func TriggerSchedulerStop(scheduler string, appName string) error {
 
 	clientset, err := NewKubernetesClient()
 	if err != nil {
+		if isK3sKubernetes() {
+			if err := isK3sInstalled(); err != nil {
+				common.LogWarn("k3s is not installed, skipping")
+				return nil
+			}
+		}
 		return fmt.Errorf("Error creating kubernetes client: %w", err)
 	}
 


### PR DESCRIPTION
This will provide the possibility for users to talk to existing kubernetes clusters, thereby removing one of the biggest reasons for having the old scheduler-kubernetes plugin around.

See #6588 for impetus /cc @taraszka.