### PR TITLE
Execute one-off commands with DOKKU_APP_SHELL as the initial command under the k3s scheduler

### DIFF
--- a/plugins/app-json/triggers.go
+++ b/plugins/app-json/triggers.go
@@ -226,7 +226,7 @@ func TriggerPostReleaseBuilder(builderType string, appName string, image string)
 		return err
 	}
 
-	if err := setScale(appName, image); err != nil {
+	if err := setScale(appName); err != nil {
 		return err
 	}
 

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -788,24 +788,7 @@ func TriggerSchedulerEnter(scheduler string, appName string, processType string,
 
 	command := args
 	if len(args) == 0 {
-		command = []string{"/bin/bash"}
-		results, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
-			Trigger: "config-get-global",
-			Args:    []string{"DOKKU_APP_SHELL"},
-		})
-		globalShell := results.StdoutContents()
-		if err == nil && globalShell != "" {
-			command = []string{globalShell}
-		}
-
-		results, err = common.CallPlugnTrigger(common.PlugnTriggerInput{
-			Trigger: "config-get",
-			Args:    []string{appName, "DOKKU_APP_SHELL"},
-		})
-		appShell := results.StdoutContents()
-		if err == nil && appShell != "" {
-			command = []string{appShell}
-		}
+		command = []string{common.GetDokkuAppShell(appName)}
 	}
 
 	entrypoint := ""
@@ -1071,25 +1054,9 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 
 	// todo: do something with docker args
 	command := args
+	commandShell := common.GetDokkuAppShell(appName)
 	if len(args) == 0 {
-		command = []string{"/bin/bash"}
-		results, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
-			Trigger: "config-get-global",
-			Args:    []string{"DOKKU_APP_SHELL"},
-		})
-		globalShell := results.StdoutContents()
-		if err == nil && globalShell != "" {
-			command = []string{globalShell}
-		}
-
-		results, err = common.CallPlugnTrigger(common.PlugnTriggerInput{
-			Trigger: "config-get",
-			Args:    []string{appName, "DOKKU_APP_SHELL"},
-		})
-		appShell := results.StdoutContents()
-		if err == nil && appShell != "" {
-			command = []string{appShell}
-		}
+		command = []string{commandShell}
 	} else if len(args) == 1 {
 		resp, err := common.CallPlugnTrigger(common.PlugnTriggerInput{
 			Trigger: "procfile-get-command",
@@ -1135,7 +1102,7 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 	workingDir := common.GetWorkingDir(appName, image)
 	job, err := templateKubernetesJob(Job{
 		AppName:          appName,
-		Command:          command,
+		Command:          []string{commandShell},
 		DeploymentID:     deploymentID,
 		Entrypoint:       entrypoint,
 		Env:              extraEnv,


### PR DESCRIPTION
This commit changes the launched pod to use the configured DOKKU_APP_SHELL - default /bin/bash - to launch processes. Without this, if a non-interactive process was executed and did not immediately exit, it was possible for that process to launch twice - once when the pod started, and once when entering the pod. Ideally we know whether the process is interactive or not, but this isn't always possible when running under a tty (non-tty == non-interactive). As such, this also removes the ability to launch one-off containers that do not have a configured shell in the container, but this is better than attempting to run commands twice.