### PR TITLE
Use a long git sha in the git:report output

### DIFF
--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -295,7 +295,7 @@ cmd-git-report-single() {
     "--git-global-deploy-branch: $(fn-plugin-property-get "git" "--global" "deploy-branch" "master")"
     "--git-keep-git-dir: $(fn-plugin-property-get "git" "$APP" "keep-git-dir" "false")"
     "--git-rev-env-var: $(fn-plugin-property-get "git" "$APP" "rev-env-var" "GIT_REV")"
-    "--git-sha: $(fn-git-cmd "$APP_ROOT" rev-parse --short HEAD 2>/dev/null || false)"
+    "--git-sha: $(fn-git-cmd "$APP_ROOT" rev-parse HEAD 2>/dev/null || false)"
     "--git-source-image: $(fn-git-source-image "$APP")"
     "--git-last-updated-at: $(fn-git-last-updated-at "$APP")"
   )


### PR DESCRIPTION
The previous method sometimes truncated the sha, depending on how the app was deployed. Using the long sha will ensure that the value is stable, regardless of the deployment method.

Closes #6770