### PR TITLE
Add missing checks:set to checks help

### DIFF
--- a/plugins/checks/help-functions
+++ b/plugins/checks/help-functions
@@ -31,6 +31,7 @@ fn-help-content() {
     checks:enable <app> [process-type(s)], Enable zero-downtime deployment for all processes (or comma-separated process-type list)
     checks:report [<app>] [<flag>], Displays a checks report for one or more apps
     checks:run <app> [process-type(s)], Runs zero-downtime checks for all processes (or comma-separated process-type list)
+    checks:set [--global|<app>] <key> <value>, Set or clear a logs property for an app
     checks:skip <app> [process-type(s)], Skip zero-downtime checks for all processes (or comma-separated process-type list)
 help_content
 }


### PR DESCRIPTION
I copied from the file [docs/deployment/zero-downtime-deploys.md](https://github.com/dokku/dokku/blob/master/docs/deployment/zero-downtime-deploys.md).

Suggestion: define these help messages in only one place and create an automated way to copy them to the other places needed, so there will be no mismatches in the future. I think puting some "placeholders" inside the `.md` files and them automatically replacing them (extracting content directly from the `help-functions` files) would be a good solution. I tried to make the docs to check if it's something easy to implement and got this problem:

```shell
$ make docs-build
----> Copying mkdocs.yml
      Generating navigation
Traceback (most recent call last):
  File "/usr/src/source/contrib/write-mkdocs", line 148, in <module>
    main()
    ~~~~^^
  File "/usr/src/source/contrib/write-mkdocs", line 137, in main
    generate_nav("/usr/src/source/mkdocs.yml", "/usr/src/app/mkdocs.yml")
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/source/contrib/write-mkdocs", line 107, in generate_nav
    navigation = get_nav_from_selector(soup, selector, docs_dir)
  File "/usr/src/source/contrib/write-mkdocs", line 73, in get_nav_from_selector
    children.sort(
    ~~~~~~~~~~~~~^
        key=lambda x: list(map(int, x.split("-")[0].split("."))),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        reverse=True,
        ^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/source/contrib/write-mkdocs", line 74, in <lambda>
    key=lambda x: list(map(int, x.split("-")[0].split("."))),
                  ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'file'
```

The problem happens because of `./site/appendices/file-formats` - `children` is:
```python
['0.20.0-migration-guide.md',
 '0.31.0-migration-guide.md',
 'file-formats',
 '0.28.0-migration-guide.md',
 '0.21.0-migration-guide.md',
 '0.34.0-migration-guide.md',
 '0.6.0-migration-guide.md',
 '0.5.0-migration-guide.md',
 '0.7.0-migration-guide.md',
 '0.26.0-migration-guide.md',
 '0.33.0-migration-guide.md',
 '0.25.0-migration-guide.md',
 '0.29.0-migration-guide.md',
 '0.27.0-migration-guide.md',
 '0.22.0-migration-guide.md',
 '0.8.0-migration-guide.md',
 '0.9.0-migration-guide.md',
 '0.35.0-migration-guide.md',
 '0.32.0-migration-guide.md',
 '0.24.0-migration-guide.md',
 '0.10.0-migration-guide.md',
 '0.30.0-migration-guide.md',
 '0.23.0-migration-guide.md']
```

It can be fixed changing `contrib/write-mkdocs`:

Before:
```python
                    children.sort(
                        key=lambda x: list(map(int, x.split("-")[0].split("."))),
                        reverse=True,
                    )

```
After:

```python
                    children.sort(
                        key=lambda x: list(map(int, x.split("-")[0].split("."))) if "." in x else [-1, -1, -1],
                        reverse=True,
                    )
```