### PR TITLE
Remove systemd reverse dependency by dropping software-properties-common

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ RUN \
   && ln -sf /mnt/dokku/var/lib/dokku/data /var/lib/dokku/data \
   && ln -sf /mnt/dokku/var/lib/dokku/services /var/lib/dokku/services \
   && mv /etc/my_init.d/00_regen_ssh_host_keys.sh /etc/my_init.d/15_regen_ssh_host_keys \
-  && rm -f /usr/bin/systemctl \
   && rm -f /etc/nginx/sites-enabled/default /usr/share/nginx/html/index.html /etc/my_init.d/10_syslog-ng.init \
   && rm -f /usr/local/openresty/nginx/conf/sites-enabled/default /usr/share/openresty/html/index.html \
   && sed -i '/imklog/d' /etc/rsyslog.conf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN \
   && ln -sf /mnt/dokku/var/lib/dokku/data /var/lib/dokku/data \
   && ln -sf /mnt/dokku/var/lib/dokku/services /var/lib/dokku/services \
   && mv /etc/my_init.d/00_regen_ssh_host_keys.sh /etc/my_init.d/15_regen_ssh_host_keys \
+  && rm -f /usr/bin/systemctl \
   && rm -f /etc/nginx/sites-enabled/default /usr/share/nginx/html/index.html /etc/my_init.d/10_syslog-ng.init \
   && rm -f /usr/local/openresty/nginx/conf/sites-enabled/default /usr/share/openresty/html/index.html \
   && sed -i '/imklog/d' /etc/rsyslog.conf \

--- a/contrib/images/digitalocean/in_parts/011-docker
+++ b/contrib/images/digitalocean/in_parts/011-docker
@@ -9,7 +9,6 @@ pkgs=(apt-transport-https
   curl
   jq
   linux-image-extra-virtual
-  software-properties-common
 )
 
 echo '--> Updating apt repositories'

--- a/contrib/images/digitalocean/in_parts/012-dokku-packages
+++ b/contrib/images/digitalocean/in_parts/012-dokku-packages
@@ -15,7 +15,6 @@ pkgs=(apache2-utils
   netcat
   net-tools
 
-  software-properties-common
   parallel
   python3-software-properties
   rsync

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.33.7
 Section: web
 Priority: optional
 Architecture: amd64
-Depends: apache2-utils, locales, git, cpio, curl, man-db, netcat, sshcommand, docker-engine-cs (>= 17.05.0) | docker-engine (>= 17.05.0) | docker-io (>= 17.05.0) | docker.io (>= 17.05.0) | docker-ce (>= 17.05.0) | docker-ee (>= 17.05.0) | moby-engine, docker-compose-plugin | moby-compose, docker-buildx-plugin | moby-buildx, docker-container-healthchecker, docker-image-labeler, lambda-builder, net-tools, netrc, software-properties-common, parallel, procfile-util, python-software-properties | python3-software-properties, rsync, rsyslog, dos2unix, jq, unzip, util-linux
+Depends: apache2-utils, locales, git, cpio, curl, man-db, netcat, sshcommand, docker-engine-cs (>= 17.05.0) | docker-engine (>= 17.05.0) | docker-io (>= 17.05.0) | docker.io (>= 17.05.0) | docker-ce (>= 17.05.0) | docker-ee (>= 17.05.0) | moby-engine, docker-compose-plugin | moby-compose, docker-buildx-plugin | moby-buildx, docker-container-healthchecker, docker-image-labeler, lambda-builder, net-tools, netrc, parallel, procfile-util, rsync, rsyslog, dos2unix, jq, unzip, util-linux
 Recommends: herokuish, bash-completion, dokku-update, dokku-event-listener
 Pre-Depends: gliderlabs-sigil, nginx (>= 1.8.0) | openresty, dnsutils, cgroupfs-mount | cgroup-lite, plugn, sudo, python3, debconf
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>


### PR DESCRIPTION
Through some random machinations, software-properties-common now has a dependency on systemd. This breaks the built docker image as plugins will think systemd is available, so `dokku plugin:install --core` will reference that over sv.

Since we don't manage ppas in Dokku anymore - the only use was for an nginx ppa so we could use a newer Nginx - this can be safely removed.

Also remove some other stuff related to systemd that aren't required anymore.