### PR TITLE
fix: using correct path for `docker-container-healthchecker`

### DIFF
--- a/plugins/scheduler-docker-local/check-deploy
+++ b/plugins/scheduler-docker-local/check-deploy
@@ -153,7 +153,7 @@ trigger-scheduler-docker-local-check-deploy() {
     echo "$content" >"$TMP_APP_JSON_OUTPUT"
   fi
 
-  sudo /usr/bin/docker-container-healthchecker check "$DOKKU_APP_CONTAINER_ID" "${ARG_ARRAY[@]}" || FAILEDCHECKS="$?"
+  sudo $(which docker-container-healthchecker) check "$DOKKU_APP_CONTAINER_ID" "${ARG_ARRAY[@]}" || FAILEDCHECKS="$?"
 
   if [[ $FAILEDCHECKS -gt 0 ]]; then
     "$DOCKER_BIN" container update --restart=no "$DOKKU_APP_CONTAINER_ID" &>/dev/null || true


### PR DESCRIPTION
First of all, `dokku` is fantastic 💯 .

I had this error:
```bash
remote: sudo: /usr/bin/docker-container-healthchecker: command not found
```

Which I think is due to:
It is installed via the Makefile https://github.com/dokku/dokku/blob/e2d51bfeb308c01fa3a2ec912cde30d98058bee7/Makefile#L163 in `/usr/local/bin/docker-container-healthchecker` although it is here called directly with `/usr/bin/docker-container-healthchecker`.
But I could also be wrong :-)

Here is a quick fix if someone else has the same issue:

```bash
cp /usr/local/bin/docker-container-healthchecker /usr/bin/docker-container-healthchecker
```