### PR TITLE
Fixes incorrect documentation link for null builder

### DIFF
--- a/docs/deployment/builders/null.md
+++ b/docs/deployment/builders/null.md
@@ -3,7 +3,7 @@
 > [!IMPORTANT]
 > New as of 0.25.0
 
-The `null` builder does nothing, and is useful for routing to services not managed by Dokku. It should not be used in normal operation. Please see the [network documentation](/docs/networking/network.md#routing-an-app-to-a-known-ip:port-combination) for more information on the aforementioned use case.
+The `null` builder does nothing, and is useful for routing to services not managed by Dokku. It should not be used in normal operation. Please see the [network documentation](/docs/networking/network.md/#routing-an-app-to-a-known-ipport-combination) for more information on the aforementioned use case.
 
 ## Usage
 

--- a/docs/deployment/builders/null.md
+++ b/docs/deployment/builders/null.md
@@ -3,7 +3,7 @@
 > [!IMPORTANT]
 > New as of 0.25.0
 
-The `null` builder does nothing, and is useful for routing to services not managed by Dokku. It should not be used in normal operation. Please see the [network documentation](/docs/networking/network.md/#routing-an-app-to-a-known-ipport-combination) for more information on the aforementioned use case.
+The `null` builder does nothing, and is useful for routing to services not managed by Dokku. It should not be used in normal operation. Please see the [network documentation](/docs/networking/network.md#routing-an-app-to-a-known-ipport-combination) for more information on the aforementioned use case.
 
 ## Usage
 


### PR DESCRIPTION
Noticed the null builder docs was not routing to the right header on the page when it's clicked. Fixed it.