### PR TITLE
Call sed in unbuffered form to ensure log output is streamed to stdout

### DIFF
--- a/plugins/scheduler-docker-local/scheduler-logs
+++ b/plugins/scheduler-docker-local/scheduler-logs
@@ -35,7 +35,7 @@ trigger-scheduler-docker-local-scheduler-logs() {
     if [[ $PRETTY_PRINT == "true" ]]; then
       local DOKKU_LOGS_CMD+="($DOCKER_BIN logs $DOKKU_LOGS_ARGS $CID 2>&1)"
     else
-      local DOKKU_LOGS_PRETTY_PRINT_CMD="sed -r 's/^([^Z]+Z )/\x1b[${COLOR}m\1app[$DYNO]:\x1b[0m /gm'"
+      local DOKKU_LOGS_PRETTY_PRINT_CMD="sed -u -r 's/^([^Z]+Z )/\x1b[${COLOR}m\1app[$DYNO]:\x1b[0m /gm'"
       local DOKKU_LOGS_CMD+="($DOCKER_BIN logs -t $DOKKU_LOGS_ARGS $CID 2>&1 | $DOKKU_LOGS_PRETTY_PRINT_CMD)"
     fi
     if [[ $i != "$MAX_INDEX" ]]; then

--- a/plugins/scheduler-docker-local/scheduler-run-logs
+++ b/plugins/scheduler-docker-local/scheduler-run-logs
@@ -38,7 +38,7 @@ trigger-scheduler-docker-local-scheduler-logs() {
     if [[ $PRETTY_PRINT == "true" ]]; then
       local DOKKU_LOGS_CMD+="($DOCKER_BIN logs $DOKKU_LOGS_ARGS $CID 2>&1)"
     else
-      local DOKKU_LOGS_PRETTY_PRINT_CMD="sed -r 's/^([^Z]+Z )/\x1b[${COLOR}m\1app[$DYNO]:\x1b[0m /gm'"
+      local DOKKU_LOGS_PRETTY_PRINT_CMD="sed -u -r 's/^([^Z]+Z )/\x1b[${COLOR}m\1app[$DYNO]:\x1b[0m /gm'"
       local DOKKU_LOGS_CMD+="($DOCKER_BIN logs -t $DOKKU_LOGS_ARGS $CID 2>&1 | $DOKKU_LOGS_PRETTY_PRINT_CMD)"
     fi
     if [[ $i != "$MAX_INDEX" ]]; then


### PR DESCRIPTION
The new exec callers somehow setup the environment differently, causing sed to not properly detect that it should run in unbuffered form. This change forces sed to run in unbuffered mode.

Closes #6602