### PR TITLE
Allow exit code 2 when waiting for cloud-init to complete

### DIFF
--- a/contrib/images/digitalocean/packer.pkr.hcl
+++ b/contrib/images/digitalocean/packer.pkr.hcl
@@ -30,6 +30,7 @@ build {
       "echo '--> Waiting until cloud-init is complete'",
       "/usr/bin/cloud-init status --wait",
     ]
+    valid_exit_codes = [0, 2]
   }
 
   provisioner "file" {


### PR DESCRIPTION
A change in cloud-init and/or the Ubuntu image provided by Digitalocean causes builds to fail due to cloud-init status exiting 2. The error is ignorable.

See digitalocean/marketplace-partners#186 for more details.