### PR TITLE
Check if nginx is running before reloading during an app deletion

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -75,7 +75,7 @@ trigger-nginx-vhosts-install() {
   case "$DOKKU_DISTRO" in
     debian | raspbian)
       if [[ -x "$systemctl_path" ]]; then
-        echo "%dokku ALL=(ALL) NOPASSWD:$systemctl_path enable $NGINX_INIT_NAME, $systemctl_path disable $NGINX_INIT_NAME, $systemctl_path reload $NGINX_INIT_NAME, $systemctl_path start $NGINX_INIT_NAME, $systemctl_path stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
+        echo "%dokku ALL=(ALL) NOPASSWD:$systemctl_path enable $NGINX_INIT_NAME, $systemctl_path disable $NGINX_INIT_NAME, $systemctl_path reload $NGINX_INIT_NAME, $systemctl_path start $NGINX_INIT_NAME, $systemctl_path stop $NGINX_INIT_NAME, $systemctl_path is-active --quiet $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       else
         echo "%dokku ALL=(ALL) NOPASSWD:/usr/sbin/invoke-rc.d $NGINX_INIT_NAME enable, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME disable, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME reload, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME start, /usr/sbin/invoke-rc.d $NGINX_INIT_NAME stop, $NGINX_BIN -t, ${NGINX_BIN} -t -c *" >"$NGINX_SUDOERS_FILE"
       fi
@@ -83,18 +83,18 @@ trigger-nginx-vhosts-install() {
 
     ubuntu)
       if [[ "$DOKKU_INIT_SYSTEM" == "sv" ]]; then
-        echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/sv enable $NGINX_INIT_NAME, /usr/bin/sv disable $NGINX_INIT_NAME, /usr/bin/sv reload $NGINX_INIT_NAME, /usr/bin/sv start $NGINX_INIT_NAME, /usr/bin/sv stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
+        echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/sv enable $NGINX_INIT_NAME, /usr/bin/sv disable $NGINX_INIT_NAME, /usr/bin/sv reload $NGINX_INIT_NAME, /usr/bin/sv start $NGINX_INIT_NAME, /usr/bin/sv stop $NGINX_INIT_NAME, /usr/bin/sv status $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       elif [[ -x "$systemctl_path" ]]; then
-        echo "%dokku ALL=(ALL) NOPASSWD:$systemctl_path enable $NGINX_INIT_NAME, $systemctl_path disable $NGINX_INIT_NAME, $systemctl_path reload $NGINX_INIT_NAME, $systemctl_path start $NGINX_INIT_NAME, $systemctl_path stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
+        echo "%dokku ALL=(ALL) NOPASSWD:$systemctl_path enable $NGINX_INIT_NAME, $systemctl_path disable $NGINX_INIT_NAME, $systemctl_path reload $NGINX_INIT_NAME, $systemctl_path start $NGINX_INIT_NAME, $systemctl_path stop $NGINX_INIT_NAME, $systemctl_path is-active --quiet $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       elif [[ -x /usr/bin/sv ]]; then
-        echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/sv enable $NGINX_INIT_NAME, /usr/bin/sv disable $NGINX_INIT_NAME, /usr/bin/sv reload $NGINX_INIT_NAME, /usr/bin/sv start $NGINX_INIT_NAME, /usr/bin/sv stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
+        echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/sv enable $NGINX_INIT_NAME, /usr/bin/sv disable $NGINX_INIT_NAME, /usr/bin/sv reload $NGINX_INIT_NAME, /usr/bin/sv start $NGINX_INIT_NAME, /usr/bin/sv stop $NGINX_INIT_NAME, /usr/bin/sv status $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       else
         echo "%dokku ALL=(ALL) NOPASSWD:/etc/init.d/$NGINX_INIT_NAME enable, /etc/init.d/$NGINX_INIT_NAME disable, /etc/init.d/$NGINX_INIT_NAME reload, /etc/init.d/$NGINX_INIT_NAME start, /etc/init.d/$NGINX_INIT_NAME stop, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       fi
       ;;
 
     arch)
-      echo "%dokku ALL=(ALL) NOPASSWD:$systemctl_path enable $NGINX_INIT_NAME, $systemctl_path disable $NGINX_INIT_NAME, $systemctl_path reload $NGINX_INIT_NAME, $systemctl_path start $NGINX_INIT_NAME, $systemctl_path stop $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
+      echo "%dokku ALL=(ALL) NOPASSWD:$systemctl_path enable $NGINX_INIT_NAME, $systemctl_path disable $NGINX_INIT_NAME, $systemctl_path reload $NGINX_INIT_NAME, $systemctl_path start $NGINX_INIT_NAME, $systemctl_path stop $NGINX_INIT_NAME, $systemctl_path is-active --quiet $NGINX_INIT_NAME, $NGINX_BIN -t, $NGINX_BIN -t -c *" >"$NGINX_SUDOERS_FILE"
       ;;
   esac
 

--- a/plugins/nginx-vhosts/internal-functions
+++ b/plugins/nginx-vhosts/internal-functions
@@ -523,6 +523,57 @@ fn-nginx-vhosts-nginx-location() {
   echo "$NGINX_LOCATION"
 }
 
+fn-nginx-vhosts-nginx-is-running() {
+  declare desc="check if nginx is running"
+  local NGINX_INIT_NAME
+
+  NGINX_INIT_NAME=nginx
+  if fn-nginx-vhosts-uses-openresty; then
+    NGINX_INIT_NAME=openresty
+  fi
+
+  case "$DOKKU_DISTRO" in
+    debian | raspbian)
+      if [[ -x "$systemctl_path" ]]; then
+        if sudo "$systemctl_path" is-active --quiet "$NGINX_INIT_NAME"; then
+          return 0
+        fi
+      else
+        dokku_log_warn "Checking $NGINX_INIT_NAME status is not possible for init.d managed services"
+        return 0
+      fi
+      ;;
+
+    ubuntu)
+      # support docker-based installations
+      if [[ "$DOKKU_INIT_SYSTEM" == "sv" ]]; then
+        if sudo /usr/bin/sv status $NGINX_INIT_NAME | grep -q "^run:"; then
+          return 0
+        fi
+      elif [[ -x "$systemctl_path" ]]; then
+        if sudo "$systemctl_path" is-active --quiet "$NGINX_INIT_NAME"; then
+          return 0
+        fi
+      elif [[ -x /usr/bin/sv ]]; then
+        if sudo /usr/bin/sv status $NGINX_INIT_NAME | grep -q "^run:"; then
+          return 0
+        fi
+      else
+        dokku_log_warn "Checking $NGINX_INIT_NAME status is not possible for init.d managed services"
+        return 0
+      fi
+      ;;
+
+    arch)
+      if sudo "$systemctl_path" is-active --quiet "$NGINX_INIT_NAME"; then
+        return 0
+      fi
+      ;;
+  esac
+
+  return 1
+}
+
 fn-nginx-vhosts-nginx-init-cmd() {
   declare desc="start nginx for given distros"
   declare CMD="$1"

--- a/plugins/nginx-vhosts/post-delete
+++ b/plugins/nginx-vhosts/post-delete
@@ -10,7 +10,9 @@ trigger-nginx-vhosts-post-delete() {
   declare APP="$1"
 
   fn-plugin-property-destroy "nginx" "$APP"
-  restart_nginx "$@" >/dev/null
+  if fn-nginx-vhosts-nginx-is-running; then
+    restart_nginx "$@" >/dev/null
+  fi
   rm -rf "${DOKKU_LIB_ROOT}/data/nginx-vhosts/app-$APP"
 }
 


### PR DESCRIPTION
The purpose of the reload is to remove nginx from being loaded. If nginx isn't running, then by definition the config is not loaded.

Closes #6832