### PR TITLE
fix: set permissions correctly on all files in the builder-release process

### DIFF
--- a/plugins/builder-herokuish/dockerfiles/builder-release.Dockerfile
+++ b/plugins/builder-herokuish/dockerfiles/builder-release.Dockerfile
@@ -3,6 +3,6 @@ FROM $APP_IMAGE
 
 ARG DOKKU_APP_USER herokuishuser
 COPY --chown=$DOKKU_APP_USER 00-global-env.sh 01-app-env.sh /app/.profile.d/
-RUN TRACE=$TRACE USER=$DOKKU_APP_USER HEROKUISH_DISABLE_CHOWN=false /exec true
+RUN find "/app" \( \! -user "$DOKKU_APP_USER" -o \! -group "$DOKKU_APP_USER" \) -print0 | xargs -0 -r chown "$DOKKU_APP_USER:$DOKKU_APP_USER"
 USER $DOKKU_APP_USER
 ENV HEROKUISH_SETUIDGUID false


### PR DESCRIPTION
Due to the execution of profile files when running /exec, it was possible to get into a state where files owned by root would exist in a built herokuish image.

We now instead chown the files directly, which ensures profile files only get executed at runtime.

Closes gliderlabs/herokuish#1212
Refs dokku/dokku#6851