### PR TITLE
Traefik: not expose all containers

### DIFF
--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -12,6 +12,7 @@ services:
       - --entrypoints.https.address=:443
       {{ end }}
       - --providers.docker
+      - --providers.docker.exposedByDefault=false
       - --api={{ $.TRAEFIK_API_ENABLED }}
       - --api.dashboard={{ $.TRAEFIK_DASHBOARD_ENABLED }}
 
@@ -33,6 +34,7 @@ services:
 
       {{ if eq $.TRAEFIK_API_ENABLED "true" }}
       # Dashboard
+      - "traefik.enable=true"
       - "traefik.http.routers.api.rule=Host(`{{ $.TRAEFIK_API_VHOST }}`)"
       - "traefik.http.routers.api.service=api@internal"
       - "traefik.http.routers.api.entrypoints={{ if $.TRAEFIK_LETSENCRYPT_EMAIL }}https{{ else }}http{{ end }}"


### PR DESCRIPTION
Hi,

by setting exposedByDefault to false only containers are exposed that have the `traefik.enable` label. The label is already there for the web containers, it was only missing for the dashboard.

It might be a breaking change for people who have manually exposed other containers

traefik documentation: https://doc.traefik.io/traefik/providers/docker/#exposedbydefault
