### PR TITLE
Remove errant tab character in cron:set help text

### DIFF
--- a/plugins/cron/src/commands/commands.go
+++ b/plugins/cron/src/commands/commands.go
@@ -21,7 +21,7 @@ Additional commands:`
     cron:list <app> [--format json|stdout], List scheduled cron tasks for an app
     cron:report [<app>] [<flag>], Display report about an app
     cron:run <app> <cron_id> [--detach], Run a cron task on the fly
-	cron:set [--global|<app>] <key> <value>, Set or clear a cron property for an app`
+    cron:set [--global|<app>] <key> <value>, Set or clear a cron property for an app`
 )
 
 func main() {


### PR DESCRIPTION
Noticed it was showing up first and with odd indentation in the output of `dokku help --all`. Now it will be indented like the others.

<img width="1455" alt="image" src="https://github.com/dokku/dokku/assets/70472/a6ee2dc5-792b-45b1-8126-93afdab4e654">
