### PR TITLE
Correct errors in brew doctor output when making a formula release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,19 @@ jobs:
     needs: release
     steps:
       - name: Brew doctor
+        run: |
+          brew doctor || true
+      - name: Brew cleanup
+        run: |
+          echo "====> Untapping homebrew/core"
+          brew untap homebrew/core || true
+          echo "====> Untapping homebrew/cask"
+          brew untap homebrew/cask || true
+          echo "====> Uninstalling openssl@1.1"
+          brew uninstall openssl@1.1 || true
+          echo "====> Uninstalling ruby@3.0"
+          brew uninstall ruby@3.0 || true
+      - name: Brew doctor
         run: brew doctor
       - name: Brew config
         run: brew config


### PR DESCRIPTION
The default homebrew setup with the macos-latest runners has issues that cause `brew doctor` to exit non-zero. The exit codes of the commands are ignored in case they are no longer necessary in the future.