### PR TITLE
Add support for non-local nginx implementations

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -2583,6 +2583,25 @@ DOKKU_SCHEDULER="$1"; APP="$2";
 # TODO
 ```
 
+### `scheduler-proxy-logs`
+
+> [!WARNING]
+> The scheduler plugin trigger apis are under development and may change
+> between minor releases until the 1.0 release.
+- Description: Allows you to run scheduler commands when retrieving failed container logs
+- Invoked by: `dokku nginx:access-logs` and `dokku nginx:error-logs`
+- Arguments: `$DOKKU_SCHEDULER $APP $PROXY_TYPE $LOG_TYPE $TAIL $NUM_LINES`
+- Example:
+
+```shell
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+DOKKU_SCHEDULER="$1"; APP="$2"; $PROXY_TYPE="$3"; LOG_TYPE="$4"; TAIL="$5"; NUM_LINES="$6"
+
+# TODO
+```
+
 ### `scheduler-pre-restore`
 
 > [!WARNING]

--- a/plugins/nginx-vhosts/functions
+++ b/plugins/nginx-vhosts/functions
@@ -74,10 +74,23 @@ nginx_logs() {
     dokku_log_fail "$NGINX_LOGS_TYPE logs are disabled for this app"
   fi
 
+  local tail=false
+  local num=0
   if [[ $3 == "-t" ]]; then
+    tail=true
+  else
+    num=20
+  fi
+
+  local DOKKU_SCHEDULER=$(get_app_scheduler "$APP")
+  if [[ "$DOKKU_SCHEDULER" != "docker-local" ]]; then
+    plugn trigger scheduler-nginx-logs "$DOKKU_SCHEDULER" "$APP" "nginx" "$NGINX_LOGS_TYPE" "$tail" "$num"
+  fi
+
+  if [[ "$tail" == "true" ]]; then
     local NGINX_LOGS_ARGS="-F"
   else
-    local NGINX_LOGS_ARGS="-n 20"
+    local NGINX_LOGS_ARGS="-n $num"
   fi
 
   tail "$NGINX_LOGS_ARGS" "$NGINX_LOGS_PATH"

--- a/plugins/scheduler-k3s/Makefile
+++ b/plugins/scheduler-k3s/Makefile
@@ -1,5 +1,5 @@
 SUBCOMMANDS = subcommands/annotations:set subcommands/autoscaling-auth:set subcommands/autoscaling-auth:report subcommands/cluster-add subcommands/cluster-list subcommands/cluster-remove subcommands/initialize subcommands/labels:set subcommands/report subcommands/set subcommands/show-kubeconfig subcommands/uninstall
-TRIGGERS = triggers/install triggers/post-app-clone-setup triggers/post-app-rename-setup triggers/post-delete triggers/report triggers/scheduler-app-status triggers/scheduler-deploy triggers/scheduler-enter triggers/scheduler-logs triggers/scheduler-post-delete triggers/scheduler-run triggers/scheduler-run-list triggers/scheduler-stop
+TRIGGERS = triggers/install triggers/post-app-clone-setup triggers/post-app-rename-setup triggers/post-delete triggers/report triggers/scheduler-app-status triggers/scheduler-deploy triggers/scheduler-enter triggers/scheduler-logs triggers/scheduler-nginx-logs triggers/scheduler-post-delete triggers/scheduler-run triggers/scheduler-run-list triggers/scheduler-stop
 BUILD = commands subcommands triggers
 PLUGIN_NAME = scheduler-k3s
 

--- a/plugins/scheduler-k3s/src/triggers/triggers.go
+++ b/plugins/scheduler-k3s/src/triggers/triggers.go
@@ -84,6 +84,22 @@ func main() {
 		}
 
 		err = scheduler_k3s.TriggerSchedulerLogs(scheduler, appName, processType, tail, quiet, numLines)
+	case "scheduler-proxy-logs":
+		var tail bool
+		var numLines int64
+		scheduler := flag.Arg(0)
+		appName := flag.Arg(1)
+		proxyType := flag.Arg(2)
+		logType := flag.Arg(3)
+		tail, err = strconv.ParseBool(flag.Arg(4))
+		if err != nil {
+			tail = false
+		}
+		numLines, err = strconv.ParseInt(flag.Arg(5), 10, 64)
+		if err != nil {
+			numLines = 0
+		}
+		err = scheduler_k3s.TriggerSchedulerProxyLogs(scheduler, appName, proxyType, logType, tail, numLines)
 	case "scheduler-stop":
 		scheduler := flag.Arg(0)
 		appName := flag.Arg(1)


### PR DESCRIPTION
If the scheduler is not docker-local, we will assume that a separate plugin trigger will pull access/error logs on our behalf. For k3s, the naive implementation is to pull logs from a single container (multiple ingress-nginx pods will be supported in a future release).

Closes #7268