### PR TITLE
Dereference annotated git tags when deploying via git:sync

### DIFF
--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -457,7 +457,7 @@ fn-git-fetch() {
     GIT_TERMINAL_PROMPT=0 fn-git-cmd "$APP_ROOT" fetch --update-head-ok remote "$DOKKU_DEPLOY_BRANCH"
   else
     GIT_TERMINAL_PROMPT=0 fn-git-cmd "$APP_ROOT" fetch --update-head-ok remote
-    fn-git-cmd "$APP_ROOT" update-ref "refs/heads/$DOKKU_DEPLOY_BRANCH" "$GIT_REF"
+    fn-git-cmd "$APP_ROOT" update-ref "refs/heads/$DOKKU_DEPLOY_BRANCH" "$GIT_REF^{commit}"
   fi
 
   fn-git-cmd "$APP_ROOT" config --add core.bare true

--- a/tests/unit/git_3.bats
+++ b/tests/unit/git_3.bats
@@ -378,6 +378,30 @@ teardown() {
   assert_output_contains "$SMOKE_TEST_APP_2_0_0_SHA"
 }
 
+@test "(git) git:sync existing [--no-build annotated-tag]" {
+  run /bin/bash -c "dokku git:sync $TEST_APP https://github.com/dokku/smoke-test-app.git 1.0.0"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "cat /home/dokku/$TEST_APP/refs/heads/master"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "$SMOKE_TEST_APP_1_0_0_SHA"
+
+  run /bin/bash -c "dokku git:sync $TEST_APP https://github.com/dokku/smoke-test-app.git 2.0.0-annotated"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "cat /home/dokku/$TEST_APP/refs/heads/master"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "$SMOKE_TEST_APP_2_0_0_SHA"
+}
+
 @test "(git) git:sync existing [--no-build commit]" {
   run /bin/bash -c "dokku git:sync $TEST_APP https://github.com/dokku/smoke-test-app.git 1.0.0"
   echo "output: $output"


### PR DESCRIPTION
`refs/heads/master` cannot be updated to an annotated tag per se; the rev given must first be resolved to a commit. `^{commit}` recursively dereferences the rev until a commit is found.

Resolves #6737 and test failure:

```console
# bats --filter 'annotated-tag' 'tests/unit/git_3.bats'
git_3.bats
 ✗ (git) git:sync existing [--no-build annotated-tag]
   fatal: update_ref failed for ref 'refs/heads/master': cannot update ref 'refs/heads/master': trying to write non-commit object 6399bed673f513332f3d5d99e777e0262f42404c to branch 'refs/heads/master'
```
