### PR TITLE
Clarify x64 as amd64/arch64 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,8 @@ Support us with a monthly donation and help us continue our activities. [[Become
 
 A fresh VM running any of the following operating systems:
 
-- Ubuntu 20.04 / 22.04 / 24.04 (64-bit) - Any currently supported release
-- Debian 11+ (64-bit)
-- Arch Linux (64-bit) *(experimental)*
+- Ubuntu 20.04 / 22.04 / 24.04 (amd64/arch64) - Any currently supported release
+- Debian 11+ (amd64/arch64)
 
 An SSH keypair that can be used for application deployment. If this exists before installation, it will be automatically imported into dokku.
 Otherwise, you will need to import the keypair manually after installation using `dokku ssh-keys:add`.

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Support us with a monthly donation and help us continue our activities. [[Become
 
 A fresh VM running any of the following operating systems:
 
-- Ubuntu 20.04 / 22.04 / 24.04 x64 - Any currently supported release
-- Debian 11+ x64
-- Arch Linux x64 *(experimental)*
+- Ubuntu 20.04 / 22.04 / 24.04 (64-bit) - Any currently supported release
+- Debian 11+ (64-bit)
+- Arch Linux (64-bit) *(experimental)*
 
 An SSH keypair that can be used for application deployment. If this exists before installation, it will be automatically imported into dokku.
 Otherwise, you will need to import the keypair manually after installation using `dokku ssh-keys:add`.


### PR DESCRIPTION
So I started by searching after reading README.md, and came across #6312 

Maybe others assume x64 is synonymous with 64-bit, but I find the long-hand, helped me to understand that `arm64` and `aarch64`, and `amd64` as well as `x86_64` (which I thought x64 most closely resembled) would all be supported, and it's a minimum native bus width limitation, dispensing with the history of x86 and 8086, than anything else.

6312 suggests arm64 is fair game, and should work.

Unsure what this means for RISC-V, or if there are other 64-bit architectures this has not been tested on.