### PR TITLE
Execute go get/build with mod in readonly mode

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -28,10 +28,10 @@ clean:
 	find . -xtype l -delete
 
 commands: **/**/commands.go
-	GOARCH=$(GOARCH) go build -ldflags="-s -w" $(GO_ARGS) -o commands src/commands/commands.go
+	GOARCH=$(GOARCH) go build -mod=readonly -ldflags="-s -w" $(GO_ARGS) -o commands src/commands/commands.go
 
 subcommands:
-	GOARCH=$(GOARCH) go build -ldflags="-s -w" $(GO_ARGS) -o subcommands/subcommands src/subcommands/subcommands.go
+	GOARCH=$(GOARCH) go build -mod=readonly -ldflags="-s -w" $(GO_ARGS) -o subcommands/subcommands src/subcommands/subcommands.go
 	$(MAKE) $(SUBCOMMANDS)
 
 subcommands/%:
@@ -41,7 +41,7 @@ src-clean:
 	rm -rf .gitignore src vendor Makefile *.go glide.* go.sum go.mod
 
 triggers:
-	GOARCH=$(GOARCH) go build -ldflags="-s -w" $(GO_ARGS) -o triggers src/triggers/triggers.go
+	GOARCH=$(GOARCH) go build -mod=readonly -ldflags="-s -w" $(GO_ARGS) -o triggers src/triggers/triggers.go
 	$(MAKE) $(TRIGGERS)
 
 triggers/%:

--- a/tests.mk
+++ b/tests.mk
@@ -182,7 +182,7 @@ go-test-plugin:
 		-v $$PWD:$(GO_REPO_ROOT) \
 		-w $(GO_REPO_ROOT) \
 		$(BUILD_IMAGE) \
-		bash -c "cd plugins/$(PLUGIN_NAME) && go get github.com/onsi/gomega && go test -v -p 1 -race " || exit $$?
+		bash -c "cd plugins/$(PLUGIN_NAME) && go get github.com/onsi/gomega && go test -v -p 1 -race -mod=readonly " || exit $$?
 
 unit-tests: go-tests
 	@echo running bats unit tests...


### PR DESCRIPTION
This will avoid issues where a build or test will inadvertently update dependencies, causing drift between what is in code and what is being tested/run.