### PR TITLE
Allow usage of newer nginx.conf.sigil on older versions of dokku

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.conf.sigil
+++ b/plugins/nginx-vhosts/templates/nginx.conf.sigil
@@ -13,11 +13,11 @@ server {
   error_log   {{ $.NGINX_ERROR_LOG_PATH }};
   underscores_in_headers {{ $.NGINX_UNDERSCORE_IN_HEADERS }};
 
-  client_body_timeout {{ $.CLIENT_BODY_TIMEOUT }};
-  client_header_timeout {{ $.CLIENT_HEADER_TIMEOUT }};
-  keepalive_timeout {{ $.KEEPALIVE_TIMEOUT }};
-  lingering_timeout {{ $.LINGERING_TIMEOUT }};
-  send_timeout {{ $.SEND_TIMEOUT }};
+  {{ if $.CLIENT_BODY_TIMEOUT }}client_body_timeout {{ $.CLIENT_BODY_TIMEOUT }};{{end}}
+  {{ if $.CLIENT_HEADER_TIMEOUT }}client_header_timeout {{ $.CLIENT_HEADER_TIMEOUT }};{{end}}
+  {{ if $.KEEPALIVE_TIMEOUT }}keepalive_timeout {{ $.KEEPALIVE_TIMEOUT }};{{end}}
+  {{ if $.LINGERING_TIMEOUT }}lingering_timeout {{ $.LINGERING_TIMEOUT }};{{end}}
+  {{ if $.SEND_TIMEOUT }}send_timeout {{ $.SEND_TIMEOUT }};{{end}}
 
 {{ if (and (eq $listen_port "80") ($.SSL_INUSE)) }}
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
@@ -36,9 +36,9 @@ server {
 
     proxy_pass  http://{{ $.APP }}-{{ $upstream_port }};
     proxy_http_version 1.1;
-    proxy_connect_timeout {{ $.PROXY_CONNECT_TIMEOUT }};
-    proxy_read_timeout {{ $.PROXY_READ_TIMEOUT }};
-    proxy_send_timeout {{ $.PROXY_SEND_TIMEOUT }};
+    {{ if $.PROXY_CONNECT_TIMEOUT }}proxy_connect_timeout {{ $.PROXY_CONNECT_TIMEOUT }};{{end}}
+    {{ if $.PROXY_READ_TIMEOUT }}proxy_read_timeout {{ $.PROXY_READ_TIMEOUT }};{{end}}
+    {{ if $.PROXY_SEND_TIMEOUT }}proxy_send_timeout {{ $.PROXY_SEND_TIMEOUT }};{{end}}
     proxy_buffer_size {{ $.PROXY_BUFFER_SIZE }};
     proxy_buffering {{ $.PROXY_BUFFERING }};
     proxy_buffers {{ $.PROXY_BUFFERS }};
@@ -90,11 +90,11 @@ server {
   ssl_protocols             TLSv1.2 {{ if eq $.TLS13_SUPPORTED "true" }}TLSv1.3{{ end }};
   ssl_prefer_server_ciphers off;
 
-  client_body_timeout {{ $.CLIENT_BODY_TIMEOUT }};
-  client_header_timeout {{ $.CLIENT_HEADER_TIMEOUT }};
-  keepalive_timeout {{ $.KEEPALIVE_TIMEOUT }};
-  lingering_timeout {{ $.LINGERING_TIMEOUT }};
-  send_timeout {{ $.SEND_TIMEOUT }};
+  {{ if $.CLIENT_BODY_TIMEOUT }}client_body_timeout {{ $.CLIENT_BODY_TIMEOUT }};{{end}}
+  {{ if $.CLIENT_HEADER_TIMEOUT }}client_header_timeout {{ $.CLIENT_HEADER_TIMEOUT }};{{end}}
+  {{ if $.KEEPALIVE_TIMEOUT }}keepalive_timeout {{ $.KEEPALIVE_TIMEOUT }};{{end}}
+  {{ if $.LINGERING_TIMEOUT }}lingering_timeout {{ $.LINGERING_TIMEOUT }};{{end}}
+  {{ if $.SEND_TIMEOUT }}send_timeout {{ $.SEND_TIMEOUT }};{{end}}
 
   location    / {
 
@@ -108,9 +108,9 @@ server {
     proxy_pass  http://{{ $.APP }}-{{ $upstream_port }};
     {{ if eq $.HTTP2_PUSH_SUPPORTED "true" }}http2_push_preload on; {{ end }}
     proxy_http_version 1.1;
-    proxy_connect_timeout {{ $.PROXY_CONNECT_TIMEOUT }};
-    proxy_read_timeout {{ $.PROXY_READ_TIMEOUT }};
-    proxy_send_timeout {{ $.PROXY_SEND_TIMEOUT }};
+    {{ if $.PROXY_CONNECT_TIMEOUT }}proxy_connect_timeout {{ $.PROXY_CONNECT_TIMEOUT }};{{end}}
+    {{ if $.PROXY_READ_TIMEOUT }}proxy_read_timeout {{ $.PROXY_READ_TIMEOUT }};{{end}}
+    {{ if $.PROXY_SEND_TIMEOUT }}proxy_send_timeout {{ $.PROXY_SEND_TIMEOUT }};{{end}}
     proxy_buffer_size {{ $.PROXY_BUFFER_SIZE }};
     proxy_buffering {{ $.PROXY_BUFFERING }};
     proxy_buffers {{ $.PROXY_BUFFERS }};


### PR DESCRIPTION
Folks might mistakenly pull the latest template file - which introduces new variables - causing deployment failures.

This change allows them to use the newer template by checking if the variables are set before using them.

Closes #7277