### PR TITLE
Add missing post-delete scripts to checks, caddy-vhosts and haproxy-vhosts

### DIFF
--- a/plugins/caddy-vhosts/post-delete
+++ b/plugins/caddy-vhosts/post-delete
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-caddy-vhosts-post-delete() {
+  declare desc="caddy-vhosts post-delete trigger"
+  declare trigger="post-delete"
+  declare APP="$1"
+
+  fn-plugin-property-destroy "caddy" "$APP"
+}
+
+trigger-caddy-vhosts-post-delete "$@"

--- a/plugins/checks/post-delete
+++ b/plugins/checks/post-delete
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-checks-post-delete() {
+  declare desc="checks post-delete trigger"
+  declare trigger="post-delete"
+  declare APP="$1"
+
+  fn-plugin-property-destroy "checks" "$APP"
+}
+
+trigger-checks-post-delete "$@"

--- a/plugins/haproxy-vhosts/post-delete
+++ b/plugins/haproxy-vhosts/post-delete
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+trigger-haproxy-vhosts-post-delete() {
+  declare desc="haproxy-vhosts post-delete trigger"
+  declare trigger="post-delete"
+  declare APP="$1"
+
+  fn-plugin-property-destroy "haproxy" "$APP"
+}
+
+trigger-haproxy-vhosts-post-delete "$@"


### PR DESCRIPTION
This PR fixes #7443. Since this was a simple fix, I preferred not to create an issue/PR for each plugin.

Note: I'm not used to the Dokku test suite and couldn't run it properly here, so I just copied the `post-delete` from another plugin and changed the names accordingly. If you feel like a test is needed, could you please send me more context on how to do it?
The tests could be something like this:

```shell
# For checks

APP_NAME="test-app-checks-bug"
dokku apps:create "$APP_NAME"

dokku checks:report "$APP_NAME" | grep 'Checks wait to retire:'
# TODO: assert no value defined

dokku checks:set "$APP_NAME" wait-to-retire 120
dokku checks:report "$APP_NAME" | grep 'Checks wait to retire:'
# TODO: assert output has '120'

echo "$APP_NAME" | dokku apps:destroy "$APP_NAME"
dokku apps:create "$APP_NAME"
dokku checks:report "$APP_NAME" | grep 'Checks wait to retire:'
# TODO: assert no value defined
```

```shell
# For caddy-vhosts

APP_NAME="test-app-bug-plugin-caddy-data"
dokku apps:create "$APP_NAME"
dokku caddy:report "$APP_NAME" | grep 'Caddy tls internal'
# TODO: check output 'false' (default value)

dokku caddy:set "$APP_NAME" tls-internal true
dokku caddy:report "$APP_NAME" | grep 'Caddy tls internal'
# TODO: check output 'true'

echo "$APP_NAME" | dokku apps:destroy "$APP_NAME"
dokku apps:create "$APP_NAME"
dokku caddy:report "$APP_NAME" | grep 'Caddy tls internal' 
# TODO: check output 'false'
```

For haproxy I could not reproduce it since it seems that it ignores the app settings - the only settings that matter are `--global`, which is weird because the `haproxy:report <app-name>` shows "Haproxy image:" for each app (and it doesn't have the prefix "**Global**" as other plugins like `domains`). To clarify:

```shell
APP_NAME="test-app-bug-plugin-haproxy-data"
dokku apps:create "$APP_NAME"
dokku haproxy:report "$APP_NAME" | grep 'Haproxy image:'
# Gives: byjg/easy-haproxy:4.4.0

# New image for app: report does not show it
dokku haproxy:set "$APP_NAME" image new-value-for-app
dokku haproxy:report "$APP_NAME" | grep 'Haproxy image:'
# Result: byjg/easy-haproxy:4.4.0

# New image for global: report does show it
dokku haproxy:set --global image new-value-for-global
dokku haproxy:report "$APP_NAME" | grep 'Haproxy image:'
# Result: new-value-for-global
```