### PR TITLE
Correctly handle scale to zero with the Keda http addon

### DIFF
--- a/plugins/scheduler-k3s/functions.go
+++ b/plugins/scheduler-k3s/functions.go
@@ -669,6 +669,14 @@ func getAutoscaling(input GetAutoscalingInput) (ProcessAutoscaling, error) {
 				httpTrigger.Metadata["concurrency_target_value"] = "100"
 			}
 
+			triggers = append(triggers, ProcessAutoscalingTrigger{
+				Name: trigger.Name,
+				Type: "external-push",
+				Metadata: map[string]string{
+					"httpScaledObject": fmt.Sprintf("%s-%s", input.AppName, input.ProcessType),
+					"scalerAddress":    "keda-add-ons-http-external-scaler.keda:9090",
+				},
+			})
 			continue
 		}
 

--- a/plugins/scheduler-k3s/scheduler_k3s.go
+++ b/plugins/scheduler-k3s/scheduler_k3s.go
@@ -120,7 +120,7 @@ var HelmCharts = []HelmChart{
 		Namespace:       "keda",
 		ReleaseName:     "keda",
 		RepoURL:         "https://kedacore.github.io/charts",
-		Version:         "2.13.1",
+		Version:         "2.16.0",
 	},
 	{
 		ChartPath:       "keda-add-ons-http",


### PR DESCRIPTION
There is a bug in the Keda project that caused Keda to incorrectly handle empty trigger lists. If self-managing the ScaledObject when using an HTTPScaledObject, an external-push trigger must be created.

This change additionally updates the chart to fix any potential bugs in usage of keda.