### PR TITLE
Run arm build on 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
   build-image-arm64:
     name: build-image.linux/arm64
     needs: build
-    runs-on: buildjet-4vcpu-ubuntu-2404-arm
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
     timeout-minutes: 20
 
     steps:


### PR DESCRIPTION
There is no 24.04 buildjet runner, so this just stalls forever.