### PR TITLE
Migrate away from transitional packages

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -168,10 +168,6 @@ install-dokku-from-deb-package() {
     NO_INSTALL_RECOMMENDS=" --no-install-recommends "
   fi
 
-  echo "--> Initial apt-get update"
-  apt-get update -qq >/dev/null
-  apt-get -qq -y --no-install-recommends install apt-transport-https
-
   if ! command -v docker &>/dev/null; then
     echo "--> Installing docker"
     if uname -r | grep -q linode; then

--- a/contrib/images/digitalocean/in_parts/011-docker
+++ b/contrib/images/digitalocean/in_parts/011-docker
@@ -4,8 +4,7 @@ set -o errexit
 
 export DEBIAN_FRONTEND=noninteractive
 
-pkgs=(apt-transport-https
-  ca-certificates
+pkgs=(ca-certificates
   curl
   jq
   linux-image-extra-virtual

--- a/contrib/images/digitalocean/in_parts/012-dokku-packages
+++ b/contrib/images/digitalocean/in_parts/012-dokku-packages
@@ -24,7 +24,7 @@ pkgs=(apache2-utils
   unzip
 
   nginx
-  dnsutils
+  bind9-dnsutils
   cgroupfs-mount
   cgroup-lite
   sudo

--- a/deb.mk
+++ b/deb.mk
@@ -11,10 +11,6 @@ endif
 .PHONY: install-from-deb deb-all deb-dokku deb-setup
 
 install-from-deb:
-	@echo "--> Initial apt-get update"
-	sudo apt-get update -qq >/dev/null
-	sudo apt-get -qq -y --no-install-recommends install apt-transport-https
-
 	@echo "--> Installing docker"
 	wget -nv -O - https://get.docker.com/ | sh
 

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 Architecture: amd64
 Depends: apache2-utils, locales, git, cpio, curl, man-db, netcat, sshcommand, docker-engine-cs (>= 17.05.0) | docker-engine (>= 17.05.0) | docker-io (>= 17.05.0) | docker.io (>= 17.05.0) | docker-ce (>= 17.05.0) | docker-ee (>= 17.05.0) | moby-engine, docker-compose-plugin | moby-compose, docker-buildx-plugin | moby-buildx, docker-container-healthchecker, docker-image-labeler, lambda-builder, net-tools, netrc, parallel, procfile-util, rsync, rsyslog, dos2unix, jq, unzip, util-linux
 Recommends: herokuish, bash-completion, dokku-update, dokku-event-listener
-Pre-Depends: gliderlabs-sigil, nginx (>= 1.8.0) | openresty, dnsutils, cgroupfs-mount | cgroup-lite, plugn, sudo, python3, debconf
+Pre-Depends: gliderlabs-sigil, nginx (>= 1.8.0) | openresty, bind9-dnsutils, cgroupfs-mount | cgroup-lite, plugn, sudo, python3, debconf
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 Description: Docker-powered PaaS that helps build and manage the lifecycle of applications
  Dokku is an extensible, open source Platform as a Service

--- a/docs/getting-started/install/debian.md
+++ b/docs/getting-started/install/debian.md
@@ -3,10 +3,6 @@
 As of 0.3.18, Dokku defaults to being installed via Debian package. While certain hosts may require extra work to get running, you may optionally wish to automate the installation of Dokku without the use of our `bootstrap.sh` Bash script. The following are the steps run by said script:
 
 ```shell
-# install prerequisites
-sudo apt-get update -qq >/dev/null
-sudo apt-get -qq -y --no-install-recommends install apt-transport-https
-
 # install docker
 wget -nv -O - https://get.docker.com/ | sh
 

--- a/plugins/nginx-vhosts/dependencies
+++ b/plugins/nginx-vhosts/dependencies
@@ -2,29 +2,11 @@
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 
-nginx_install() {
-  declare desc="install nginx and dnsutils"
-  export DEBIAN_FRONTEND=noninteractive
-  apt-get -qq -y --no-install-recommends install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" nginx dnsutils
-}
-
 trigger-nginx-vhosts-dependencies() {
   declare desc="installs dependencies for the nginx-vhosts plugin"
   declare trigger="dependencies"
 
   case "$DOKKU_DISTRO" in
-    debian | raspbian)
-      nginx_install
-      ;;
-
-    ubuntu)
-      if command -v nginx &>/dev/null; then
-        return
-      fi
-
-      nginx_install
-      ;;
-
     arch)
       pacman -S --noconfirm --noprogressbar --needed nginx bind-tools
       ;;


### PR DESCRIPTION
Several of the packages being installed were actually transitional packages, that is, the package itself is either a complete no-op (since the package is already installed), or else the package only exists to depend on another package of a new name (to support people who are running older operating systems).

For the former, we can drop the dependency entirely, and for the latter we should use the new package name directly.