### PR TITLE
Release Dokku on supported versions of Debian and Raspbian

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Support us with a monthly donation and help us continue our activities. [[Become
 A fresh VM running any of the following operating systems:
 
 - Ubuntu 20.04 / 22.04 / 24.04 x64 - Any currently supported release
-- Debian 10+ x64
+- Debian 11+ x64
 - Arch Linux x64 *(experimental)*
 
 An SSH keypair that can be used for application deployment. If this exists before installation, it will be automatically imported into dokku.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 # That's good because it prevents our output overlapping with wget's.
 # It also means that we can't run a partially downloaded script.
 
-SUPPORTED_VERSIONS="Debian [10, 11, 12], Ubuntu [20.04, 22.04, 24.04]"
+SUPPORTED_VERSIONS="Debian [11, 12], Ubuntu [20.04, 22.04, 24.04]"
 
 log-fail() {
   declare desc="log fail formatter"
@@ -193,14 +193,14 @@ install-dokku-from-deb-package() {
       OS_ID="noble"
     fi
   elif [[ "$DOKKU_DISTRO" == "debian" ]]; then
-    OS_IDS=("stretch" "buster" "bullseye" "bookworm")
+    OS_IDS=("bullseye" "bookworm")
     if ! in-array "$OS_ID" "${OS_IDS[@]}"; then
-      OS_ID="bullseye"
+      OS_ID="bookworm"
     fi
   elif [[ "$DOKKU_DISTRO" == "raspbian" ]]; then
-    OS_IDS=("buster" "bullseye")
+    OS_IDS=("bullseye" "bookworm")
     if ! in-array "$OS_ID" "${OS_IDS[@]}"; then
-      OS_ID="bullseye"
+      OS_ID="bookworm"
     fi
   fi
 

--- a/contrib/release-dokku
+++ b/contrib/release-dokku
@@ -134,7 +134,7 @@ fn-publish-package() {
   [[ "$RELEASE_TYPE" == "raspbian" ]] && DIST=raspbian
 
   if [[ "$RELEASE_TYPE" == "raspbian" ]]; then
-    OS_IDS=("buster" "bullseye")
+    OS_IDS=("bullseye" "bookworm")
     for OS_ID in "${OS_IDS[@]}"; do
       log-info "(release-dokku) pushing deb to packagecloud.com/${REPOSITORY}/${DIST}"
       package_cloud push "${REPOSITORY}/${DIST}/${OS_ID}" "$PACKAGE_NAME"
@@ -155,7 +155,7 @@ fn-publish-package() {
     done
 
     DIST=debian
-    OS_IDS=("buster" "bullseye" "bookworm")
+    OS_IDS=("bullseye" "bookworm")
     for OS_ID in "${OS_IDS[@]}"; do
       log-info "(release-dokku) pushing ${RELEASE_TYPE} to packagecloud.com/${REPOSITORY}/${DIST}"
       package_cloud push "${REPOSITORY}/${DIST}/${OS_ID}" "$PACKAGE_NAME"

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -10,7 +10,7 @@ To start using Dokku, you'll need a system that meets the following minimum requ
 
 - A fresh installation of any of the following operating systems:
     - [Ubuntu 20.04/22.04/24.04](https://www.ubuntu.com/download)
-    - [Debian 10+ x64](https://www.debian.org/distrib/)
+    - [Debian 11+ x64](https://www.debian.org/distrib/)
 - A server with one of the following architectures
     - AMD64 (alternatively known as `x86_64`), commonly used for Intel cloud servers
     - ARMV8 (alternatively known as `arm64`), commonly used for Raspberry PI and AWS Graviton


### PR DESCRIPTION
The policy has always been to only release for supported versions of operating systems, so this change aligns what we release for and how Dokku may be installed.

Folks running unmaintained operating systems should upgrade, as the packages are never guaranteed to exist in the Dokku apt repository.