### PR TITLE
Handle case where most builders didn't detect amd64 images on arm64

### DIFF
--- a/plugins/builder-dockerfile/builder-release
+++ b/plugins/builder-dockerfile/builder-release
@@ -22,8 +22,14 @@ trigger-builder-dockerfile-builder-release() {
   TMP_WORK_DIR="$(mktemp -d "/tmp/dokku-${DOKKU_PID}-${FUNCNAME[0]}.XXXXXX")"
   trap "rm -rf '$TMP_WORK_DIR' >/dev/null" RETURN INT TERM EXIT
 
-  local DOCKER_BUILD_LABEL_ARGS=("--label=org.label-schema.schema-version=1.0" "--label=org.label-schema.vendor=dokku" "--label=com.dokku.app-name=$APP" "--label=com.dokku.image-stage=release" "--label=dokku")
-  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-dockerfile/dockerfiles/builder-release.Dockerfile" --build-arg APP_IMAGE="$IMAGE" -t "$IMAGE" "$TMP_WORK_DIR"; then
+  local DOCKER_BUILD_ARGS=("--label=org.label-schema.schema-version=1.0" "--label=org.label-schema.vendor=dokku" "--label=com.dokku.app-name=$APP" "--label=com.dokku.image-stage=release" "--label=dokku")
+
+  if fn-force-arm64-image "$IMAGE"; then
+    dokku_log_warn "Detected linux/amd64 image, forcing --platform=linux/amd64"
+    DOCKER_BUILD_ARGS+=("--platform=linux/amd64")
+  fi
+
+  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-dockerfile/dockerfiles/builder-release.Dockerfile" --build-arg APP_IMAGE="$IMAGE" -t "$IMAGE" "$TMP_WORK_DIR"; then
     dokku_log_warn "Failure injecting docker labels on image"
     return 1
   fi

--- a/plugins/builder-herokuish/builder-release
+++ b/plugins/builder-herokuish/builder-release
@@ -26,8 +26,14 @@ trigger-builder-herokuish-builder-release() {
   config_export global >"$TMP_WORK_DIR/00-global-env.sh"
   config_export app "$APP" >"$TMP_WORK_DIR/01-app-env.sh"
 
-  local DOCKER_BUILD_LABEL_ARGS=("--label=org.label-schema.schema-version=1.0" "--label=org.label-schema.vendor=dokku" "--label=com.dokku.app-name=$APP" "--label=com.dokku.image-stage=release" "--label=dokku")
-  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/builder-release.Dockerfile" --build-arg APP_IMAGE="$IMAGE" -t "$IMAGE" "$TMP_WORK_DIR"; then
+  local DOCKER_BUILD_ARGS=("--label=org.label-schema.schema-version=1.0" "--label=org.label-schema.vendor=dokku" "--label=com.dokku.app-name=$APP" "--label=com.dokku.image-stage=release" "--label=dokku")
+
+  if fn-force-arm64-image "$IMAGE"; then
+    dokku_log_warn "Detected linux/amd64 image, forcing --platform=linux/amd64"
+    DOCKER_BUILD_ARGS+=("--platform=linux/amd64")
+  fi
+
+  if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-herokuish/dockerfiles/builder-release.Dockerfile" --build-arg APP_IMAGE="$IMAGE" -t "$IMAGE" "$TMP_WORK_DIR"; then
     dokku_log_warn "Failure injecting environment variables"
     return 1
   fi

--- a/plugins/builder-nixpacks/builder-release
+++ b/plugins/builder-nixpacks/builder-release
@@ -12,7 +12,6 @@ trigger-builder-nixpacks-builder-release() {
     return
   fi
 
-
   local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
   plugn trigger pre-release-builder "$BUILDER_TYPE" "$APP" "$IMAGE"
 

--- a/plugins/builder-nixpacks/builder-release
+++ b/plugins/builder-nixpacks/builder-release
@@ -12,14 +12,14 @@ trigger-builder-nixpacks-builder-release() {
     return
   fi
 
-  local DOCKER_BUILD_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP  --label=com.dokku.image-stage=release --label=dokku"
 
+  local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
   plugn trigger pre-release-builder "$BUILDER_TYPE" "$APP" "$IMAGE"
 
   TMP_WORK_DIR="$(mktemp -d "/tmp/dokku-${DOKKU_PID}-${FUNCNAME[0]}.XXXXXX")"
   trap "rm -rf '$TMP_WORK_DIR' >/dev/null" RETURN INT TERM EXIT
 
-  local IMAGE=$(get_app_image_name "$APP" "$IMAGE_TAG")
+  local DOCKER_BUILD_LABEL_ARGS="--label=org.label-schema.schema-version=1.0 --label=org.label-schema.vendor=dokku --label=com.dokku.app-name=$APP  --label=com.dokku.image-stage=release --label=dokku"
   if ! suppress_output "$DOCKER_BIN" image build "${DOCKER_BUILD_LABEL_ARGS[@]}" $DOKKU_GLOBAL_BUILD_ARGS -f "$PLUGIN_AVAILABLE_PATH/builder-nixpacks/dockerfiles/builder-release.Dockerfile" --build-arg APP_IMAGE="$IMAGE" -t "$IMAGE" "$TMP_WORK_DIR"; then
     dokku_log_warn "Failure injecting docker labels on image"
     return 1

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -203,6 +203,17 @@ dokku_container_log_verbose_quiet() {
   IFS=$OIFS
 }
 
+fn-force-arm64-image() {
+  declare IMAGE="$1"
+  local image_architecture="$("$DOCKER_BIN" image inspect --format '{{.Architecture}}' "$IMAGE")"
+
+  if [[ "$image_architecture" == "amd64" ]] && [[ "$(dpkg --print-architecture 2>/dev/null || true)" != "amd64" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 fn-is-valid-app-name() {
   declare desc="verify that the app name matches naming restrictions"
   local APP="$1"


### PR DESCRIPTION
Images would build but then fail to be tagged, causing deployment problems on arm64 architectures for a small number of images.

Also fix a minor issue in the nixpacks builder that caused any pre-release-builder triggers that consumed the image to get an empty string instead.