### PR TITLE
Remove references to version in compose files

### DIFF
--- a/docs/getting-started/install/docker.md
+++ b/docs/getting-started/install/docker.md
@@ -25,8 +25,6 @@ docker container run -d \
 Alternatively, you can use `docker-compose.yml`:
 
 ```yaml
-version: "3.8"
-
 services:
   dokku:
     image: dokku/dokku:0.34.9

--- a/plugins/caddy-vhosts/templates/compose.yml.sigil
+++ b/plugins/caddy-vhosts/templates/compose.yml.sigil
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 services:
   caddy:
     image: "{{ $.CADDY_IMAGE }}"

--- a/plugins/haproxy-vhosts/templates/compose.yml.sigil
+++ b/plugins/haproxy-vhosts/templates/compose.yml.sigil
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 services:
   haproxy:
     image: "{{ $.HAPROXY_IMAGE }}"

--- a/plugins/logs/templates/compose.yml.tmpl
+++ b/plugins/logs/templates/compose.yml.tmpl
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 services:
   vector:
     image: "{{ $.VectorImage }}"

--- a/plugins/openresty-vhosts/templates/compose.yml.sigil
+++ b/plugins/openresty-vhosts/templates/compose.yml.sigil
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 services:
   openresty:
     image: "{{ $.OPENRESTY_IMAGE }}"

--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 services:
   traefik:
     image: "{{ $.TRAEFIK_IMAGE }}"


### PR DESCRIPTION
This is now deprecated and causes a warning to be raised.