### PR TITLE
Compute path for docker-container-healthchecker

### DIFF
--- a/plugins/scheduler-docker-local/check-deploy
+++ b/plugins/scheduler-docker-local/check-deploy
@@ -153,7 +153,10 @@ trigger-scheduler-docker-local-check-deploy() {
     echo "$content" >"$TMP_APP_JSON_OUTPUT"
   fi
 
-  sudo /usr/bin/docker-container-healthchecker check "$DOKKU_APP_CONTAINER_ID" "${ARG_ARRAY[@]}" || FAILEDCHECKS="$?"
+  local docker_container_healthchecker_path
+  docker_container_healthchecker_path="$(command -v docker-container-healthchecker)"
+
+  sudo "$docker_container_healthchecker_path" check "$DOKKU_APP_CONTAINER_ID" "${ARG_ARRAY[@]}" || FAILEDCHECKS="$?"
 
   if [[ $FAILEDCHECKS -gt 0 ]]; then
     "$DOCKER_BIN" container update --restart=no "$DOKKU_APP_CONTAINER_ID" &>/dev/null || true

--- a/plugins/scheduler-docker-local/install
+++ b/plugins/scheduler-docker-local/install
@@ -16,7 +16,9 @@ trigger-scheduler-docker-local-install() {
 
   rm -f "/etc/sudoers.d/dokku-cron"
 
-  echo "%dokku ALL=(ALL) NOPASSWD:/usr/bin/docker-container-healthchecker" >"/etc/sudoers.d/dokku-docker-container-healthchecker"
+  local docker_container_healthchecker_path
+  docker_container_healthchecker_path="$(command -v docker-container-healthchecker)"
+  echo "%dokku ALL=(ALL) NOPASSWD:$docker_container_healthchecker_path" >"/etc/sudoers.d/dokku-docker-container-healthchecker"
   chmod "0440" "/etc/sudoers.d/dokku-docker-container-healthchecker"
 
   DOKKU_PATH="$(command -v dokku)"


### PR DESCRIPTION
This fixes an issue for source-based Dokku installs where the binary is installed in /usr/local/bin instead of /usr/bin due to not being installed via an OS package.

Closes #7010