### PR TITLE
Update how domains:clear works and add domains:reset command

### DIFF
--- a/docs/appendices/0.36.0-migration-guide.md
+++ b/docs/appendices/0.36.0-migration-guide.md
@@ -4,3 +4,4 @@
 
 - Process stop timeouts are now configured via the `ps` property `stop-timeout-seconds`. Existing `DOKKU_DOCKER_STOP_TIMEOUT` environment variables will be automatically migrated to the new value.
 - Processes now default to a `30` second stop timeout.
+- The `domains:clear` command no longer runs domain setup after clearing the domains. Use `domains:reset` or run `domains:setup` manually to have the same effect.

--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -6,8 +6,8 @@
 ```
 domains:add <app> <domain> [<domain> ...]      # Add domains to app
 domains:add-global <domain> [<domain> ...]     # Add global domain names
-domains:clear <app>                            # Clear all domains for app
-domains:clear-global                           # Clear global domain names
+domains:clear <app>                            # Remove all app domains
+domains:clear-global                           # Remove all global domains
 domains:disable <app>                          # Disable VHOST support
 domains:enable <app>                           # Enable VHOST support
 domains:remove <app> <domain> [<domain> ...]   # Remove domains from app
@@ -67,7 +67,7 @@ dokku domains:add node-js-app dokku.me
 # list custom domains for app
 dokku domains:report node-js-app
 
-# clear all custom domains for app
+# delete all domains for app
 dokku domains:clear node-js-app
 
 # remove a custom domain from app

--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -6,8 +6,8 @@
 ```
 domains:add <app> <domain> [<domain> ...]      # Add domains to app
 domains:add-global <domain> [<domain> ...]     # Add global domain names
-domains:clear <app>                            # Remove all app domains
-domains:clear-global                           # Remove all global domains
+domains:clear <app>                            # Clear all domains for app
+domains:clear-global                           # Clear global domain names
 domains:disable <app>                          # Disable VHOST support
 domains:enable <app>                           # Enable VHOST support
 domains:remove <app> <domain> [<domain> ...]   # Remove domains from app

--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -68,7 +68,7 @@ dokku domains:add node-js-app dokku.me
 # list custom domains for app
 dokku domains:report node-js-app
 
-# delete all domains for app
+# clear all custom domains for app
 dokku domains:clear node-js-app
 
 # remove a custom domain from app

--- a/docs/configuration/domains.md
+++ b/docs/configuration/domains.md
@@ -13,6 +13,7 @@ domains:enable <app>                           # Enable VHOST support
 domains:remove <app> <domain> [<domain> ...]   # Remove domains from app
 domains:remove-global <domain> [<domain> ...]  # Remove global domain names
 domains:report [<app>|--global] [<flag>]       # Displays a domains report for one or more apps
+domains:reset <app>                            # Reset app domains to global-configured domains
 domains:set <app> <domain> [<domain> ...]      # Set domains for app
 domains:set-global <domain> [<domain> ...]     # Set global domain names
 ```
@@ -75,6 +76,9 @@ dokku domains:remove node-js-app dokku.me
 
 # set all custom domains for app
 dokku domains:set node-js-app dokku.me dokku.org
+
+# delete all app domains and configure available global domains on it
+dokku domains:reset node-js-app
 ```
 
 ## Displaying domains reports for an app

--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -1699,7 +1699,7 @@ curl "http://httpstat.us/200"
 ### `post-domains-update`
 
 - Description: Allows you to run commands once the domain for an app has been updated. It also sends in the command that has been used. This can be "add", "clear" or "remove". The third argument will be the optional list of domains
-- Invoked by: `dokku domains:add`, `dokku domains:clear`, `dokku domains:remove`, `dokku domains:set`
+- Invoked by: `dokku domains:add`, `dokku domains:clear`, `dokku domains:remove`, `dokku domains:reset`, `dokku domains:set`
 - Arguments: `$APP` `action name` `domains`
 - Example:
 

--- a/docs/networking/proxy-management.md
+++ b/docs/networking/proxy-management.md
@@ -158,6 +158,8 @@ At this time, the following dokku commands are used to interact with a complete 
     - triggers: `pre-enable-vhost`
 - `domains:remove`: Removes a domain from an app.
     - triggers: `post-domains-update`
+- `domains:reset`: Reset app domains to global-configured domains.
+    - triggers: `post-domains-update`
 - `domains:set`: Sets all domains for a given app.
     - triggers: `post-domains-update`
 - `proxy:build-config`: Builds - or rebuilds - external proxy configuration.

--- a/docs/networking/proxy-management.md
+++ b/docs/networking/proxy-management.md
@@ -150,7 +150,7 @@ At this time, the following dokku commands are used to interact with a complete 
 
 - `domains:add`: Adds a given domain to an app.
     - triggers: `post-domains-update`
-- `domains:clear`: Remove all app domains.
+- `domains:clear`: Clears out an app's associated domains.
     - triggers: `post-domains-update`
 - `domains:disable`: Disables domains for an app.
     - triggers: `pre-disable-vhost`

--- a/docs/networking/proxy-management.md
+++ b/docs/networking/proxy-management.md
@@ -150,7 +150,7 @@ At this time, the following dokku commands are used to interact with a complete 
 
 - `domains:add`: Adds a given domain to an app.
     - triggers: `post-domains-update`
-- `domains:clear`: Clears out an app's associated domains.
+- `domains:clear`: Remove all app domains.
     - triggers: `post-domains-update`
 - `domains:disable`: Disables domains for an app.
     - triggers: `pre-disable-vhost`

--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -24,9 +24,8 @@ fn-domains-clear-app() {
   local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
 
   rm -f "$APP_VHOST_PATH"
-  domains_setup "$APP"
   plugn trigger post-domains-update "$APP" "clear"
-  dokku_log_info1 "Cleared domains in $APP"
+  dokku_log_info1 "Deleted all domains for $APP"
 }
 
 fn-domains-disable() {

--- a/plugins/domains/functions
+++ b/plugins/domains/functions
@@ -25,7 +25,7 @@ fn-domains-clear-app() {
 
   rm -f "$APP_VHOST_PATH"
   plugn trigger post-domains-update "$APP" "clear"
-  dokku_log_info1 "Deleted all domains for $APP"
+  dokku_log_info1 "Cleared domains in $APP"
 }
 
 fn-domains-disable() {

--- a/plugins/domains/help-functions
+++ b/plugins/domains/help-functions
@@ -29,7 +29,7 @@ fn-help-content() {
   cat <<help_content
     domains:add <app> <domain> [<domain> ...], Add domains to app
     domains:add-global <domain> [<domain> ...], Add global domain names
-    domains:clear <app>, Remove all app domains
+    domains:clear <app>, Clear all domains for app
     domains:clear-global, Clear global domain names
     domains:disable <app>, Disable VHOST support
     domains:enable <app>, Enable VHOST support

--- a/plugins/domains/help-functions
+++ b/plugins/domains/help-functions
@@ -29,7 +29,7 @@ fn-help-content() {
   cat <<help_content
     domains:add <app> <domain> [<domain> ...], Add domains to app
     domains:add-global <domain> [<domain> ...], Add global domain names
-    domains:clear <app>, Clear all domains for app
+    domains:clear <app>, Remove all app domains
     domains:clear-global, Clear global domain names
     domains:disable <app>, Disable VHOST support
     domains:enable <app>, Enable VHOST support

--- a/plugins/domains/help-functions
+++ b/plugins/domains/help-functions
@@ -36,6 +36,7 @@ fn-help-content() {
     domains:remove <app> <domain> [<domain> ...], Remove domains from app
     domains:remove-global <domain> [<domain> ...], Remove global domain names
     domains:report [<app>|--global] [<flag>], Displays a domains report for one or more apps
+    domains:reset <app>, Reset app domains to global-configured domains
     domains:set <app> <domain> [<domain> ...], Set domains for app
     domains:set-global <domain> [<domain> ...], Set global domain names
 help_content

--- a/plugins/domains/subcommands/clear
+++ b/plugins/domains/subcommands/clear
@@ -5,7 +5,7 @@ source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/domains/functions"
 
 cmd-domains-clear() {
-  declare desc="clear all app domains"
+  declare desc="remove all app domains"
   declare cmd="domains:clear"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"

--- a/plugins/domains/subcommands/clear
+++ b/plugins/domains/subcommands/clear
@@ -5,7 +5,7 @@ source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/domains/functions"
 
 cmd-domains-clear() {
-  declare desc="remove all app domains"
+  declare desc="clear all app domains"
   declare cmd="domains:clear"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1"

--- a/plugins/domains/subcommands/clear-global
+++ b/plugins/domains/subcommands/clear-global
@@ -5,11 +5,11 @@ source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/domains/functions"
 
 cmd-domains-clear-global() {
-  declare desc="clear global domain names via command line"
+  declare desc="remove all global domains"
   declare cmd="domains:clear-global"
   [[ "$1" == "$cmd" ]] && shift 1
 
-  dokku_log_info1_quiet "Clearing global domains"
+  dokku_log_info1_quiet "Deleting global domains"
   domains_clear_global "$@"
 }
 

--- a/plugins/domains/subcommands/clear-global
+++ b/plugins/domains/subcommands/clear-global
@@ -5,11 +5,11 @@ source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 source "$PLUGIN_AVAILABLE_PATH/domains/functions"
 
 cmd-domains-clear-global() {
-  declare desc="remove all global domains"
+  declare desc="clear global domain names"
   declare cmd="domains:clear-global"
   [[ "$1" == "$cmd" ]] && shift 1
 
-  dokku_log_info1_quiet "Deleting global domains"
+  dokku_log_info1_quiet "Clearing global domains"
   domains_clear_global "$@"
 }
 

--- a/plugins/domains/subcommands/reset
+++ b/plugins/domains/subcommands/reset
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/domains/functions"
+
+cmd-domains-reset() {
+  declare desc="reset app domains to global-configured domains"
+  declare cmd="domains:reset"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1"
+
+  verify_app_name "$APP"
+  local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
+
+  rm -f "$APP_VHOST_PATH"
+  domains_setup "$APP"
+  plugn trigger post-domains-update "$APP" "reset"
+  dokku_log_info1 "Reset domains for $APP"
+}
+
+cmd-domains-reset "$@"

--- a/plugins/domains/subcommands/reset
+++ b/plugins/domains/subcommands/reset
@@ -11,12 +11,10 @@ cmd-domains-reset() {
   declare APP="$1"
 
   verify_app_name "$APP"
-  local APP_VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
-
-  rm -f "$APP_VHOST_PATH"
+  fn-domains-clear "$APP"
   domains_setup "$APP"
   plugn trigger post-domains-update "$APP" "reset"
-  dokku_log_info1 "Reset domains for $APP"
+  dokku_log_info1_quiet "Reset domains for $APP"
 }
 
 cmd-domains-reset "$@"

--- a/plugins/domains/subcommands/setup
+++ b/plugins/domains/subcommands/setup
@@ -12,6 +12,8 @@ cmd-domains-setup() {
 
   verify_app_name "$APP"
   domains_setup "$APP"
+  plugn trigger post-domains-update "$APP" "reset"
+  dokku_log_info1_quiet "Setup domains for $APP"
 }
 
 cmd-domains-setup "$@"

--- a/tests/unit/domains.bats
+++ b/tests/unit/domains.bats
@@ -188,7 +188,7 @@ teardown() {
   assert_output_contains a--domain.with--hyphens
 }
 
-@test "(domains) domains:clear" {
+@test "(domains) domains:reset" {
   run /bin/bash -c "dokku domains:add $TEST_APP test.app.${DOKKU_DOMAIN}"
   echo "output: $output"
   echo "status: $status"
@@ -199,7 +199,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku domains:clear $TEST_APP"
+  run /bin/bash -c "dokku domains:reset $TEST_APP"
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/domains.bats
+++ b/tests/unit/domains.bats
@@ -347,8 +347,8 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  # run domains:clear in order to invoke default vhost creation
-  run /bin/bash -c "dokku --quiet domains:clear test.dokku.test"
+  # run domains:reset in order to invoke default vhost creation
+  run /bin/bash -c "dokku --quiet domains:reset test.dokku.test"
   echo "output: $output"
   echo "status: $status"
   assert_success


### PR DESCRIPTION
Fixes #7438

Note: this is my first PR/change to a Dokku core plugin and I wasn't sure how to implement a proper test, so a test missing for `domains:clear` (since the old test now actually tests the `domains:reset` functionality and I just renamed it). I think this is the only thing missing in this PR. Could you help me implementing this?