### PR TITLE
Skip ssh key setup when starting docker image

### DIFF
--- a/docker/etc/my_init.d/10_dokku_init
+++ b/docker/etc/my_init.d/10_dokku_init
@@ -89,6 +89,9 @@ main() {
     dokku --quiet domains:set-global "$DOKKU_HOSTNAME"
   fi
 
+  echo "dokku dokku/skip_key_file boolean true" | debconf-set-selections
+  echo "dokku dokku/key_file string /root/.ssh/id_rsa.pub" | debconf-set-selections
+
   NGINX_ROOT="/etc/nginx"
   if [[ -x /usr/bin/openresty ]]; then
     NGINX_ROOT="/usr/local/openresty/nginx/conf"


### PR DESCRIPTION
When deploying the Dokku via Docker, ssh keys are added directly via the ssh-keys:add command, and thus we can skip this step completely (as there won't be a public key in that path).