### PR TITLE
Install jq in vagrant vm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant::configure("2") do |config|
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
 
-    vm.vm.provision :shell, :inline => "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq >/dev/null && apt-get -qq -y --no-install-recommends install git build-essential >/dev/null && cd /root/dokku && #{make_cmd}"
+    vm.vm.provision :shell, :inline => "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq >/dev/null && apt-get -qq -y --no-install-recommends install git build-essential jq >/dev/null && cd /root/dokku && #{make_cmd}"
     vm.vm.provision :shell do |s|
       s.inline = <<-EOT
         echo '"\e[5~": history-search-backward' > /root/.inputrc


### PR DESCRIPTION
This small PR is to address `vagrant up` issue:

```
==> dokku: Running provisioner: shell...
    dokku: Running: inline script


    dokku: apt-get update -qq
    dokku: make: jq: Command not found
    dokku: wget -qO /tmp/docker-image-labeler_latest.tgz
    dokku: wget: missing URL
    dokku: Usage: wget [OPTION]... [URL]...
    dokku: 
    dokku: Try `wget --help' for more options.
    dokku: make: *** [Makefile:153: docker-image-labeler] Error 1
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
```

It seems the `jq` is missing in the current Bento Ubuntu image.