### PR TITLE
Update all dependencies in the dokku ecosystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,43 +153,36 @@ man-db:
 	apt-get -qq -y --no-install-recommends install man-db
 
 docker-image-labeler:
-	wget -qO /tmp/docker-image-labeler_latest.tgz ${DOCKER_IMAGE_LABELER_URL}
-	tar xzf /tmp/docker-image-labeler_latest.tgz -C /usr/local/bin
-	mv /usr/local/bin/docker-image-labeler-${TARGETARCH} /usr/local/bin/docker-image-labeler
+	wget -qO /usr/local/bin/docker-image-labeler ${DOCKER_IMAGE_LABELER_URL}
+	chmod +x /usr/local/bin/docker-image-labeler
 
 docker-container-healthchecker:
-	wget -qO /tmp/docker-container-healthchecker_latest.tgz ${DOCKER_CONTAINER_HEALTHCHECKER_URL}
-	tar xzf /tmp/docker-container-healthchecker_latest.tgz -C /usr/local/bin
-	mv /usr/local/bin/docker-container-healthchecker-${TARGETARCH} /usr/local/bin/docker-container-healthchecker
+	wget -qO /usr/local/bin/docker-container-healthchecker ${DOCKER_CONTAINER_HEALTHCHECKER_URL}
+	chmod +x /usr/local/bin/docker-container-healthchecker
 
 lambda-builder:
-	wget -qO /tmp/lambda-builder_latest.tgz ${LAMBDA_BUILDER_URL}
-	tar xzf /tmp/lambda-builder_latest.tgz -C /usr/local/bin
-	mv /usr/local/bin/lambda-builder-${TARGETARCH} /usr/local/bin/lambda-builder
+	wget -qO /usr/local/bin/lambda-builder ${LAMBDA_BUILDER_URL}
+	chmod +x /usr/local/bin/lambda-builder
 
 netrc:
-	wget -qO /tmp/netrc_latest.tgz ${NETRC_URL}
-	tar xzf /tmp/netrc_latest.tgz -C /usr/local/bin
-	mv /usr/local/bin/netrc-${TARGETARCH} /usr/local/bin/netrc
+	wget -qO /usr/local/bin/netrc ${NETRC_URL}
+	chmod +x /usr/local/bin/netrc
 
 procfile-util:
-	wget -qO /tmp/procfile-util_latest.tgz ${PROCFILE_UTIL_URL}
-	tar xzf /tmp/procfile-util_latest.tgz -C /usr/local/bin
-	mv /usr/local/bin/procfile-util-${TARGETARCH} /usr/local/bin/procfile-util
+	wget -qO /usr/local/bin/procfile-util ${PROCFILE_UTIL_URL}
+	chmod +x /usr/local/bin/procfile-util
 
 plugn:
-	wget -qO /tmp/plugn_latest.tgz ${PLUGN_URL}
-	tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
-	mv /usr/local/bin/plugn-${TARGETARCH} /usr/local/bin/plugn
+	wget -qO /usr/local/bin/plugn ${PLUGN_URL}
+	chmod +x /usr/local/bin/plugn
 
 sigil:
-	wget -qO /tmp/sigil_latest.tgz ${SIGIL_URL}
-	tar xzf /tmp/sigil_latest.tgz -C /usr/local/bin
-	mv /usr/local/bin/gliderlabs-sigil-${TARGETARCH} /usr/local/bin/sigil
+	wget -qO /usr/local/bin/sigil ${SIGIL_URL}
+	chmod +x /usr/local/bin/sigil
 
 sshcommand:
-	wget -qO /tmp/sshcommand_latest.tgz ${SSHCOMMAND_URL}
-	tar xzf /tmp/sshcommand_latest.tgz -C /usr/local/bin
+	wget -qO /usr/local/bin/sshcommand ${SSHCOMMAND_URL}
+	chmod +x /usr/local/bin/sshcommand
 	sshcommand create dokku /usr/local/bin/dokku
 
 docker:

--- a/contrib/dependencies.json
+++ b/contrib/dependencies.json
@@ -1,97 +1,87 @@
 {
   "dependencies": [
     {
-      "name": "docker-image-labeler",
-      "version": "0.6.1",
+      "name": "docker-container-healthchecker",
+      "version": "0.10.2",
       "urls": {
-        "amd64": "https://github.com/dokku/docker-image-labeler/releases/download/v0.6.1/docker-image-labeler_0.6.1_linux_amd64.tgz",
-        "arm64": "https://github.com/dokku/docker-image-labeler/releases/download/v0.6.1/docker-image-labeler_0.6.1_linux_arm64.tgz",
-        "arm": "https://github.com/dokku/docker-image-labeler/releases/download/v0.6.1/docker-image-labeler_0.6.1_linux_armhf.tgz"
+        "amd64": "https://github.com/dokku/docker-container-healthchecker/releases/download/v0.10.2/docker-container-healthchecker-linux-amd64",
+        "arm64": "https://github.com/dokku/docker-container-healthchecker/releases/download/v0.10.2/docker-container-healthchecker-linux-arm64"
       }
     },
     {
-      "name": "docker-container-healthchecker",
-      "version": "0.9.0",
+      "name": "docker-image-labeler",
+      "version": "0.7.0",
       "urls": {
-        "amd64": "https://github.com/dokku/docker-container-healthchecker/releases/download/v0.9.0/docker-container-healthchecker_0.9.0_linux_amd64.tgz",
-        "arm64": "https://github.com/dokku/docker-container-healthchecker/releases/download/v0.9.0/docker-container-healthchecker_0.9.0_linux_arm64.tgz",
-        "arm": "https://github.com/dokku/docker-container-healthchecker/releases/download/v0.9.0/docker-container-healthchecker_0.9.0_linux_armhf.tgz"
+        "amd64": "https://github.com/dokku/docker-image-labeler/releases/download/v0.7.0/docker-image-labeler-linux-amd64",
+        "arm64": "https://github.com/dokku/docker-image-labeler/releases/download/v0.7.0/docker-image-labeler-linux-arm64"
       }
     },
     {
       "name": "lambda-builder",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "urls": {
-        "amd64": "https://github.com/dokku/lambda-builder/releases/download/v0.6.0/lambda-builder_0.6.0_linux_amd64.tgz",
-        "arm64": "https://github.com/dokku/lambda-builder/releases/download/v0.6.0/lambda-builder_0.6.0_linux_arm64.tgz",
-        "arm": "https://github.com/dokku/lambda-builder/releases/download/v0.6.0/lambda-builder_0.6.0_linux_armhf.tgz"
+        "amd64": "https://github.com/dokku/lambda-builder/releases/download/v0.7.0/lambda-builder-linux-amd64",
+        "arm64": "https://github.com/dokku/lambda-builder/releases/download/v0.7.0/lambda-builder-linux-arm64"
       }
     },
     {
       "name": "netrc",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "urls": {
-        "amd64": "https://github.com/dokku/netrc/releases/download/v0.8.0/netrc_0.8.0_linux_amd64.tgz",
-        "arm64": "https://github.com/dokku/netrc/releases/download/v0.8.0/netrc_0.8.0_linux_arm64.tgz",
-        "arm": "https://github.com/dokku/netrc/releases/download/v0.8.0/netrc_0.8.0_linux_armhf.tgz"
+        "amd64": "https://github.com/dokku/netrc/releases/download/v0.9.0/netrc-linux-amd64",
+        "arm64": "https://github.com/dokku/netrc/releases/download/v0.9.0/netrc-linux-arm64"
       }
     },
     {
       "name": "procfile-util",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "urls": {
-        "amd64": "https://github.com/dokku/procfile-util/releases/download/v0.17.1/procfile-util_0.17.1_linux_amd64.tgz",
-        "arm64": "https://github.com/dokku/procfile-util/releases/download/v0.17.1/procfile-util_0.17.1_linux_arm64.tgz",
-        "arm": "https://github.com/dokku/procfile-util/releases/download/v0.17.1/procfile-util_0.17.1_linux_armhf.tgz"
+        "amd64": "https://github.com/dokku/procfile-util/releases/download/v0.18.0/procfile-util-linux-amd64",
+        "arm64": "https://github.com/dokku/procfile-util/releases/download/v0.18.0/procfile-util-linux-arm64"
       }
     },
     {
       "name": "sshcommand",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "urls": {
-        "amd64": "https://github.com/dokku/sshcommand/releases/download/v0.17.1/sshcommand_0.17.1_linux_x86_64.tgz",
-        "arm64": "https://github.com/dokku/sshcommand/releases/download/v0.17.1/sshcommand_0.17.1_linux_x86_64.tgz",
-        "arm": "https://github.com/dokku/sshcommand/releases/download/v0.17.1/sshcommand_0.17.1_linux_x86_64.tgz"
+        "amd64": "https://github.com/dokku/sshcommand/releases/download/v0.18.0/sshcommand",
+        "arm64": "https://github.com/dokku/sshcommand/releases/download/v0.18.0/sshcommand"
       }
     }
   ],
   "predependencies": [
     {
       "name": "gliderlabs-sigil",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "urls": {
-        "amd64": "https://github.com/gliderlabs/sigil/releases/download/v0.10.1/gliderlabs-sigil_0.10.1_linux_amd64.tgz",
-        "arm64": "https://github.com/gliderlabs/sigil/releases/download/v0.10.1/gliderlabs-sigil_0.10.1_linux_arm64.tgz",
-        "arm": "https://github.com/gliderlabs/sigil/releases/download/v0.10.1/gliderlabs-sigil_0.10.1_linux_armhf.tgz"
+        "amd64": "https://github.com/gliderlabs/sigil/releases/download/v0.11.0/sigil-linux-amd64",
+        "arm64": "https://github.com/gliderlabs/sigil/releases/download/v0.11.0/sigil-linux-arm64"
       }
     },
     {
       "name": "plugn",
-      "version": "0.13.0",
+      "version": "0.15.3",
       "urls": {
-        "amd64": "https://github.com/dokku/plugn/releases/download/v0.13.0/plugn_0.13.0_linux_amd64.tgz",
-        "arm64": "https://github.com/dokku/plugn/releases/download/v0.13.0/plugn_0.13.0_linux_arm64.tgz",
-        "arm": "https://github.com/dokku/plugn/releases/download/v0.13.0/plugn_0.13.0_linux_armhf.tgz"
+        "amd64": "https://github.com/dokku/plugn/releases/download/v0.15.3/plugn-linux-amd64",
+        "arm64": "https://github.com/dokku/plugn/releases/download/v0.15.3/plugn-linux-arm64"
       }
     }
   ],
   "recommendations": [
     {
       "name": "dokku-event-listener",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "urls": {
-        "amd64": "https://github.com/dokku/dokku-event-listener/releases/download/v0.15.0/dokku-event-listener_0.15.0_linux_amd64.tgz",
-        "arm64": "https://github.com/dokku/dokku-event-listener/releases/download/v0.15.0/dokku-event-listener_0.15.0_linux_arm64.tgz",
-        "arm": "https://github.com/dokku/dokku-event-listener/releases/download/v0.15.0/dokku-event-listener_0.15.0_linux_armhf.tgz"
+        "amd64": "https://github.com/dokku/dokku-event-listener/releases/download/v0.16.0/dokku-event-listener-linux-amd64",
+        "arm64": "https://github.com/dokku/dokku-event-listener/releases/download/v0.16.0/dokku-event-listener-linux-arm64"
       }
     },
     {
       "name": "dokku-update",
-      "version": "0.7.2",
+      "version": "0.9.1",
       "urls": {
-        "amd64": "https://github.com/dokku/dokku-update/releases/download/v0.7.2/dokku-update_0.7.2_linux_x86_64.tgz",
-        "arm64": "https://github.com/dokku/dokku-update/releases/download/v0.7.2/dokku-update_0.7.2_linux_x86_64.tgz",
-        "arm": "https://github.com/dokku/dokku-update/releases/download/v0.7.2/dokku-update_0.7.2_linux_x86_64.tgz"
+        "amd64": "https://github.com/dokku/dokku-update/releases/download/v0.9.1/dokku-update",
+        "arm64": "https://github.com/dokku/dokku-update/releases/download/v0.9.1/dokku-update"
       }
     },
     {
@@ -99,8 +89,7 @@
       "version": "0.9.1",
       "urls": {
         "amd64": "https://github.com/gliderlabs/herokuish/releases/download/v0.9.1/herokuish_0.9.1_linux_x86_64.tgz",
-        "arm64": "https://github.com/gliderlabs/herokuish/releases/download/v0.9.1/herokuish_0.9.1_linux_x86_64.tgz",
-        "arm": "https://github.com/gliderlabs/herokuish/releases/download/v0.9.1/herokuish_0.9.1_linux_x86_64.tgz"
+        "arm64": "https://github.com/gliderlabs/herokuish/releases/download/v0.9.1/herokuish_0.9.1_linux_x86_64.tgz"
       }
     }
   ]

--- a/contrib/dependencies.json
+++ b/contrib/dependencies.json
@@ -2,42 +2,42 @@
   "dependencies": [
     {
       "name": "docker-container-healthchecker",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "urls": {
-        "amd64": "https://github.com/dokku/docker-container-healthchecker/releases/download/v0.10.2/docker-container-healthchecker-linux-amd64",
-        "arm64": "https://github.com/dokku/docker-container-healthchecker/releases/download/v0.10.2/docker-container-healthchecker-linux-arm64"
+        "amd64": "https://github.com/dokku/docker-container-healthchecker/releases/download/v0.11.0/docker-container-healthchecker-linux-amd64",
+        "arm64": "https://github.com/dokku/docker-container-healthchecker/releases/download/v0.11.0/docker-container-healthchecker-linux-arm64"
       }
     },
     {
       "name": "docker-image-labeler",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "urls": {
-        "amd64": "https://github.com/dokku/docker-image-labeler/releases/download/v0.7.0/docker-image-labeler-linux-amd64",
-        "arm64": "https://github.com/dokku/docker-image-labeler/releases/download/v0.7.0/docker-image-labeler-linux-arm64"
+        "amd64": "https://github.com/dokku/docker-image-labeler/releases/download/v0.8.0/docker-image-labeler-linux-amd64",
+        "arm64": "https://github.com/dokku/docker-image-labeler/releases/download/v0.8.0/docker-image-labeler-linux-arm64"
       }
     },
     {
       "name": "lambda-builder",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "urls": {
-        "amd64": "https://github.com/dokku/lambda-builder/releases/download/v0.7.0/lambda-builder-linux-amd64",
-        "arm64": "https://github.com/dokku/lambda-builder/releases/download/v0.7.0/lambda-builder-linux-arm64"
+        "amd64": "https://github.com/dokku/lambda-builder/releases/download/v0.8.0/lambda-builder-linux-amd64",
+        "arm64": "https://github.com/dokku/lambda-builder/releases/download/v0.8.0/lambda-builder-linux-arm64"
       }
     },
     {
       "name": "netrc",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "urls": {
-        "amd64": "https://github.com/dokku/netrc/releases/download/v0.9.0/netrc-linux-amd64",
-        "arm64": "https://github.com/dokku/netrc/releases/download/v0.9.0/netrc-linux-arm64"
+        "amd64": "https://github.com/dokku/netrc/releases/download/v0.10.0/netrc-linux-amd64",
+        "arm64": "https://github.com/dokku/netrc/releases/download/v0.10.0/netrc-linux-arm64"
       }
     },
     {
       "name": "procfile-util",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "urls": {
-        "amd64": "https://github.com/dokku/procfile-util/releases/download/v0.18.0/procfile-util-linux-amd64",
-        "arm64": "https://github.com/dokku/procfile-util/releases/download/v0.18.0/procfile-util-linux-arm64"
+        "amd64": "https://github.com/dokku/procfile-util/releases/download/v0.19.0/procfile-util-linux-amd64",
+        "arm64": "https://github.com/dokku/procfile-util/releases/download/v0.19.0/procfile-util-linux-arm64"
       }
     },
     {
@@ -70,26 +70,26 @@
   "recommendations": [
     {
       "name": "dokku-event-listener",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "urls": {
-        "amd64": "https://github.com/dokku/dokku-event-listener/releases/download/v0.16.0/dokku-event-listener-linux-amd64",
-        "arm64": "https://github.com/dokku/dokku-event-listener/releases/download/v0.16.0/dokku-event-listener-linux-arm64"
+        "amd64": "https://github.com/dokku/dokku-event-listener/releases/download/v0.17.0/dokku-event-listener-linux-amd64",
+        "arm64": "https://github.com/dokku/dokku-event-listener/releases/download/v0.17.0/dokku-event-listener-linux-arm64"
       }
     },
     {
       "name": "dokku-update",
-      "version": "0.9.1",
+      "version": "0.9.4",
       "urls": {
-        "amd64": "https://github.com/dokku/dokku-update/releases/download/v0.9.1/dokku-update",
-        "arm64": "https://github.com/dokku/dokku-update/releases/download/v0.9.1/dokku-update"
+        "amd64": "https://github.com/dokku/dokku-update/releases/download/v0.9.4/dokku-update",
+        "arm64": "https://github.com/dokku/dokku-update/releases/download/v0.9.4/dokku-update"
       }
     },
     {
       "name": "herokuish",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "urls": {
-        "amd64": "https://github.com/gliderlabs/herokuish/releases/download/v0.9.1/herokuish_0.9.1_linux_x86_64.tgz",
-        "arm64": "https://github.com/gliderlabs/herokuish/releases/download/v0.9.1/herokuish_0.9.1_linux_x86_64.tgz"
+        "amd64": "https://github.com/gliderlabs/herokuish/releases/download/v0.9.2/herokuish_0.9.2_linux_x86_64.tgz",
+        "arm64": "https://github.com/gliderlabs/herokuish/releases/download/v0.9.2/herokuish_0.9.2_linux_x86_64.tgz"
       }
     }
   ]


### PR DESCRIPTION
This pulls all the latest automatic releases for us, ensuring our CI runs against what folks will end up installing.