### PR TITLE
Only apply the cluster issuers helm chart when setting letsencrypt properties

### DIFF
--- a/plugins/scheduler-k3s/subcommands.go
+++ b/plugins/scheduler-k3s/subcommands.go
@@ -734,6 +734,16 @@ func CommandReport(appName string, format string, infoFlag string) error {
 // CommandSet set or clear a scheduler-k3s property for an app
 func CommandSet(appName string, property string, value string) error {
 	common.CommandPropertySet("scheduler-k3s", appName, property, value, DefaultProperties, GlobalProperties)
+
+	letsencryptProperties := map[string]bool{
+		"letsencrypt-email-prod": true,
+		"letsencrypt-email-stag": true,
+		"letsencrypt-server":     true,
+	}
+	if appName == "--global" && letsencryptProperties[property] {
+		return applyClusterIssuers(context.Background())
+	}
+
 	return nil
 }
 

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -135,11 +135,6 @@ func TriggerSchedulerDeploy(scheduler string, appName string, imageTag string) e
 		return fmt.Errorf("Error loading environment for deployment: %w", err)
 	}
 
-	err = applyClusterIssuers(ctx)
-	if err != nil {
-		return fmt.Errorf("Error applying cluster issuers: %w", err)
-	}
-
 	issuerName := "letsencrypt-stag"
 	server := getComputedLetsencryptServer(appName)
 	if server == "prod" || server == "production" {


### PR DESCRIPTION
Otherwise, we're constantly re-installing the same helm chart during deploys, leading to longer deploys.