### PR TITLE
Guard against invalid proxy values due to move of port mapping to ports plugin

### DIFF
--- a/plugins/proxy/subcommands.go
+++ b/plugins/proxy/subcommands.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
 	"github.com/dokku/dokku/plugins/config"
@@ -87,6 +88,11 @@ func CommandSet(appName string, proxyType string) error {
 
 	if len(proxyType) < 2 {
 		return errors.New("Please specify a proxy type")
+	}
+
+	if strings.Contains(proxyType, ":") {
+		common.LogWarn("Detected potential port mapping instead of proxy type")
+		return errors.New("Consider using ports:set command or specifying a valid proxy")
 	}
 
 	key := "DOKKU_APP_PROXY_TYPE"

--- a/tests/unit/proxy.bats
+++ b/tests/unit/proxy.bats
@@ -28,6 +28,14 @@ teardown() {
   assert_output "$help_output"
 }
 
+@test "(proxy:set) invalid port mapping set" {
+  run /bin/bash -c "dokku proxy:set $TEST_APP http:80:80"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Detected potential port mapping instead of proxy type"
+}
+
 @test "(proxy) proxy:build-config/clear-config" {
   run deploy_app
   echo "output: $output"


### PR DESCRIPTION
Users somewhat infrequently set a port mapping as the proxy type, causing issues in exposing apps publicly. Ideally we list out the available proxy types, but that would be a potential bc-break for non-core plugins, so this is the way to go for now.

Closes #6764