### PR TITLE
Fix detached tty for k3s

### DIFF
--- a/docs/processes/one-off-tasks.md
+++ b/docs/processes/one-off-tasks.md
@@ -66,7 +66,7 @@ dokku run --no-tty node-js-app ls -lah
 > [!IMPORTANT]
 > New as of 0.25.0
 
-Finally, a container can be run in "detached" mode via the `run:detached` Dokku command. Running a process in detached mode will immediately return a `CONTAINER_ID`. Detached containers are run without a tty and are also removed at the end of process execution.
+Finally, a container can be run in "detached" mode via the `run:detached` Dokku command. Running a process in detached mode will immediately return the container name (or pod name when using the k3s scheduler). Detached containers are run without a tty and are also removed at the end of process execution.
 
 ```shell
 dokku run:detached node-js-app ls -lah

--- a/docs/processes/one-off-tasks.md
+++ b/docs/processes/one-off-tasks.md
@@ -66,7 +66,7 @@ dokku run --no-tty node-js-app ls -lah
 > [!IMPORTANT]
 > New as of 0.25.0
 
-Finally, a container can be run in "detached" mode via the `run:detached` Dokku command. Running a process in detached mode will immediately return the container name (or pod name when using the k3s scheduler). Detached containers are run without a tty and are also removed at the end of process execution.
+Finally, a container can be run in "detached" mode via the `run:detached` Dokku command. Running a process in detached mode will immediately return the container name (or pod name when using the k3s scheduler). Detached containers run without a tty by default and are also removed at the end of process execution.
 
 ```shell
 dokku run:detached node-js-app ls -lah

--- a/plugins/scheduler-k3s/k8s.go
+++ b/plugins/scheduler-k3s/k8s.go
@@ -385,7 +385,7 @@ func (k KubernetesClient) ExecCommand(ctx context.Context, input ExecCommandInpu
 
 	size := t.GetSize()
 	sizeQueue := t.MonitorSize(size)
-	actuallyTty := (sizeQueue != nil) || os.Getenv("DOKKU_FORCE_TTY") == "true"
+	actuallyTty := (sizeQueue != nil) || common.ToBool(os.Getenv("DOKKU_FORCE_TTY"))
 
 	if actuallyTty {
 		req.Param("tty", "true")

--- a/plugins/scheduler-k3s/k8s.go
+++ b/plugins/scheduler-k3s/k8s.go
@@ -385,7 +385,7 @@ func (k KubernetesClient) ExecCommand(ctx context.Context, input ExecCommandInpu
 
 	size := t.GetSize()
 	sizeQueue := t.MonitorSize(size)
-	actuallyTty := sizeQueue != nil
+	actuallyTty := (sizeQueue != nil) || os.Getenv("DOKKU_FORCE_TTY") == "true"
 
 	if actuallyTty {
 		req.Param("tty", "true")

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -1142,7 +1142,7 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 		Image:            image,
 		ImagePullSecrets: imagePullSecrets,
 		ImageSourceType:  imageSourceType,
-		Interactive:      attachToPod || os.Getenv("DOKKU_FORCE_TTY") == "true",
+		Interactive:      attachToPod || common.ToBool(os.Getenv("DOKKU_FORCE_TTY")),
 		Labels:           labels,
 		Namespace:        namespace,
 		ProcessType:      processType,

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -1192,7 +1192,7 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 	}
 
 	batchJobSelector := fmt.Sprintf("batch.kubernetes.io/job-name=%s", createdJob.Name)
-	_, err = waitForPodToExist(ctx, WaitForPodToExistInput{
+	pods, err := waitForPodToExist(ctx, WaitForPodToExistInput{
 		Clientset:     clientset,
 		Namespace:     namespace,
 		RetryCount:    3,
@@ -1202,6 +1202,7 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 		return fmt.Errorf("Error waiting for pod to exist: %w", err)
 	}
 	if !attachToPod {
+		fmt.Println(pods[0].Name)
 		return nil
 	}
 
@@ -1254,7 +1255,7 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 		return fmt.Errorf("Error waiting for pod to be running: %w", err)
 	}
 
-	pods, err := clientset.ListPods(ctx, ListPodsInput{
+	pods, err = clientset.ListPods(ctx, ListPodsInput{
 		Namespace:     namespace,
 		LabelSelector: batchJobSelector,
 	})

--- a/plugins/scheduler-k3s/triggers.go
+++ b/plugins/scheduler-k3s/triggers.go
@@ -1142,7 +1142,7 @@ func TriggerSchedulerRun(scheduler string, appName string, envCount int, args []
 		Image:            image,
 		ImagePullSecrets: imagePullSecrets,
 		ImageSourceType:  imageSourceType,
-		Interactive:      attachToPod,
+		Interactive:      attachToPod || os.Getenv("DOKKU_FORCE_TTY") == "true",
 		Labels:           labels,
 		Namespace:        namespace,
 		ProcessType:      processType,


### PR DESCRIPTION
Fixes some inconsistencies for k3s when compared to executing `dokku run:detached` with docker-local scheduler:

1. Prints pod name (similarly docker-local prints container name)
2. Properly sets interactive and tty arguments/variables respecting --force-tty flag (which sets DOKKU_FORCE_TTY)

--

Other suggestion: I notice some ENV variables are being set to "true" and others to "1". Maybe update common.ToBool to also check for "1"?