### PR TITLE
test: fix go.0 test

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,7 +1,7 @@
 GO_ARGS ?=
 GO_PLUGIN_MAKE_TARGET ?= build
 GO_REPO_ROOT := /go/src/github.com/dokku/dokku
-BUILD_IMAGE := golang:1.21.13
+BUILD_IMAGE := golang:1.23.1
 GO_BUILD_CACHE ?= /tmp/dokku-go-build-cache
 GO_MOD_CACHE   ?= /tmp/dokku-go-mod-mod
 GO_ROOT_MOUNT  ?= $$PWD/../..:$(GO_REPO_ROOT)


### PR DESCRIPTION
gomega 1.34.2 requires go >= 1.22

For example in https://github.com/dokku/dokku/actions/runs/10904136772/job/30260295745?pr=7152

> go: github.com/onsi/gomega@v1.34.2 requires go >= 1.22 (running go 1.21.13; GOTOOLCHAIN=local)