### PR TITLE
Write contents to stdout before writing to a file

### DIFF
--- a/plugins/common/docker.go
+++ b/plugins/common/docker.go
@@ -155,7 +155,7 @@ func CopyFromImage(appName string, image string, source string, destination stri
 	}()
 
 	// write contents to tmpFile
-	if _, err := tmpFile.Write([]byte(contents)); err != nil {
+	if _, err := tmpFile.Write([]byte(content)); err != nil {
 		return fmt.Errorf("Unable to write to temporary file: %v", err)
 	}
 


### PR DESCRIPTION
Rather than writing directly to the file - thus utilizing whatever user docker is being executed as - we copy the file to stdout and then write it to the temp file. This ensures permissions on the file are as expected from Dokku's end.

Closes #7336