### PR TITLE
Add a make target to copy the dokku binary over

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,12 @@ go-clean:
 		fi ;\
 	done
 
-copyfiles:
-	$(MAKE) go-build || exit 1
+copydokku:
 	cp dokku /usr/local/bin/dokku
+	chmod 0755 /usr/local/bin/dokku
+
+copyfiles: copydokku
+	$(MAKE) go-build || exit 1
 	mkdir -p ${CORE_PLUGINS_PATH} ${PLUGINS_PATH}
 	rm -rf ${CORE_PLUGINS_PATH}/*
 	test -d ${CORE_PLUGINS_PATH}/enabled || PLUGIN_PATH=${CORE_PLUGINS_PATH} plugn init


### PR DESCRIPTION
This is helpful when in local development. While rare, sometimes the dokku binary needs to have some changes applied.