### PR TITLE
fix: #7035 broke traefik https router rule

### DIFF
--- a/plugins/traefik-vhosts/docker-args-process-deploy
+++ b/plugins/traefik-vhosts/docker-args-process-deploy
@@ -125,7 +125,7 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
       output="$output --label traefik.http.routers.$APP-$PROC_TYPE-https.service=$APP-$PROC_TYPE-https"
       output="$output --label traefik.http.routers.$APP-$PROC_TYPE-https.tls.certresolver=leresolver"
       if [[ -n "$traefik_domains" ]]; then
-        output="$output --label \"traefik.http.routers.$APP-$PROC_TYPE-https.rule=Host(\\\`$traefik_domains\\\`)\""
+        output="$output --label \"traefik.http.routers.$APP-$PROC_TYPE-https.rule=$traefik_domains\""
       fi
     fi
   fi


### PR DESCRIPTION
#7035 reworked how traefik domains are constructed but missed updating the https router rule accordingly.