### PR TITLE
Use copytruncate in logrotate commands

### DIFF
--- a/plugins/20_events/install
+++ b/plugins/20_events/install
@@ -16,24 +16,24 @@ trigger-events-install() {
   # exits gracefully if the path already exists
   mkdir -m 775 -p "$DOKKU_LOGS_DIR"
   case "$DOKKU_DISTRO" in
-    arch | debian | raspbian)
-      chgrp dokku "$DOKKU_LOGS_DIR"
-      ;;
-    *)
-      chown syslog:dokku "$DOKKU_LOGS_DIR"
-      ;;
+  arch | debian | raspbian)
+    chgrp dokku "$DOKKU_LOGS_DIR"
+    ;;
+  *)
+    chown syslog:dokku "$DOKKU_LOGS_DIR"
+    ;;
   esac
 
   if [[ ! -f "$DOKKU_EVENTS_LOGFILE" ]]; then
     touch "$DOKKU_EVENTS_LOGFILE"
     case "$DOKKU_DISTRO" in
-      arch | debian | raspbian)
-        chgrp dokku "$DOKKU_EVENTS_LOGFILE"
-        ;;
-      *)
-        # chown syslog:root might not work on SUSE
-        chown syslog:dokku "$DOKKU_EVENTS_LOGFILE"
-        ;;
+    arch | debian | raspbian)
+      chgrp dokku "$DOKKU_EVENTS_LOGFILE"
+      ;;
+    *)
+      # chown syslog:root might not work on SUSE
+      chown syslog:dokku "$DOKKU_EVENTS_LOGFILE"
+      ;;
     esac
     chmod 664 "$DOKKU_EVENTS_LOGFILE"
   fi
@@ -56,16 +56,12 @@ EOF
     cat >"$DOKKU_LOGROTATE_FILE" <<EOF
 $DOKKU_LOGS_DIR/*.log {
         daily
-        rotate 7
         missingok
-        notifempty
-        su syslog dokku
+        rotate 7
         compress
         delaycompress
-        postrotate
-                reload rsyslog &>/dev/null || true
-        endscript
-        create 664 syslog dokku
+        notifempty
+        copytruncate
 }
 EOF
 

--- a/plugins/20_events/install
+++ b/plugins/20_events/install
@@ -16,24 +16,24 @@ trigger-events-install() {
   # exits gracefully if the path already exists
   mkdir -m 775 -p "$DOKKU_LOGS_DIR"
   case "$DOKKU_DISTRO" in
-  arch | debian | raspbian)
-    chgrp dokku "$DOKKU_LOGS_DIR"
-    ;;
-  *)
-    chown syslog:dokku "$DOKKU_LOGS_DIR"
-    ;;
+    arch | debian | raspbian)
+      chgrp dokku "$DOKKU_LOGS_DIR"
+      ;;
+    *)
+      chown syslog:dokku "$DOKKU_LOGS_DIR"
+      ;;
   esac
 
   if [[ ! -f "$DOKKU_EVENTS_LOGFILE" ]]; then
     touch "$DOKKU_EVENTS_LOGFILE"
     case "$DOKKU_DISTRO" in
-    arch | debian | raspbian)
-      chgrp dokku "$DOKKU_EVENTS_LOGFILE"
-      ;;
-    *)
-      # chown syslog:root might not work on SUSE
-      chown syslog:dokku "$DOKKU_EVENTS_LOGFILE"
-      ;;
+      arch | debian | raspbian)
+        chgrp dokku "$DOKKU_EVENTS_LOGFILE"
+        ;;
+      *)
+        # chown syslog:root might not work on SUSE
+        chown syslog:dokku "$DOKKU_EVENTS_LOGFILE"
+        ;;
     esac
     chmod 664 "$DOKKU_EVENTS_LOGFILE"
   fi


### PR DESCRIPTION
While using create is more correct, logs in Dokku are considered ephemeral, and thus shouldn't be considered subject to the more comprehensive log retention standards one might require out of a logging system.

By switching to copytruncate, we can ensure that logs mounted from within containers do not have that matched the old settings and cases where the log file is written by a user other than the one specified in the old logrotate settings.

Closes #6633
Closes #4000