### PR TITLE
Wait until helm charts are installed before marking a deploy as failed or completed

### DIFF
--- a/plugins/scheduler-k3s/functions.go
+++ b/plugins/scheduler-k3s/functions.go
@@ -226,6 +226,7 @@ func applyKedaClusterTriggerAuthentications(ctx context.Context, triggerType str
 		ReleaseName:       fmt.Sprintf("keda-cluster-trigger-authentications-%s", triggerType),
 		RollbackOnFailure: true,
 		Timeout:           timeoutDuration,
+		Wait:              true,
 	})
 	if err != nil {
 		return fmt.Errorf("Error installing keda-cluster-trigger-authentications-%s chart: %w", triggerType, err)
@@ -333,6 +334,7 @@ func applyClusterIssuers(ctx context.Context) error {
 		ReleaseName:       "cluster-issuers",
 		RollbackOnFailure: true,
 		Timeout:           timeoutDuration,
+		Wait:              true,
 	})
 	if err != nil {
 		return fmt.Errorf("Error installing cluster-issuer chart: %w", err)
@@ -1398,6 +1400,11 @@ func installHelmCharts(ctx context.Context, clientset KubernetesClient, shouldIn
 			return fmt.Errorf("Error creating helm agent: %w", err)
 		}
 
+		timeoutDuration, err := time.ParseDuration("300s")
+		if err != nil {
+			return fmt.Errorf("Error parsing deploy timeout duration: %w", err)
+		}
+
 		err = helmAgent.InstallOrUpgradeChart(ctx, ChartInput{
 			ChartPath:   chart.ChartPath,
 			Namespace:   chart.Namespace,
@@ -1405,6 +1412,8 @@ func installHelmCharts(ctx context.Context, clientset KubernetesClient, shouldIn
 			RepoURL:     chart.RepoURL,
 			Values:      values,
 			Version:     chart.Version,
+			Timeout:     timeoutDuration,
+			Wait:        true,
 		})
 		if err != nil {
 			return fmt.Errorf("Error installing chart %s: %w", chart.ChartPath, err)

--- a/plugins/scheduler-k3s/helm.go
+++ b/plugins/scheduler-k3s/helm.go
@@ -51,6 +51,7 @@ type ChartInput struct {
 	RepoURL           string
 	RollbackOnFailure bool
 	Timeout           time.Duration
+	Wait              bool
 	Version           string
 	Values            map[string]interface{}
 }
@@ -239,7 +240,7 @@ func (h *HelmAgent) InstallChart(ctx context.Context, input ChartInput) error {
 	client.Namespace = namespace
 	client.ReleaseName = input.ReleaseName
 	client.Timeout = input.Timeout
-	client.Wait = false
+	client.Wait = input.Wait
 
 	settings := cli.New()
 	if input.RepoURL != "" {
@@ -314,7 +315,7 @@ func (h *HelmAgent) UpgradeChart(ctx context.Context, input ChartInput) error {
 	client.MaxHistory = 10
 	client.Namespace = namespace
 	client.Timeout = input.Timeout
-	client.Wait = false
+	client.Wait = input.Wait
 	if input.RepoURL != "" {
 		client.RepoURL = input.RepoURL
 	}

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -594,6 +594,7 @@ func TriggerSchedulerDeploy(scheduler string, appName string, imageTag string) e
 		ReleaseName:       appName,
 		RollbackOnFailure: allowRollbacks,
 		Timeout:           timeoutDuration,
+		Wait:              true,
 	})
 	if err != nil {
 		return err

--- a/tests/unit/scheduler-k3s-2.bats
+++ b/tests/unit/scheduler-k3s-2.bats
@@ -44,11 +44,6 @@ teardown_() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "sleep 20"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
   assert_http_localhost_response "http" "$TEST_APP.dokku.me" "80" "" "python/http.server"
 
   # include autoscaling tests
@@ -128,11 +123,6 @@ teardown_() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "sleep 20"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
   assert_http_localhost_response "http" "$TEST_APP.dokku.me" "80" "" "python/http.server"
 
   run /bin/bash -c "kubectl get pods -o=jsonpath='{.items[*]..resources.requests.cpu}'"
@@ -178,11 +168,6 @@ teardown_() {
   assert_success
 
   run /bin/bash -c "dokku git:sync --build $TEST_APP https://github.com/dokku/smoke-test-app.git"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "sleep 20"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -233,11 +218,6 @@ teardown_() {
   assert_success
 
   run /bin/bash -c "dokku git:sync --build $TEST_APP https://github.com/dokku/smoke-test-app.git"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "sleep 20"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -668,8 +668,6 @@ install_k3s() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-
-  sleep 20
 }
 
 uninstall_k3s() {


### PR DESCRIPTION
This ensures applications are actually up vs giving a false sense of security to users about the state of their applications.