### PR TITLE
Specify the correct workdir and default command for images built via herokuish

### DIFF
--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -42,7 +42,10 @@ trigger-builder-herokuish-builder-build() {
   NEW_DOKKU_IMAGE=$(plugn trigger builder-dokku-image "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR" "$DOKKU_IMAGE")
   [[ -n "$NEW_DOKKU_IMAGE" ]] && DOKKU_IMAGE="$NEW_DOKKU_IMAGE"
 
-  if ! TAR_CID=$(tar -c . | "$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /app && tar -xC /app"); then
+  local DOCKER_BUILD_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  DOKKU_APP_USER=$(config_get "$APP" DOKKU_APP_USER || true)
+  DOKKU_APP_USER=${DOKKU_APP_USER:="herokuishuser"}
+  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/copy-source.Dockerfile" --build-arg APP_IMAGE="$IMAGE" --build-arg DOKKU_APP_USER=$DOKKU_APP_USER -t $IMAGE "$SOURCECODE_WORK_DIR"; then
     DOKKU_SKIP_IMAGE_CLEANUP_REGISTRATION=1 plugn trigger scheduler-register-retired "$APP" "$TAR_CID"
     dokku_log_warn "Failure extracting app code"
     return 1

--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -45,20 +45,11 @@ trigger-builder-herokuish-builder-build() {
   local DOCKER_BUILD_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
   DOKKU_APP_USER=$(config_get "$APP" DOKKU_APP_USER || true)
   DOKKU_APP_USER=${DOKKU_APP_USER:="herokuishuser"}
-  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/copy-source.Dockerfile" --build-arg APP_IMAGE="$IMAGE" --build-arg DOKKU_APP_USER=$DOKKU_APP_USER -t $IMAGE "$SOURCECODE_WORK_DIR"; then
+  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/copy-source.Dockerfile" --build-arg APP_IMAGE="$DOKKU_IMAGE" --build-arg DOKKU_APP_USER=$DOKKU_APP_USER -t $IMAGE "$SOURCECODE_WORK_DIR"; then
     DOKKU_SKIP_IMAGE_CLEANUP_REGISTRATION=1 plugn trigger scheduler-register-retired "$APP" "$TAR_CID"
     dokku_log_warn "Failure extracting app code"
     return 1
   fi
-
-  if test "$("$DOCKER_BIN" container wait "$TAR_CID")" -ne 0; then
-    DOKKU_SKIP_IMAGE_CLEANUP_REGISTRATION=1 plugn trigger scheduler-register-retired "$APP" "$TAR_CID"
-    dokku_log_warn "Failure extracting app code"
-    return 1
-  fi
-
-  "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$TAR_CID" "$IMAGE" >/dev/null
-  DOKKU_SKIP_IMAGE_CLEANUP_REGISTRATION=1 plugn trigger scheduler-register-retired "$APP" "$TAR_CID"
 
   if fn-plugn-trigger-exists "pre-build-buildpack"; then
     dokku_log_warn "Deprecated: please upgrade plugin to use 'pre-build' plugin trigger instead of pre-build-buildpack"

--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -31,7 +31,7 @@ trigger-builder-herokuish-builder-build() {
   fi
 
   local IMAGE=$(get_app_image_name "$APP")
-  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL dokku=" "--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.image-stage=build" "--change" "LABEL com.dokku.builder-type=herokuish" "--change" "LABEL com.dokku.app-name=$APP")
+  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL dokku=" "--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.image-stage=build" "--change" "LABEL com.dokku.builder-type=herokuish" "--change" "LABEL com.dokku.app-name=$APP" "--change" "WORKDIR /app" "--change" "CMD bash" "--change" "ENTRYPOINT [\"/exec\"]")
   local DOCKER_RUN_LABEL_ARGS=("--label=dokku" "--label=org.label-schema.schema-version=1.0" "--label=org.label-schema.vendor=dokku" "--label=com.dokku.image-stage=build" "--label=com.dokku.builder-type=herokuish" "--label=com.dokku.app-name=$APP")
   local CID TAR_CID
 

--- a/plugins/builder-herokuish/dockerfiles/builder-release.Dockerfile
+++ b/plugins/builder-herokuish/dockerfiles/builder-release.Dockerfile
@@ -1,4 +1,5 @@
 ARG APP_IMAGE
 FROM $APP_IMAGE
 
-COPY 00-global-env.sh 01-app-env.sh /app/.profile.d/
+ARG DOKKU_APP_USER herokuishuser
+COPY --chown=$DOKKU_APP_USER 00-global-env.sh 01-app-env.sh /app/.profile.d/

--- a/plugins/builder-herokuish/dockerfiles/copy-source.Dockerfile
+++ b/plugins/builder-herokuish/dockerfiles/copy-source.Dockerfile
@@ -1,0 +1,6 @@
+ARG APP_IMAGE
+FROM $APP_IMAGE
+
+ARG DOKKU_APP_USER herokuishuser
+RUN USER=$DOKKU_APP_USER /exec true
+COPY --chown=$DOKKU_APP_USER . /app

--- a/plugins/builder-herokuish/dockerfiles/pre-build.Dockerfile
+++ b/plugins/builder-herokuish/dockerfiles/pre-build.Dockerfile
@@ -1,5 +1,6 @@
 ARG APP_IMAGE
 FROM $APP_IMAGE
 
-COPY .env.d /tmp/env
-COPY .env /app/.env
+ARG DOKKU_APP_USER herokuishuser
+COPY --chown=$DOKKU_APP_USER .env.d /tmp/env
+COPY --chown=$DOKKU_APP_USER .env /app/.env

--- a/plugins/builder-herokuish/pre-build
+++ b/plugins/builder-herokuish/pre-build
@@ -39,7 +39,11 @@ trigger-builder-herokuish-pre-build-buildpack() {
   echo "$dotenv_contents" >"$TMP_WORK_DIR/.env"
   config_export app "$APP" --format envfile --merged >>"$TMP_WORK_DIR/.env"
 
-  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/pre-build.Dockerfile" --build-arg APP_IMAGE="$IMAGE" -t $IMAGE "$TMP_WORK_DIR"; then
+
+  DOKKU_APP_USER=$(config_get "$APP" DOKKU_APP_USER || true)
+  DOKKU_APP_USER=${DOKKU_APP_USER:="herokuishuser"}
+
+  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/pre-build.Dockerfile" --build-arg APP_IMAGE="$IMAGE" --build-arg DOKKU_APP_USER=$DOKKU_APP_USER -t $IMAGE "$TMP_WORK_DIR"; then
     dokku_log_warn "Failure injecting BUILD_ENV into build environment"
     return 1
   fi


### PR DESCRIPTION
Previously, the default WORKDIR was set not set, meaning that other tooling would need to guess at the correct path for herokuish images (which is always /app). This change ensures that a 'docker image inspect' always returns the correct path.

Additionally, the default entrypoint is now '/exec' - which ensures the environment is always setup correctly, while 'bash' is set as the default command.

Refs #6611 

---

I might need to change the entrypoint/cmd changes to just be a `CMD /exec bash` and no entrypoint change, pending how tests run, as I don't want to break backwards compatibility for the sake of correctness here, given that Herokuish is otherwise effectively frozen.