### PR TITLE
Popd out of tmp directory after a git push-based deployment

### DIFF
--- a/plugins/git/functions
+++ b/plugins/git/functions
@@ -15,7 +15,7 @@ git_build_app_repo() {
 
   # clean up after ourselves
   local GIT_BUILD_APP_REPO_TMP_WORK_DIR=$(mktemp -d "/tmp/dokku-${DOKKU_PID}-${FUNCNAME[0]}.XXXXXX")
-  trap "rm -rf '$GIT_BUILD_APP_REPO_TMP_WORK_DIR' >/dev/null" RETURN INT TERM EXIT
+  trap "popd &>/dev/null || true; rm -rf '$GIT_BUILD_APP_REPO_TMP_WORK_DIR' >/dev/null" RETURN INT TERM EXIT
 
   chmod 755 "$GIT_BUILD_APP_REPO_TMP_WORK_DIR"
   unset GIT_DIR GIT_QUARANTINE_PATH GIT_WORK_TREE

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process
@@ -86,10 +86,11 @@ fn-scheduler-deploy-process() {
     local CONTAINER_IDX_OFFSET=$((PROC_COUNT + 1))
   fi
   local container_state_filetype
+  pushd "$DOKKU_ROOT/$APP" >/dev/null
   for container_state_filetype in CONTAINER IP PORT; do
-    cd "$DOKKU_ROOT/$APP"
     find . -maxdepth 1 -name "$container_state_filetype.$PROC_TYPE.*" -printf "%f\n" | sort -t . -k 3 -n | tail -n +$CONTAINER_IDX_OFFSET | xargs rm -f
   done
+  popd &>/dev/null || pushd "/tmp" >/dev/null
 }
 
 main() {


### PR DESCRIPTION
Without this, we end up with PWD issues as the tmp directory is removed automatically after a build.

Closes #6771