### PR TITLE
Fix typos in nginx documentation

### DIFF
--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -324,9 +324,9 @@ Changing these value globally or on a per-app basis will require rebuilding the 
 | proxy-busy-buffers-size   | `16k`                                 | string  | Limits the total size of buffers that can be busy sending a response to the client while the response is not yet fully read. |
 | proxy-read-timeout        | `60s`                                 | string  | Timeout (with units) for reading response from your backend server                  |
 | underscore-in-headers     | `off`                                 | string  | Enables or disables the use of underscores in client request header fields.         |
-| x-forwarded-for-value     | `$remote_addr`                        | string  | Used for specifying the header value to set for the `X-Forwared-For` header         |
-| x-forwarded-port-value    | `$server_port`                        | string  | Used for specifying the header value to set for the `X-Forwared-Port` header        |
-| x-forwarded-proto-value   | `$scheme`                             | string  | Used for specifying the header value to set for the `X-Forwared-Proto` header       |
+| x-forwarded-for-value     | `$remote_addr`                        | string  | Used for specifying the header value to set for the `X-Forwarded-For` header         |
+| x-forwarded-port-value    | `$server_port`                        | string  | Used for specifying the header value to set for the `X-Forwarded-Port` header        |
+| x-forwarded-proto-value   | `$scheme`                             | string  | Used for specifying the header value to set for the `X-Forwarded-Proto` header       |
 | x-forwarded-ssl           | empty string                          | string  | Less commonly used alternative to `X-Forwarded-Proto` (valid values: `on` or `off`) |
 
 #### Binding to specific addresses


### PR DESCRIPTION
in the docs.  no security or IP implications, just a typo.