### PR TITLE
Error out when the Dockerfile is missing during builder-dockerfile execution

### DIFF
--- a/plugins/builder-dockerfile/builder-build
+++ b/plugins/builder-dockerfile/builder-build
@@ -23,6 +23,11 @@ trigger-builder-dockerfile-builder-build() {
 
   pushd "$SOURCECODE_WORK_DIR" &>/dev/null
 
+  if [[ ! -f "$SOURCECODE_WORK_DIR/Dockerfile" ]]; then
+    dokku_log_fail "No Dockerfile found in source code directory"
+    return 1
+  fi
+
   if fn-plugn-trigger-exists "pre-build-dockerfile"; then
     dokku_log_warn "Deprecated: please upgrade plugin to use 'pre-build' plugin trigger instead of pre-build-dockerfile"
     plugn trigger pre-build-dockerfile "$APP"


### PR DESCRIPTION
Users may inadvertently set the builder to 'dockerfile' and have build errors when there is no Dockerfile. This change makes it clear that the dockerfile _must_ exist in order for the build to succeed.

Closes #7181