### PR TITLE
fix dokku_client.sh to correctly handle git urls that contain port numbers

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -111,7 +111,9 @@ main() {
   if [[ -z "$APP" ]]; then
     if [[ -d .git ]] || git rev-parse --git-dir &>/dev/null; then
       set +e
-      APP=$(git remote -v 2>/dev/null | grep -Ei "^${DOKKU_GIT_REMOTE}\s" | grep -Ei "dokku@$DOKKU_REMOTE_HOST" | head -n 1 | cut -f2 -d'@' | cut -f1 -d' ' | cut -f2 -d':' 2>/dev/null)
+      # Read app name and port from a git url of the form "dokku ssh://dokku@dokkuhost.example.com:5412/project-name (fetch)"
+      APP=$(git remote -v 2>/dev/null | grep -Ei "^${DOKKU_GIT_REMOTE}\s" | grep -Ei "dokku@$DOKKU_REMOTE_HOST" | head -n 1 | cut -f2 -d'@' | cut -f2 -d'/' | cut -f1 -d' ' 2>/dev/null)
+      DOKKU_PORT=$(git remote -v 2>/dev/null | grep -Ei "^${DOKKU_GIT_REMOTE}\s" | grep -Ei "dokku@$DOKKU_REMOTE_HOST" | head -n 1 | cut -f2 -d'@' | cut -f1 -d'/' | cut -f2 -d':' 2>/dev/null)
       set -e
     else
       echo " !     This is not a git repository" 1>&2


### PR DESCRIPTION
read both application name and port number from remote