### PR TITLE
Remove prefixing releaseName with 'dokku-' in UninstallChart and GetValues calls in  scheduler-k3s/triggers.go

### DIFF
--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -1113,7 +1113,7 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 		return fmt.Errorf("Error creating helm agent: %w", err)
 	}
 
-	values, err := helmAgent.GetValues(fmt.Sprintf("dokku-%s", appName))
+	values, err := helmAgent.GetValues(appName)
 	if err != nil {
 		return fmt.Errorf("Error getting helm values: %w", err)
 	}
@@ -1411,7 +1411,7 @@ func TriggerSchedulerPostDelete(scheduler string, appName string) error {
 		return fmt.Errorf("Error creating helm agent: %w", err)
 	}
 
-	err = helmAgent.UninstallChart(fmt.Sprintf("dokku-%s", appName))
+	err = helmAgent.UninstallChart(appName)
 	if err != nil {
 		return fmt.Errorf("Error uninstalling chart: %w", err)
 	}


### PR DESCRIPTION
TriggerSchedulerRun fails because of this, giving:
```
!     Error getting helm values: Error getting values: release: not found
```
because it's looking for a release name that does not exist.