### PR TITLE
[docs] Clarify difference between dokku run and docker run in docker-options.md

### DIFF
--- a/docs/advanced-usage/docker-options.md
+++ b/docs/advanced-usage/docker-options.md
@@ -3,7 +3,9 @@
 > [!IMPORTANT]
 > New as of 0.3.17
 
-Pass [container options](https://docs.docker.com/engine/reference/run/) to the `docker run` command  during Dokku's `build`, `deploy` and `run` phases
+Pass [container options](https://docs.docker.com/engine/reference/run/) to the `docker run`* command  during Dokku's `build`, `deploy` and `run` phases.
+
+*do not confuse `docker run` with `dokku run`. The `dokku run` phase is for one-off containers created by dokku run and cron tasks. The deploy phase is for containers that are created (and subsequently *run* as part of a deploy). See [About Dokku phases](#about-dokku-phases) & issue https://github.com/dokku/dokku/issues/7219.
 
 ```
 docker-options:add <app> <phase(s)> OPTION    # Add Docker option to app for phase (comma-separated phase list)


### PR DESCRIPTION
Hopefully clarifies the difference between dokku run and docker run in docker-options.md for other readers who may also get confused by this.

Ref https://github.com/dokku/dokku/issues/7219

How I got confused:

I read the docs: "Pass [container options](https://docs.docker.com/engine/reference/run/) to the docker run" ([here](https://dokku.com/docs/advanced-usage/docker-options/?)), and read the *docker* run reference, missing the nuanced detail different between `docker run`/`dokku run`  -> `dokku deploy` stage.

