### PR TITLE
Remove traefik priority functionality

### DIFF
--- a/docs/networking/proxies/traefik.md
+++ b/docs/networking/proxies/traefik.md
@@ -116,16 +116,6 @@ dokku traefik:set --global log-level DEBUG
 
 After modifying, the Traefik container will need to be restarted.
 
-### Setting rule priority
-
-By default, app deployments will result in the newer traefik rules using a higher priority in order to have any newer rules respected by Traefik. Rule priorities will always increase according to the current unix timestamp. The priority may be fixed by setting the app-level `priority` property:
-
-```shell
-dokku traefik:set node-js-app priority 12345
-```
-
-After modifying, the app container will need to be recreated via a `ps:rebuild` or an app deployment.
-
 ### SSL Configuration
 
 The traefik plugin only supports automatic ssl certificates from it's letsencrypt integration. Managed certificates provided by the `certs` plugin are ignored.

--- a/plugins/traefik-vhosts/command-functions
+++ b/plugins/traefik-vhosts/command-functions
@@ -44,7 +44,6 @@ cmd-traefik-report-single() {
     "--traefik-letsencrypt-email: $(fn-traefik-letsencrypt-email)"
     "--traefik-letsencrypt-server: $(fn-traefik-letsencrypt-server)"
     "--traefik-log-level: $(fn-traefik-log-level)"
-    "--traefik-priority: $(fn-traefik-priority "$APP")"
   )
 
   if [[ -z "$INFO_FLAG" ]]; then

--- a/plugins/traefik-vhosts/docker-args-process-deploy
+++ b/plugins/traefik-vhosts/docker-args-process-deploy
@@ -8,7 +8,7 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
   declare desc="nginx-vhosts core-post-deploy plugin trigger"
   declare trigger="docker-args-process-deploy"
   declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3" PROC_TYPE="$4" CONTAINER_INDEX="$5"
-  local app_domains is_app_listening letsencrypt_email output proxy_container_port proxy_host_port port_map priority proxy_scheme proxy_schemes traefik_domains
+  local app_domains is_app_listening letsencrypt_email output proxy_container_port proxy_host_port port_map proxy_scheme proxy_schemes traefik_domains
   local proxy_container_http_port proxy_container_http_port_candidate proxy_host_http_port_candidate
   local proxy_container_https_port proxy_container_https_port_candidate proxy_host_https_port_candidate
   local STDIN=$(cat)
@@ -87,11 +87,6 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
       traefik_domains="${traefik_domains// /\\\`,\\\`}"
     fi
 
-    priority="$(fn-traefik-priority "$APP")"
-    if [[ -z "$priority" ]]; then
-      priority="$(date +%s)"
-    fi
-
     output="--label traefik.enable=true"
     if [[ -n "$proxy_container_http_port" ]] || [[ -n "$proxy_container_http_port_candidate" ]]; then
       if [[ -z "$proxy_container_http_port" ]]; then
@@ -102,7 +97,6 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
 
       output="$output --label traefik.http.services.$APP-$PROC_TYPE-http.loadbalancer.server.port=$proxy_container_http_port"
       output="$output --label traefik.http.routers.$APP-$PROC_TYPE-http.entrypoints=http"
-      output="$output --label traefik.http.routers.$APP-$PROC_TYPE-http.priority=$priority"
       output="$output --label traefik.http.routers.$APP-$PROC_TYPE-http.service=$APP-$PROC_TYPE-http"
       if [[ -n "$traefik_domains" ]]; then
         output="$output --label \"traefik.http.routers.$APP-$PROC_TYPE-http.rule=Host(\\\`$traefik_domains\\\`)\""
@@ -118,7 +112,6 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
 
       output="$output --label traefik.http.services.$APP-$PROC_TYPE-https.loadbalancer.server.port=$proxy_container_https_port"
       output="$output --label traefik.http.routers.$APP-$PROC_TYPE-https.entrypoints=https"
-      output="$output --label traefik.http.routers.$APP-$PROC_TYPE-https.priority=$priority"
       output="$output --label traefik.http.routers.$APP-$PROC_TYPE-https.service=$APP-$PROC_TYPE-https"
       output="$output --label traefik.http.routers.$APP-$PROC_TYPE-https.tls.certresolver=leresolver"
       if [[ -n "$traefik_domains" ]]; then

--- a/plugins/traefik-vhosts/internal-functions
+++ b/plugins/traefik-vhosts/internal-functions
@@ -92,8 +92,3 @@ fn-traefik-log-level() {
   log_level="$(fn-plugin-property-get-default "traefik" "--global" "log-level" "ERROR")"
   echo "${log_level^^}"
 }
-
-fn-traefik-priority() {
-  declare APP="$1"
-  fn-plugin-property-get-default "traefik" "$APP" "priority" ""
-}

--- a/plugins/traefik-vhosts/subcommands/set
+++ b/plugins/traefik-vhosts/subcommands/set
@@ -9,13 +9,13 @@ cmd-traefik-set() {
   declare cmd="traefik:set"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("api-enabled" "api-vhost" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "image" "letsencrypt-email" "letsencrypt-server" "log-level" "priority")
+  local VALID_KEYS=("api-enabled" "api-vhost" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "image" "letsencrypt-email" "letsencrypt-server" "log-level")
   local GLOBAL_KEYS=("api-enabled" "api-vhost" "dashboard"-enabled "basic-auth-username" "basic-auth-password" "image" "letsencrypt-email" "letsencrypt-server" "log-level")
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then
-    dokku_log_fail "Invalid key specified, valid keys include: api-enabled api-vhost dashboard-enabled basic-auth-username basic-auth-password image letsencrypt-email letsencrypt-server log-level priority"
+    dokku_log_fail "Invalid key specified, valid keys include: api-enabled api-vhost dashboard-enabled basic-auth-username basic-auth-password image letsencrypt-email letsencrypt-server log-level"
   fi
 
   if ! fn-in-array "$KEY" "${GLOBAL_KEYS[@]}"; then

--- a/tests/unit/traefik.bats
+++ b/tests/unit/traefik.bats
@@ -140,34 +140,6 @@ teardown() {
   assert_success
 }
 
-@test "(traefik) traefik:set priority" {
-  run /bin/bash -c "dokku proxy:set $TEST_APP traefik"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "dokku traefik:set $TEST_APP priority 12345"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run deploy_app
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "docker inspect $TEST_APP.web.1 --format '{{ index .Config.Labels \"traefik.http.services.$TEST_APP-web-http.loadbalancer.server.port\" }}'"
-  echo "output: $output"
-  echo "status: $status"
-  assert_output "5000"
-
-  run /bin/bash -c "docker inspect $TEST_APP.web.1 --format '{{ index .Config.Labels \"traefik.http.routers.$TEST_APP-web-http.priority\" }}'"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-  assert_output "12345"
-}
-
 @test "(traefik) ssl" {
   run /bin/bash -c "dokku builder-herokuish:set $TEST_APP allowed true"
   echo "output: $output"


### PR DESCRIPTION
Setting a priority appears to cause minor outages in certain cases, so we should just avoid setting it on behalf of users and allow them to set this directly.