### PR TITLE
Fix Vagrantfile NFS config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,9 +39,11 @@ Vagrant::configure("2") do |config|
   end
 
   config.vm.define "empty", autostart: false
+  config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false
+
 
   config.vm.define "dokku", primary: true do |vm|
-    vm.vm.synced_folder File.dirname(__FILE__), "/root/dokku"
+    vm.vm.synced_folder File.dirname(__FILE__), "/root/dokku", type: "nfs", nfs_version: 4, nfs_udp: false
     vm.vm.hostname = "#{DOKKU_DOMAIN}"
     vm.vm.network :private_network, ip: DOKKU_IP
 
@@ -77,14 +79,14 @@ Vagrant::configure("2") do |config|
   end
 
   config.vm.define "dokku-deb", autostart: false do |vm|
-    vm.vm.synced_folder File.dirname(__FILE__), "/root/dokku"
+    vm.vm.synced_folder File.dirname(__FILE__), "/root/dokku", type: "nfs", nfs_version: 4, nfs_udp: false
     vm.vm.hostname = "#{DOKKU_DOMAIN}"
     vm.vm.network :private_network, ip: DOKKU_IP
     vm.vm.provision :shell, :inline => "cd /root/dokku && make install-from-deb"
   end
 
   config.vm.define "build", autostart: false do |vm|
-    vm.vm.synced_folder File.dirname(__FILE__), "/root/dokku"
+    vm.vm.synced_folder File.dirname(__FILE__), "/root/dokku", type: "nfs", nfs_version: 4, nfs_udp: false
     vm.vm.hostname = "#{DOKKU_DOMAIN}"
     vm.vm.network :private_network, ip: DOKKU_IP
     vm.vm.provision :shell, :inline => "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq >/dev/null && apt-get -qq -y --no-install-recommends install git >/dev/null && cd /root/dokku && #{make_cmd}"
@@ -93,9 +95,9 @@ Vagrant::configure("2") do |config|
 
   config.vm.define "build-arch", autostart: false do |vm|
     vm.vm.box = "bugyt/archlinux"
-    vm.vm.synced_folder File.dirname(__FILE__), "/dokku"
+    vm.vm.synced_folder File.dirname(__FILE__), "/dokku", type: "nfs", nfs_version: 4, nfs_udp: false
     if Pathname.new("#{File.dirname(__FILE__)}/../dokku-arch").exist?
-      vm.vm.synced_folder "#{File.dirname(__FILE__)}/../dokku-arch", "/dokku-arch"
+      vm.vm.synced_folder "#{File.dirname(__FILE__)}/../dokku-arch", "/dokku-arch", type: "nfs", nfs_version: 4, nfs_udp: false
     end
     vm.vm.hostname = "#{DOKKU_DOMAIN}"
     vm.vm.network :private_network, ip: DOKKU_IP

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,7 @@ Vagrant::configure("2") do |config|
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
 
-    vm.vm.provision :shell, :inline => "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq >/dev/null && apt-get -qq -y --no-install-recommends install git build-essential jq >/dev/null && cd /root/dokku && #{make_cmd}"
+    vm.vm.provision :shell, :inline => "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq >/dev/null && apt-get -qq -y --no-install-recommends install git build-essential jq nginx >/dev/null && cd /root/dokku && #{make_cmd}"
     vm.vm.provision :shell do |s|
       s.inline = <<-EOT
         echo '"\e[5~": history-search-backward' > /root/.inputrc


### PR DESCRIPTION
I had some problems when trying to run the Dokku VM via Vagrant.

The first was related to NFS UDP support. Got this error:

```
mount.nfs: requested NFS version or transport protocol is not supported
```

I tried to [enable NFS UDP support](https://stackoverflow.com/a/74964717/1299446) but got another error:

```
mount.nfs: an incorrect mount option was specified for /vagrant
```

Then, I saw [this issue in Vagrant repo](https://github.com/hashicorp/vagrant/issues/12758) and [this doc page](https://developer.hashicorp.com/vagrant/docs/synced-folders/nfs#other-notes) and tried forcing NFS v4 and disabling UDP in Vagrant configs and it worked!

I also had a problem finding the `nginx` package when running the VM the first time, so I added it to the `apt-get install` command.
