### PR TITLE
Run unit tests outside of docker by default

### DIFF
--- a/plugins/common/common_test.go
+++ b/plugins/common/common_test.go
@@ -28,7 +28,7 @@ func setupTests() (err error) {
 }
 
 func setupTestApp() (err error) {
-	Expect(os.MkdirAll(testAppDir, 0644)).To(Succeed())
+	Expect(os.MkdirAll(testAppDir, 0766)).To(Succeed())
 	b := []byte(testEnvLine + "\n")
 	if err = os.WriteFile(testEnvFile, b, 0644); err != nil {
 		return
@@ -37,7 +37,7 @@ func setupTestApp() (err error) {
 }
 
 func setupTestApp2() (err error) {
-	Expect(os.MkdirAll(testAppDir2, 0644)).To(Succeed())
+	Expect(os.MkdirAll(testAppDir2, 0766)).To(Succeed())
 	b := []byte(testEnvLine2 + "\n")
 	if err = os.WriteFile(testEnvFile2, b, 0644); err != nil {
 		return

--- a/tests.mk
+++ b/tests.mk
@@ -179,14 +179,16 @@ go-tests:
 	@$(MAKE) go-test-plugin PLUGIN_NAME=network
 
 go-test-plugin:
+	cd plugins/$(PLUGIN_NAME) && go get github.com/onsi/gomega && DOKKU_ROOT=/home/dokku go test -v -p 1 -race -mod=readonly || exit $$?
+
+go-test-plugin-in-docker:
 	@echo running go unit tests...
 	docker run --rm \
-		-e DOKKU_ROOT=/home/dokku \
 		-e GO111MODULE=on \
 		-v $$PWD:$(GO_REPO_ROOT) \
 		-w $(GO_REPO_ROOT) \
 		$(BUILD_IMAGE) \
-		bash -c "cd plugins/$(PLUGIN_NAME) && go get github.com/onsi/gomega && go test -v -p 1 -race -mod=readonly " || exit $$?
+		bash -c "make go-test-plugin PLUGIN_NAME=$(PLUGIN_NAME)" || exit $$?
 
 unit-tests: go-tests
 	@echo running bats unit tests...


### PR DESCRIPTION
This allows execution of unit tests within the devcontainer environment, which already has the correct golang.

Refs #7375