### PR TITLE
Copy code into initial base image via docker build

### DIFF
--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -36,26 +36,23 @@ trigger-builder-herokuish-builder-build() {
   local CID TAR_CID
 
   pushd "$SOURCECODE_WORK_DIR" &>/dev/null
+  if [[ -f "$SOURCECODE_WORK_DIR/.dockerignore" ]]; then
+    rm -f "$SOURCECODE_WORK_DIR/.dockerignore"
+  fi
 
   eval "$(config_export app "$APP")"
   plugn trigger builder-create-dokku-image "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR" "$DOKKU_IMAGE"
   NEW_DOKKU_IMAGE=$(plugn trigger builder-dokku-image "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR" "$DOKKU_IMAGE")
   [[ -n "$NEW_DOKKU_IMAGE" ]] && DOKKU_IMAGE="$NEW_DOKKU_IMAGE"
 
-  if ! TAR_CID=$(tar -c . | "$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /app && tar -xC /app"); then
+  local DOCKER_BUILD_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP"
+  DOKKU_APP_USER=$(config_get "$APP" DOKKU_APP_USER || true)
+  DOKKU_APP_USER=${DOKKU_APP_USER:="herokuishuser"}
+  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/copy-source.Dockerfile" --build-arg APP_IMAGE="$DOKKU_IMAGE" --build-arg DOKKU_APP_USER=$DOKKU_APP_USER -t $IMAGE "$SOURCECODE_WORK_DIR"; then
     DOKKU_SKIP_IMAGE_CLEANUP_REGISTRATION=1 plugn trigger scheduler-register-retired "$APP" "$TAR_CID"
     dokku_log_warn "Failure extracting app code"
     return 1
   fi
-
-  if test "$("$DOCKER_BIN" container wait "$TAR_CID")" -ne 0; then
-    DOKKU_SKIP_IMAGE_CLEANUP_REGISTRATION=1 plugn trigger scheduler-register-retired "$APP" "$TAR_CID"
-    dokku_log_warn "Failure extracting app code"
-    return 1
-  fi
-
-  "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$TAR_CID" "$IMAGE" >/dev/null
-  DOKKU_SKIP_IMAGE_CLEANUP_REGISTRATION=1 plugn trigger scheduler-register-retired "$APP" "$TAR_CID"
 
   if fn-plugn-trigger-exists "pre-build-buildpack"; then
     dokku_log_warn "Deprecated: please upgrade plugin to use 'pre-build' plugin trigger instead of pre-build-buildpack"

--- a/plugins/builder-herokuish/dockerfiles/copy-source.Dockerfile
+++ b/plugins/builder-herokuish/dockerfiles/copy-source.Dockerfile
@@ -1,0 +1,7 @@
+ARG APP_IMAGE
+FROM $APP_IMAGE
+
+ARG DOKKU_APP_USER herokuishuser
+RUN USER=$DOKKU_APP_USER /exec true
+COPY --chown=$DOKKU_APP_USER . /app
+WORKDIR /app


### PR DESCRIPTION
The previous method used an ephemeral container, which was slightly more convoluted and required cleanup. The new method also allows us to set an initial WORKDIR, which is useful for ensuring 'docker exec' works as expected.