### PR TITLE
Remove the need for executing crontab as root

### DIFF
--- a/docker/etc/sudoers.d/dokku-docker
+++ b/docker/etc/sudoers.d/dokku-docker
@@ -1,1 +1,1 @@
-dokku    ALL=NOPASSWD:SETENV:/usr/bin/docker,/usr/bin/docker-container-healthchecker,/usr/bin/docker-image-labeler,/usr/bin/pack,/usr/bin/crontab
+dokku    ALL=NOPASSWD:SETENV:/usr/bin/docker,/usr/bin/docker-container-healthchecker,/usr/bin/docker-image-labeler,/usr/bin/pack

--- a/plugins/scheduler-docker-local/functions.go
+++ b/plugins/scheduler-docker-local/functions.go
@@ -16,18 +16,16 @@ import (
 
 func deleteCrontab() error {
 	result, err := common.CallExecCommand(common.ExecCommandInput{
-		Command: "/usr/bin/crontab",
+		Command: "crontab",
 		Args:    []string{"-l", "-u", "dokku"},
-		Sudo:    true,
 	})
 	if err != nil || result.ExitCode != 0 {
 		return nil
 	}
 
 	result, err = common.CallExecCommand(common.ExecCommandInput{
-		Command: "/usr/bin/crontab",
+		Command: "crontab",
 		Args:    []string{"-r", "-u", "dokku"},
-		Sudo:    true,
 	})
 	if err != nil {
 		return fmt.Errorf("Unable to remove schedule file: %w", err)
@@ -148,9 +146,8 @@ func writeCronEntries() error {
 	}
 
 	result, err := common.CallExecCommand(common.ExecCommandInput{
-		Command: "/usr/bin/crontab",
+		Command: "crontab",
 		Args:    []string{"-u", "dokku", tmpFile.Name()},
-		Sudo:    true,
 	})
 	if err != nil {
 		return fmt.Errorf("Unable to update schedule file: %w", err)

--- a/plugins/scheduler-docker-local/install
+++ b/plugins/scheduler-docker-local/install
@@ -14,8 +14,7 @@ trigger-scheduler-docker-local-install() {
 
   fn-plugin-property-setup "scheduler-docker-local"
 
-  echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/crontab" >"/etc/sudoers.d/dokku-cron"
-  chmod "0440" "/etc/sudoers.d/dokku-cron"
+  rm -f "/etc/sudoers.d/dokku-cron"
 
   echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/docker-container-healthchecker" >"/etc/sudoers.d/dokku-docker-container-healthchecker"
   chmod "0440" "/etc/sudoers.d/dokku-docker-container-healthchecker"

--- a/tests/unit/cron.bats
+++ b/tests/unit/cron.bats
@@ -41,7 +41,7 @@ teardown() {
   run /bin/bash -c "test -f /etc/sudoers.d/dokku-cron"
   echo "output: $output"
   echo "status: $status"
-  assert_success
+  assert_failure
 }
 
 @test "(cron) invalid [missing-keys]" {


### PR DESCRIPTION
This was done by design previously - to fix an issue with RHEL not allowing running crontab as the current user - but is no longer necessary with the removal of non-Debian platform support.