### PR TITLE
Force `docker builder prune` to skip confirmation

### DIFF
--- a/plugins/builder/install-builder-prune
+++ b/plugins/builder/install-builder-prune
@@ -16,7 +16,7 @@ After=docker.service
 [Service]
 Type=oneshot
 User=$DOKKU_SYSTEM_USER
-ExecStart=$DOCKER_BIN builder prune
+ExecStart=$DOCKER_BIN builder prune -f
 
 [Install]
 WantedBy=docker.service


### PR DESCRIPTION
Hello! I was excited to see #7184 land because I too had problems with my disk slowly filling up with docker build artefacts.

However, even on Dokku >0.35, this still keeps happening. I looked into the logs and I think the new prune service is never actually deleting anything because it quits when it encounters the confirmation prompt:

```
$ journalctl -u docker-builder-prune.service --boot --no-pager

Oct 19 04:05:02 systemd[1]: Starting docker-builder-prune.service - Docker builder prune service...
Oct 19 04:05:02 docker[422531]: WARNING! This will remove all dangling build cache. Are you sure you want to continue? [y/N]
Oct 19 04:05:02 systemd[1]: docker-builder-prune.service: Deactivated successfully.
Oct 19 04:05:02 systemd[1]: Finished docker-builder-prune.service - Docker builder prune service.
Oct 20 04:05:04 systemd[1]: Starting docker-builder-prune.service - Docker builder prune service...
Oct 20 04:05:04 docker[1068331]: WARNING! This will remove all dangling build cache. Are you sure you want to continue? [y/N]
Oct 20 04:05:04 systemd[1]: docker-builder-prune.service: Deactivated successfully.
Oct 20 04:05:04 systemd[1]: Finished docker-builder-prune.service - Docker builder prune service.
```

I manually added the `-f` to `ExecStart=docker builder prune -f` in `/etc/systemd/system/docker-builder-prune.service`. If I then run the service manually, I get a much more promising output. (I have already pruned it manually a few minutes ago, that's why it's 0B. But I'm optimistic it would work.)

```
$ vim /etc/systemd/system/docker-builder-prune.service # add the -f
$ systemctl --quiet reenable docker-builder-prune
$ systemctl start docker-builder-prune
$ journalctl -u docker-builder-prune.service --boot --no-pager

Oct 20 11:40:10 systemd[1]: Starting docker-builder-prune.service - Docker builder prune service...
Oct 20 11:40:10 docker[1270220]: Total:        0B
Oct 20 11:40:10 systemd[1]: docker-builder-prune.service: Deactivated successfully.
Oct 20 11:40:10 systemd[1]: Finished docker-builder-prune.service - Docker builder prune service.
```

I'm not sure if the `/etc/systemd/system/docker-builder-prune.service` is automatically recreated when upgrading Dokku, or if this PR needs any other changes. Please let me know if there is anything I can do.