### PR TITLE
Provide ability to customize chart values via `scheduler-k3s:set`

### DIFF
--- a/docs/deployment/schedulers/k3s.md
+++ b/docs/deployment/schedulers/k3s.md
@@ -572,6 +572,36 @@ dokku scheduler-k3s:set --global kube-context
 
 The default value for the `kube-context` is an empty string, and will result in Dokku using the current context within the kubeconfig.
 
+### Customizing Helm Chart Properties
+
+Dokku includes a number of helm charts by default with settings that are optimized for Dokku. That said, it may be useful to further customize the charts for a given environment. Users can customize which charts are installed by setting properties prefixed with `chart.$CHART_NAME.` with the `--global` flag.
+
+```shell
+dokku scheduler-k3s:set --global chart.cert-manager.version 1.13.3
+```
+
+> [!NOTE]
+> Properties follow dot-notation, and are expanded according to Helm's internal logic. See the [Helm documentation](https://helm.sh/docs/helm/helm_install/#helm-install) for `helm install` for further details.
+
+
+To unset a chart property, omit the value from the `scheduler-k3s:set` call:
+
+```shell
+dokku scheduler-k3s:set --global chart.cert-manager.version
+```
+
+A `scheduler-k3s:ensure-charts` command with the `--force` flag is required after changing any chart properties in order to have them apply. This will install all charts, not just the ones that have changed.
+
+```shell
+dokku scheduler-k3s:ensure-charts --force
+```
+
+Alternatively, a comma separated list of chart names can be specified to only force install the specified charts:
+
+```shell
+dokku scheduler-k3s:ensure-charts --force --chart-names cert-manager
+```
+
 ## Scheduler Interface
 
 The following sections describe implemented and unimplemented scheduler functionality for the `k3s` scheduler.

--- a/plugins/scheduler-k3s/report.go
+++ b/plugins/scheduler-k3s/report.go
@@ -37,6 +37,17 @@ func ReportSingleApp(appName string, format string, infoFlag string) error {
 		"--scheduler-k3s-global-rollback-on-failure":    reportGlobalRollbackOnFailure,
 	}
 
+	chartProperties, err := common.PropertyGetAllByPrefix("scheduler-k3s", "--global", "chart.")
+	if err != nil {
+		return fmt.Errorf("Unable to get property list: %w", err)
+	}
+	for name, value := range chartProperties {
+		flagName := "--scheduler-k3s-global-" + name
+		flags[flagName] = func(appName string) string {
+			return value
+		}
+	}
+
 	flagKeys := []string{}
 	for flagKey := range flags {
 		flagKeys = append(flagKeys, flagKey)

--- a/plugins/scheduler-k3s/src/subcommands/subcommands.go
+++ b/plugins/scheduler-k3s/src/subcommands/subcommands.go
@@ -75,8 +75,10 @@ func main() {
 		err = scheduler_k3s.CommandClusterRemove(nodeName)
 	case "ensure-charts":
 		args := flag.NewFlagSet("scheduler-k3s:ensure-charts", flag.ExitOnError)
+		forceInstall := args.Bool("force", false, "--force: force install all charts")
+		chartNames := args.StringSlice("charts", []string{}, "--charts: comma separated list of chart names to force install")
 		args.Parse(os.Args[2:])
-		err = scheduler_k3s.CommandEnsureCharts()
+		err = scheduler_k3s.CommandEnsureCharts(*forceInstall, *chartNames)
 	case "initialize":
 		args := flag.NewFlagSet("scheduler-k3s:initialize", flag.ExitOnError)
 		taintScheduling := args.Bool("taint-scheduling", false, "taint-scheduling: add a taint against scheduling app workloads")


### PR DESCRIPTION
Dokku ships with default charts and customizes their helm values. In certain cases, it may be useful to further customize those values to better support specific installations. With this change, it is now possible to set custom values by providing the key in the format `chart.$CHART_NAME.$PROPERTY`. For instance, to increase timeouts for the keda http addon:

```shell
dokku scheduler-k3s:set --global chart.keda-add-ons-http.interceptor.tcpConnectTimeout 120s
dokku scheduler-k3s:set --global chart.keda-add-ons-http.interceptor.keepAlive 120s
dokku scheduler-k3s:set --global chart.keda-add-ons-http.interceptor.responseHeaderTimeout 120s
dokku scheduler-k3s:set --global chart.keda-add-ons-http.interceptor.idleConnTimeout 120s
dokku scheduler-k3s:set --global chart.keda-add-ons-http.interceptor.tlsHandshakeTimeout 120s
dokku scheduler-k3s:set --global chart.keda-add-ons-http.interceptor.expectContinueTimeout 120s
```

To reset a value to its default, simply set the value to an empty string.

```shell
dokku scheduler-k3s:set --global chart.keda-add-ons-http.interceptor.tcpConnectTimeout
```

Once the values are set, users will need to then run `scheduler-k3s:ensure-charts` with either the `--force` flag or specify the `--chart` flag with a list of charts to force apply.

```shell
dokku scheduler-k3s:ensure-charts --force

dokku scheduler-k3s:ensure-charts --chart keda-add-ons-http
```

Note that the existing dokku-provided values cannot be removed, but can be overridden.