### PR TITLE
Drop the pod name from stdout output when creating one-off containers under the k3s scheduler

### DIFF
--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -1177,11 +1177,6 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 	if err != nil {
 		return fmt.Errorf("Error waiting for pod to exist: %w", err)
 	}
-
-	for _, pod := range pods {
-		common.LogQuiet(pod.Name)
-	}
-
 	if !attachToPod {
 		return nil
 	}


### PR DESCRIPTION
This adds unexpected output to the command, making parsing more difficult.