### PR TITLE
Let app.json define default plugin properties

### DIFF
--- a/plugins/app-json/appjson.go
+++ b/plugins/app-json/appjson.go
@@ -191,16 +191,16 @@ func GetAppjsonDirectory(appName string) string {
 
 // GetAppjsonPath returns the path to a given app's extracted app.json file for use by other plugins
 func GetAppjsonPath(appName string) string {
-	return getProcessSpecificAppJSONPath(appName)
+	return common.GetProcessSpecificAppJSONPath(appName)
 }
 
 // GetAppJSON returns the parsed app.json file for a given app
 func GetAppJSON(appName string) (AppJSON, error) {
-	if !hasAppJSON(appName) {
+	if !common.HasAppJSON(appName) {
 		return AppJSON{}, nil
 	}
 
-	b, err := os.ReadFile(getProcessSpecificAppJSONPath(appName))
+	b, err := os.ReadFile(common.GetProcessSpecificAppJSONPath(appName))
 	if err != nil {
 		return AppJSON{}, fmt.Errorf("Cannot read app.json file: %v", err)
 	}

--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -63,21 +62,6 @@ func constructScript(command string, shell string, isHerokuishImage bool, isCnbI
 	script = append(script, fmt.Sprintf("%s || exit 1;", command))
 
 	return []string{shell, "-c", strings.Join(script, " ")}
-}
-
-func getAppJSONPath(appName string) string {
-	directory := filepath.Join(common.MustGetEnv("DOKKU_LIB_ROOT"), "data", "app-json", appName)
-	return filepath.Join(directory, "app.json")
-}
-
-func getProcessSpecificAppJSONPath(appName string) string {
-	existingAppJSON := getAppJSONPath(appName)
-	processSpecificAppJSON := fmt.Sprintf("%s.%s", existingAppJSON, os.Getenv("DOKKU_PID"))
-	if common.FileExists(processSpecificAppJSON) {
-		return processSpecificAppJSON
-	}
-
-	return existingAppJSON
 }
 
 // getPhaseScript extracts app.json from app image and returns the appropriate json key/value
@@ -141,19 +125,6 @@ func getDokkuAppShell(appName string) string {
 	}
 
 	return shell
-}
-
-func hasAppJSON(appName string) bool {
-	appJSONPath := getAppJSONPath(appName)
-	if common.FileExists(fmt.Sprintf("%s.%s.missing", appJSONPath, os.Getenv("DOKKU_PID"))) {
-		return false
-	}
-
-	if common.FileExists(fmt.Sprintf("%s.%s", appJSONPath, os.Getenv("DOKKU_PID"))) {
-		return true
-	}
-
-	return common.FileExists(appJSONPath)
 }
 
 func cleanupDeploymentContainer(appName string, containerID string, phase string) error {

--- a/plugins/app-json/triggers.go
+++ b/plugins/app-json/triggers.go
@@ -38,12 +38,12 @@ func TriggerAppJSONProcessDeployParallelism(appName string, processType string) 
 
 // TriggerAppJSONGetContent outputs the contents of the app-json file, if any
 func TriggerAppJSONGetContent(appName string) error {
-	if !hasAppJSON(appName) {
+	if !common.HasAppJSON(appName) {
 		fmt.Print("{}")
 		return nil
 	}
 
-	b, err := os.ReadFile(getProcessSpecificAppJSONPath(appName))
+	b, err := os.ReadFile(common.GetProcessSpecificAppJSONPath(appName))
 	if err != nil {
 		return fmt.Errorf("Cannot read app.json file: %v", err)
 	}
@@ -61,7 +61,7 @@ func TriggerAppJSONGetContent(appName string) error {
 // TriggerCorePostDeploy sets a property to
 // allow the app to be restored on boot
 func TriggerCorePostDeploy(appName string) error {
-	existingAppJSON := getAppJSONPath(appName)
+	existingAppJSON := common.GetAppJSONPath(appName)
 	processSpecificAppJSON := fmt.Sprintf("%s.%s", existingAppJSON, os.Getenv("DOKKU_PID"))
 	if common.FileExists(processSpecificAppJSON) {
 		if err := os.Rename(processSpecificAppJSON, existingAppJSON); err != nil {
@@ -89,7 +89,7 @@ func TriggerCorePostExtract(appName string, sourceWorkDir string) error {
 		appJSONPath = "app.json"
 	}
 
-	existingAppJSON := getAppJSONPath(appName)
+	existingAppJSON := common.GetAppJSONPath(appName)
 	files, err := filepath.Glob(fmt.Sprintf("%s.*", existingAppJSON))
 	if err != nil {
 		return err

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -648,3 +648,31 @@ func VerifyAppName(appName string) error {
 
 	return nil
 }
+
+func GetAppJSONPath(appName string) string {
+	directory := filepath.Join(MustGetEnv("DOKKU_LIB_ROOT"), "data", "app-json", appName)
+	return filepath.Join(directory, "app.json")
+}
+
+func HasAppJSON(appName string) bool {
+	appJSONPath := GetAppJSONPath(appName)
+	if FileExists(fmt.Sprintf("%s.%s.missing", appJSONPath, os.Getenv("DOKKU_PID"))) {
+		return false
+	}
+
+	if FileExists(fmt.Sprintf("%s.%s", appJSONPath, os.Getenv("DOKKU_PID"))) {
+		return true
+	}
+
+	return FileExists(appJSONPath)
+}
+
+func GetProcessSpecificAppJSONPath(appName string) string {
+	existingAppJSON := GetAppJSONPath(appName)
+	processSpecificAppJSON := fmt.Sprintf("%s.%s", existingAppJSON, os.Getenv("DOKKU_PID"))
+	if FileExists(processSpecificAppJSON) {
+		return processSpecificAppJSON
+	}
+
+	return existingAppJSON
+}


### PR DESCRIPTION
This allows the repo's `app.json` to set app specific default plugin properties. It will not overwrite any properties that are explicitly set using the normal plugin property commands but it will override any defaults passed to `PropertyGetDefault`  (and `PropertyGet` which uses a blank default) in code.

For example if the `app.json` contains a `pluginproperties` key, it can set plugin properties using a key: value mapping like this:

```json
{
  "pluginproperties": {
    "nginx": {
        "client-max-body-size": "50m"
    }
  }
}
``` 

I have never worked with go before so let me know if anything could be improved. I had to move some of the app-json path functions into common to avoid a cyclical dependency error.

If this is ok to add, please let me know where I should add details in the docs. 

Any feedback is welcome, thanks.