### PR TITLE
Use smaller reference to image pull secrets in secret naming

### DIFF
--- a/plugins/scheduler-k3s/templates/chart/image-pull-secret.yaml
+++ b/plugins/scheduler-k3s/templates/chart/image-pull-secret.yaml
@@ -12,10 +12,10 @@ metadata:
     {{- end }}
     {{- end }}
   labels:
-    app.kubernetes.io/instance: image-pull-{{ $.Values.global.app_name }}.{{ $.Values.global.deploment_id }}
-    app.kubernetes.io/name: image-pull-{{ $.Values.global.app_name }}
+    app.kubernetes.io/instance: {{ $.Values.global.app_name }}.ims.{{ $.Values.global.deploment_id }}
+    app.kubernetes.io/name: {{ $.Values.global.app_name }}.ims
     app.kubernetes.io/part-of: {{ $.Values.global.app_name }}
-  name: image-pull-{{ $.Values.global.app_name }}.{{ $.Values.global.deploment_id }}
+  name: {{ $.Values.global.app_name }}.ims.{{ $.Values.global.deploment_id }}
   namespace: {{ $.Values.global.namespace }}
 data:
   .dockerconfigjson: "{{ $.Values.global.image.pull_secret_base64 }}"

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -179,7 +179,7 @@ func TriggerSchedulerDeploy(scheduler string, appName string, imageTag string) e
 				return fmt.Errorf("Error reading docker config: %w", err)
 			}
 
-			imagePullSecrets = fmt.Sprintf("image-pull-%s.%d", appName, deploymentId)
+			imagePullSecrets = fmt.Sprintf("%s.ims.%d", appName, deploymentId)
 			pullSecretBase64 = base64.StdEncoding.EncodeToString(b)
 		}
 	}


### PR DESCRIPTION
This fixes an issue where the secret name is too long in tests where the generated test app name includes a uuid.