### PR TITLE
Fix building in vagrant when jq is not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ plugin-dependencies: plugn procfile-util
 plugins: plugn procfile-util docker
 	sudo -E dokku plugin:install --core
 
-dependencies: apt-update docker-image-labeler docker-container-healthchecker lambda-builder netrc sshcommand plugn procfile-util docker help2man man-db sigil dos2unix jq parallel
+dependencies: apt-update jq docker-image-labeler docker-container-healthchecker lambda-builder netrc sshcommand plugn procfile-util docker help2man man-db sigil dos2unix parallel
 	$(MAKE) -e stack
 
 apt-update:


### PR DESCRIPTION
docker-image-labeler default DOCKER_IMAGE_LABELER_URL uses jq, so jq needs to be available first.

This happens for example when using `vagrant up dokku-window`.

Fixes #7155

I could not get local tests to work however, see https://github.com/dokku/dokku/discussions/7154