### PR TITLE
Add missing local RE_IPV4 & RE_IPV6 vars in core-post-deploy

### DIFF
--- a/plugins/domains/core-post-deploy
+++ b/plugins/domains/core-post-deploy
@@ -8,6 +8,8 @@ trigger-domains-core-post-deploy() {
   declare desc="domains core-post-deploy plugin trigger"
   declare trigger="core-post-deploy"
   declare APP="$1"
+  local RE_IPV4="$(get_ipv4_regex)"
+  local RE_IPV6="$(get_ipv6_regex)"
 
   if [[ "$(plugn trigger proxy-type "$APP")" != "nginx" ]]; then
     return


### PR DESCRIPTION
These local variables not being defined makes the regex empty, which makes dokku always print the warning.