### PR TITLE
Respect GO environment variables when building to ensure CGO is disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ go-build:
 	basedir=$(PWD); \
 	for dir in plugins/*; do \
 		if [ -e $$dir/Makefile ]; then \
-			$(MAKE) -e -C $$dir $(PLUGIN_MAKE_TARGET) || exit $$? ;\
+			GO_ARGS='$(GO_ARGS)' CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) GOWORK=off $(MAKE) -e -C $$dir $(PLUGIN_MAKE_TARGET) || exit $$? ;\
 		fi ;\
 	done
 
@@ -64,7 +64,7 @@ ifndef PLUGIN_NAME
 	$(error PLUGIN_NAME not specified)
 endif
 	if [ -e plugins/$(PLUGIN_NAME)/Makefile ]; then \
-		$(MAKE) -e -C plugins/$(PLUGIN_NAME) $(PLUGIN_MAKE_TARGET) || exit $$? ;\
+		GO_ARGS='$(GO_ARGS)' CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) GOWORK=off $(MAKE) -e -C plugins/$(PLUGIN_NAME) $(PLUGIN_MAKE_TARGET) || exit $$? ;\
 	fi
 
 go-clean:

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.23
+go 1.23.0
 
 use (
 	./plugins/app-json

--- a/plugins/app-json/Makefile
+++ b/plugins/app-json/Makefile
@@ -3,4 +3,7 @@ TRIGGERS = triggers/app-json-process-deploy-parallelism triggers/app-json-get-co
 BUILD = commands subcommands triggers
 PLUGIN_NAME = app-json
 
+goenv:
+	go env
+
 include ../../common.mk

--- a/plugins/scheduler-k3s/go.mod
+++ b/plugins/scheduler-k3s/go.mod
@@ -1,6 +1,6 @@
 module github.com/dokku/dokku/plugins/scheduler-k3s
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/cert-manager/cert-manager v1.13.3


### PR DESCRIPTION
Without this, building Dokku on a newer operating system will result in binaries that do not work on older systems. The environment variables were only being set when building in docker, which has not been used in the release workflow for a while.