### PR TITLE
Add missing export DOKKU_LIB_HOST_ROOT when running dokku in container

### DIFF
--- a/docker/etc/my_init.d/10_dokku_init
+++ b/docker/etc/my_init.d/10_dokku_init
@@ -69,6 +69,11 @@ main() {
     chown dokku:dokku /etc/default/dokku
   fi
 
+  if [[ -n "$DOKKU_LIB_HOST_ROOT" ]]; then
+    echo "export DOKKU_LIB_HOST_ROOT=$DOKKU_LIB_HOST_ROOT" >>/etc/default/dokku
+    chown dokku:dokku /etc/default/dokku
+  fi
+
   if [[ -f /mnt/dokku/plugin-list ]]; then
     while read line; do
       local plugin_name="$(echo "$line" | awk -F: '{print $1}')"


### PR DESCRIPTION
Populates DOKKU_LIB_HOST_ROOT into /etc/default/dokku which is required to enable plugins such as postgres to store data in the correct location.

Fixes #7352 