### PR TITLE
Do not attempt to expose the same mapped port more than once

### DIFF
--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process-container
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process-container
@@ -34,6 +34,7 @@ main() {
   local DOKKU_PORT=""
   if [[ "$PROC_TYPE" == "web" ]]; then
     ports=($(plugn trigger ports-get "$APP"))
+    local exposed_ports=()
     for port_map in "${ports[@]}"; do
       local scheme="$(echo "$port_map" | cut -d':' -f1)"
       local container_port="$(echo "$port_map" | cut -d':' -f3)"
@@ -41,7 +42,13 @@ main() {
         DOKKU_PORT="${DOKKU_PORT:="$container_port"}"
       fi
 
+      # skip if the exposed_ports array contains container_port
+      if fn-in-array "$container_port" "${exposed_ports[@]}"; then
+        continue
+      fi
+
       if [[ "$DOKKU_NETWORK_BIND_ALL" == "true" ]]; then
+        exposed_ports+=("$container_port")
         DOCKER_ARGS+=" -p $container_port"
       fi
     done


### PR DESCRIPTION
A newer release of Docker (27.3.1) appears to have issues with the -p flag appearing the same time more than once for a given port. This was previously not an issue, but we should remove the problem on our end regardless.

Closes #7251