### PR TITLE
Traefik optional custom http https entrypoints

### DIFF
--- a/docs/networking/proxies/traefik.md
+++ b/docs/networking/proxies/traefik.md
@@ -67,6 +67,17 @@ dokku traefik:stop
 
 The Traefik container will be stopped and removed from the system. If the container is not running, this command will do nothing.
 
+### Changing the Traefik entrypoint names
+
+When you use a self-hosted Traefik instance, your entrypoint names might be different from the default `http` and `https`
+
+Use `traefik:set` to set both `http-entry-point` and `https-entry-point` to custom values
+
+```shell
+dokku traefik:set --global http-entry-point web
+dokku traefik:set --global https-entry-point websecure
+```
+
 ### Showing the Traefik compose config
 
 For debugging purposes, it may be useful to show the Traefik compose config. This can be achieved via the `traefik:show-config` command.

--- a/plugins/traefik-vhosts/command-functions
+++ b/plugins/traefik-vhosts/command-functions
@@ -44,6 +44,8 @@ cmd-traefik-report-single() {
     "--traefik-letsencrypt-email: $(fn-traefik-letsencrypt-email)"
     "--traefik-letsencrypt-server: $(fn-traefik-letsencrypt-server)"
     "--traefik-log-level: $(fn-traefik-log-level)"
+    "--traefik-http-entry-point: $(fn-traefik-http-entry-point)"
+    "--traefik-https-entry-point: $(fn-traefik-https-entry-point)"
   )
 
   if [[ -z "$INFO_FLAG" ]]; then

--- a/plugins/traefik-vhosts/docker-args-process-deploy
+++ b/plugins/traefik-vhosts/docker-args-process-deploy
@@ -7,7 +7,7 @@ set -eo pipefail
 trigger-traefik-vhosts-docker-args-process-deploy() {
   declare desc="nginx-vhosts core-post-deploy plugin trigger"
   declare trigger="docker-args-process-deploy"
-  declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3" PROC_TYPE="$4" CONTAINER_INDEX="$5" HTTP_ENTRY_POINT="$6" HTTPS_ENTRY_POINT="$7"
+  declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3" PROC_TYPE="$4" CONTAINER_INDEX="$5"
   local app_domains is_app_listening letsencrypt_email output proxy_container_port proxy_host_port port_map proxy_scheme proxy_schemes traefik_domains
   local proxy_container_http_port proxy_container_http_port_candidate proxy_host_http_port_candidate
   local proxy_container_https_port proxy_container_https_port_candidate proxy_host_https_port_candidate

--- a/plugins/traefik-vhosts/docker-args-process-deploy
+++ b/plugins/traefik-vhosts/docker-args-process-deploy
@@ -7,7 +7,7 @@ set -eo pipefail
 trigger-traefik-vhosts-docker-args-process-deploy() {
   declare desc="nginx-vhosts core-post-deploy plugin trigger"
   declare trigger="docker-args-process-deploy"
-  declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3" PROC_TYPE="$4" CONTAINER_INDEX="$5"
+  declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3" PROC_TYPE="$4" CONTAINER_INDEX="$5" HTTP_ENTRY_POINT="$6" HTTPS_ENTRY_POINT="$7"
   local app_domains is_app_listening letsencrypt_email output proxy_container_port proxy_host_port port_map proxy_scheme proxy_schemes traefik_domains
   local proxy_container_http_port proxy_container_http_port_candidate proxy_host_http_port_candidate
   local proxy_container_https_port proxy_container_https_port_candidate proxy_host_https_port_candidate
@@ -96,7 +96,7 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
       fi
 
       output="$output --label traefik.http.services.$APP-$PROC_TYPE-http.loadbalancer.server.port=$proxy_container_http_port"
-      output="$output --label traefik.http.routers.$APP-$PROC_TYPE-http.entrypoints=http"
+      output="$output --label traefik.http.routers.$APP-$PROC_TYPE-http.entrypoints=$(fn-traefik-http-entry-point)"
       output="$output --label traefik.http.routers.$APP-$PROC_TYPE-http.service=$APP-$PROC_TYPE-http"
       if [[ -n "$traefik_domains" ]]; then
         output="$output --label \"traefik.http.routers.$APP-$PROC_TYPE-http.rule=Host(\\\`$traefik_domains\\\`)\""
@@ -111,7 +111,7 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
       fi
 
       output="$output --label traefik.http.services.$APP-$PROC_TYPE-https.loadbalancer.server.port=$proxy_container_https_port"
-      output="$output --label traefik.http.routers.$APP-$PROC_TYPE-https.entrypoints=https"
+      output="$output --label traefik.http.routers.$APP-$PROC_TYPE-https.entrypoints=$(fn-traefik-https-entry-point)"
       output="$output --label traefik.http.routers.$APP-$PROC_TYPE-https.service=$APP-$PROC_TYPE-https"
       output="$output --label traefik.http.routers.$APP-$PROC_TYPE-https.tls.certresolver=leresolver"
       if [[ -n "$traefik_domains" ]]; then

--- a/plugins/traefik-vhosts/internal-functions
+++ b/plugins/traefik-vhosts/internal-functions
@@ -92,3 +92,11 @@ fn-traefik-log-level() {
   log_level="$(fn-plugin-property-get-default "traefik" "--global" "log-level" "ERROR")"
   echo "${log_level^^}"
 }
+
+fn-traefik-http-entry-point() {
+  fn-plugin-property-get-default "traefik" "--global" "http-entry-point" "http"
+}
+
+fn-traefik-https-entry-point() {
+  fn-plugin-property-get-default "traefik" "--global" "https-entry-point" "https"
+}

--- a/plugins/traefik-vhosts/subcommands/set
+++ b/plugins/traefik-vhosts/subcommands/set
@@ -9,8 +9,8 @@ cmd-traefik-set() {
   declare cmd="traefik:set"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("api-enabled" "api-vhost" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "image" "letsencrypt-email" "letsencrypt-server" "log-level")
-  local GLOBAL_KEYS=("api-enabled" "api-vhost" "dashboard"-enabled "basic-auth-username" "basic-auth-password" "image" "letsencrypt-email" "letsencrypt-server" "log-level")
+  local VALID_KEYS=("api-enabled" "api-vhost" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "image" "letsencrypt-email" "letsencrypt-server" "log-level" "http-entry-point" "https-entry-point")
+  local GLOBAL_KEYS=("api-enabled" "api-vhost" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "image" "letsencrypt-email" "letsencrypt-server" "log-level" "http-entry-point" "https-entry-point")
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 

--- a/tests/unit/traefik.bats
+++ b/tests/unit/traefik.bats
@@ -237,3 +237,65 @@ teardown() {
   assert_success
   assert_line '      - "traefik.http.routers.api.middlewares=auth"'
 }
+
+@test "(traefik) change traefik entry point http" {
+  run /bin/bash -c "dokku builder-herokuish:set $TEST_APP allowed true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku proxy:set $TEST_APP traefik"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:set --global http-entry-point web"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "docker inspect $TEST_APP.web.1 --format '{{ index .Config.Labels \"traefik.http.routers.$TEST_APP-web-http.entrypoints\" }}'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "web"
+
+}
+
+@test "(traefik) change traefik entry point https" {
+  run /bin/bash -c "dokku builder-herokuish:set $TEST_APP allowed true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku proxy:set $TEST_APP traefik"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:set --global letsencrypt-email test@example.com"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:set --global https-entry-point websecure"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "docker inspect $TEST_APP.web.1 --format '{{ index .Config.Labels \"traefik.http.routers.$TEST_APP-web-https.entrypoints\" }}'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "websecure"
+}


### PR DESCRIPTION
The code changes add the capability to configure custom HTTP and HTTPS entry points for the Traefik virtual hosts plugin. New settings have been added to the list of valid and global keys. Also, function definitions for retrieving default HTTP and HTTPS entry points were included in the internal functions file. Furthermore, the 'docker-args-process-deploy' script now considers the new entry points while processing deployment arguments.