### PR TITLE
Remove --restart docker arguments when not running deploy-phase containers

### DIFF
--- a/plugins/docker-options/docker-args-deploy
+++ b/plugins/docker-options/docker-args-deploy
@@ -37,6 +37,14 @@ trigger-docker-options-docker-args() {
         \#*)
           continue
           ;;
+
+        --restart*)
+          if [[ "$PHASE" == "deploy" ]]; then
+            local output="$output $line"
+          fi
+          continue
+          ;;
+
         *)
           case "$IMAGE_SOURCE_TYPE" in
             dockerfile | nixpacks)


### PR DESCRIPTION
This works around cases where developers may inadvertently add this to `run` containers which _should not_ have the `--restart` flag. Run containers are one-off, and if they fail, then they should fail hard.

Refs #6783