### PR TITLE
Correctly use cache volume for herokuish builds

### DIFF
--- a/tests/unit/app-json.bats
+++ b/tests/unit/app-json.bats
@@ -20,6 +20,9 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output_contains "Executing predeploy task from app.json: touch /app/predeploy.test"
+  assert_output_contains "Executing postdeploy task from app.json: touch /app/postdeploy.test"
+  assert_output_contains "Executing prebuild task from app.json: touch /app/prebuild.test" 0
 
   run docker inspect "${TEST_APP}.web.1" --format "{{json .Config.Cmd}}"
   echo "output: $output"
@@ -37,13 +40,10 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  CID=$(docker ps -a -q -f "ancestor=dokku/${TEST_APP}" -f "label=dokku_phase_script=postdeploy")
-  DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$TEST_APP")
-  IMAGE_ID=$(docker commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" $CID dokku-test/${TEST_APP})
-  run /bin/bash -c "docker run --rm $IMAGE_ID ls /app/postdeploy.test"
+  run /bin/bash -c "dokku run $TEST_APP ls /app/postdeploy.test"
   echo "output: $output"
   echo "status: $status"
-  assert_success
+  assert_failure
 }
 
 @test "(app-json) app.json scripts postdeploy" {

--- a/tests/unit/build-env.bats
+++ b/tests/unit/build-env.bats
@@ -80,31 +80,3 @@ teardown() {
   echo "status: $status"
   assert_output "herokuish"
 }
-
-@test "(build-env) DOKKU_ROOT cache bind is used by default" {
-  run deploy_app
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  BUILD_CID=$(docker ps -a | grep $TEST_APP | grep /bin/bash | awk '{print $1}' | head -n1)
-  run /bin/bash -c "docker inspect --format '{{ .HostConfig.Binds }}' $BUILD_CID | tr -d '[]' | cut -f1 -d:"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output "$DOKKU_ROOT/$TEST_APP/cache"
-}
-
-@test "(build-env) DOKKU_HOST_ROOT cache bind is used if set" {
-  TMP_ROOT=$(mktemp -d)
-  mkdir -p $DOKKU_ROOT/.dokkurc
-  echo export DOKKU_HOST_ROOT="$TMP_ROOT" >$DOKKU_ROOT/.dokkurc/HOST_ROOT
-  DOKKU_HOST_ROOT="$TMP_ROOT" deploy_app
-
-  BUILD_CID=$(docker ps -a | grep $TEST_APP | grep /bin/bash | awk '{print $1}' | head -n1)
-  run /bin/bash -c "docker inspect --format '{{ .HostConfig.Binds }}' $BUILD_CID | tr -d '[]' | cut -f1 -d:"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output "$TMP_ROOT/$TEST_APP/cache"
-
-  rm -rf $TMP_ROOT $DOKKU_ROOT/.dokkurc/HOST_ROOT
-}

--- a/tests/unit/repo.bats
+++ b/tests/unit/repo.bats
@@ -49,22 +49,12 @@ teardown() {
   echo "status: $status"
   assert_output 1
 
-  run /bin/bash -c "find $DOKKU_ROOT/$TEST_APP/cache -type f | wc -l"
-  echo "count: '$output'"
-  echo "status: $status"
-  assert_output 0
-
   run /bin/bash -c "dokku repo:purge-cache $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
   run /bin/bash -c "docker volume ls -q --filter label=com.dokku.app-name=$TEST_APP | wc -l"
-  echo "count: '$output'"
-  echo "status: $status"
-  assert_output 0
-
-  run /bin/bash -c "find $DOKKU_ROOT/$TEST_APP/cache -type f | wc -l"
   echo "count: '$output'"
   echo "status: $status"
   assert_output 0


### PR DESCRIPTION
Rather than try to mount a directory into the container and use a symlink, directly mount the volume in.

Note that this requires deleting the task container prior to continuing in order to ensure the volume isn't still mounted prior to other tasks being executed.