### PR TITLE
Revert to building Dokku on Ubunut 20.04 Focal to hotfix glibc issues

### DIFF
--- a/contrib/build-dokku.Dockerfile
+++ b/contrib/build-dokku.Dockerfile
@@ -1,4 +1,4 @@
-FROM dokku/build-base:0.2.1 AS builder
+FROM dokku/build-base:0.1.2 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
An upcoming fix will revert this and also test that the packages install on all versions of Ubuntu.