### PR TITLE
Ensure referenced images get updated by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -141,6 +141,41 @@ updates:
     open-pull-requests-limit: 2
     labels:
       - "type: dependencies"
+  - package-ecosystem: "docker"
+    directory: "/plugins/caddy-vhosts"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - "type: dependencies"
+  - package-ecosystem: "docker"
+    directory: "/plugins/haproxy-vhosts"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - "type: dependencies"
+  - package-ecosystem: "docker"
+    directory: "/plugins/logs"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - "type: dependencies"
+  - package-ecosystem: "docker"
+    directory: "/plugins/openresty-vhosts"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - "type: dependencies"
+  - package-ecosystem: "docker"
+    directory: "/plugins/traefik-vhosts"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - "type: dependencies"
   - package-ecosystem: bundler
     directory: "/tests/apps/ruby"
     schedule:

--- a/plugins/caddy-vhosts/Dockerfile
+++ b/plugins/caddy-vhosts/Dockerfile
@@ -1,0 +1,1 @@
+FROM lucaslorentz/caddy-docker-proxy:2.8

--- a/plugins/caddy-vhosts/internal-functions
+++ b/plugins/caddy-vhosts/internal-functions
@@ -46,7 +46,7 @@ fn-caddy-template-compose-file() {
 }
 
 fn-caddy-image() {
-  fn-plugin-property-get-default "caddy" "--global" "image" "lucaslorentz/caddy-docker-proxy:2.8"
+  fn-plugin-property-get-default "caddy" "--global" "image" "$(grep "FROM" "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/Dockerfile" | awk '{print $2}')"
 }
 
 fn-caddy-letsencrypt-email() {

--- a/plugins/haproxy-vhosts/Dockerfile
+++ b/plugins/haproxy-vhosts/Dockerfile
@@ -1,0 +1,1 @@
+FROM byjg/easy-haproxy:4.3.0

--- a/plugins/haproxy-vhosts/internal-functions
+++ b/plugins/haproxy-vhosts/internal-functions
@@ -44,7 +44,7 @@ fn-haproxy-template-compose-file() {
 }
 
 fn-haproxy-image() {
-  fn-plugin-property-get-default "haproxy" "--global" "image" "byjg/easy-haproxy:4.3.0"
+  fn-plugin-property-get-default "haproxy" "--global" "image" "$(grep "FROM" "$PLUGIN_AVAILABLE_PATH/haproxy-vhosts/Dockerfile" | awk '{print $2}')"
 }
 
 fn-haproxy-log-level() {

--- a/plugins/logs/Dockerfile
+++ b/plugins/logs/Dockerfile
@@ -1,0 +1,1 @@
+FROM timberio/vector:0.35.X-debian

--- a/plugins/logs/functions.go
+++ b/plugins/logs/functions.go
@@ -121,6 +121,17 @@ func startVectorContainer(vectorImage string) error {
 	return nil
 }
 
+func getComputedVectorImage() string {
+	return common.PropertyGetDefault("logs", "--global", "vector-image", getDefaultVectorImage())
+}
+
+// getDefaultVectorImage returns the default image used for the vector container
+func getDefaultVectorImage() string {
+	contents := strings.TrimSpace(VectorDockerfile)
+	parts := strings.SplitN(contents, " ", 2)
+	return parts[1]
+}
+
 func stopVectorContainer() error {
 	if !common.IsComposeInstalled() {
 		return errors.New("Required docker compose plugin is not installed")
@@ -159,7 +170,7 @@ func stopVectorContainer() error {
 	data := vectorTemplateData{
 		DokkuLibRoot: dokkuLibRoot,
 		DokkuLogsDir: dokkuLogsDir,
-		VectorImage:  VectorImage,
+		VectorImage:  getComputedVectorImage(),
 	}
 
 	if err := tmpl.Execute(tmpFile, data); err != nil {

--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -25,8 +25,11 @@ var (
 	}
 )
 
-// VectorImage contains the default vector image to run
-const VectorImage = "timberio/vector:0.35.X-debian"
+// VectorDockerfile is the contents of the default Dockerfile
+// containing the version of vector Dokku uses
+//
+//go:embed Dockerfile
+var VectorDockerfile string
 
 // VectorDefaultSink contains the default sink in use for vector log shipping
 const VectorDefaultSink = "blackhole://?print_interval_secs=1"

--- a/plugins/logs/report.go
+++ b/plugins/logs/report.go
@@ -44,7 +44,7 @@ func reportGlobalMaxSize(appName string) string {
 }
 
 func reportVectorGlobalImage(appName string) string {
-	return common.PropertyGetDefault("logs", "--global", "vector-image", VectorImage)
+	return getComputedVectorImage()
 }
 
 func reportGlobalVectorSink(appName string) string {

--- a/plugins/logs/subcommands.go
+++ b/plugins/logs/subcommands.go
@@ -104,7 +104,7 @@ func CommandVectorStart(vectorImage string) error {
 	}
 
 	if vectorImage == "" {
-		vectorImage = common.PropertyGetDefault("logs", "--global", "vector-image", VectorImage)
+		vectorImage = common.PropertyGetDefault("logs", "--global", "vector-image", getComputedVectorImage())
 	}
 
 	common.LogVerbose("Starting vector container")

--- a/plugins/openresty-vhosts/Dockerfile
+++ b/plugins/openresty-vhosts/Dockerfile
@@ -1,0 +1,1 @@
+FROM dokku/openresty-docker-proxy:0.6.0

--- a/plugins/openresty-vhosts/internal-functions
+++ b/plugins/openresty-vhosts/internal-functions
@@ -112,7 +112,7 @@ fn-openresty-hsts-is-enabled() {
 }
 
 fn-openresty-image() {
-  fn-plugin-property-get-default "openresty" "--global" "image" "dokku/openresty-docker-proxy:0.6.0"
+  fn-plugin-property-get-default "openresty" "--global" "image" "$(grep "FROM" "$PLUGIN_AVAILABLE_PATH/openresty-vhosts/Dockerfile" | awk '{print $2}')"
 }
 
 fn-openresty-letsencrypt-email() {

--- a/plugins/traefik-vhosts/Dockerfile
+++ b/plugins/traefik-vhosts/Dockerfile
@@ -1,0 +1,1 @@
+FROM traefik:v2.10

--- a/plugins/traefik-vhosts/internal-functions
+++ b/plugins/traefik-vhosts/internal-functions
@@ -76,7 +76,7 @@ fn-traefik-dashboard-enabled() {
 }
 
 fn-traefik-image() {
-  fn-plugin-property-get-default "traefik" "--global" "image" "traefik:v2.10"
+  fn-plugin-property-get-default "traefik" "--global" "image" "$(grep "FROM" "$PLUGIN_AVAILABLE_PATH/traefik-vhosts/Dockerfile" | awk '{print $2}')"
 }
 
 fn-traefik-letsencrypt-email() {


### PR DESCRIPTION
Dokku uses a few external images for various bits of functionality, but these must be manually updated every so often due to being referenced in code.

By moving the references to Dockerfiles, we can take advantage of dependabot to issue automatic PRs when they are out of date.