### PR TITLE
Only redeploy formations that have had their values changed

### DIFF
--- a/plugins/ps/subcommands.go
+++ b/plugins/ps/subcommands.go
@@ -160,7 +160,13 @@ func CommandScale(appName string, skipDeploy bool, processTuples []string) error
 	}
 
 	common.LogInfo1(fmt.Sprintf("Scaling %s processes: %s", appName, strings.Join(processTuples, " ")))
-	return scaleSet(appName, skipDeploy, false, processTuples)
+	return scaleSet(scaleSetInput{
+		appName:           appName,
+		skipDeploy:        skipDeploy,
+		clearExisting:     false,
+		processTuples:     processTuples,
+		deployOnlyChanged: true,
+	})
 }
 
 // CommandSet sets or clears a ps property for an app

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -339,7 +339,13 @@ func TriggerPsCurrentScale(appName string) error {
 
 // TriggerPsSetScale configures the scale parameters for a given app
 func TriggerPsSetScale(appName string, skipDeploy bool, clearExisting bool, processTuples []string) error {
-	return scaleSet(appName, skipDeploy, clearExisting, processTuples)
+	return scaleSet(scaleSetInput{
+		appName:           appName,
+		skipDeploy:        skipDeploy,
+		clearExisting:     clearExisting,
+		processTuples:     processTuples,
+		deployOnlyChanged: false,
+	})
 }
 
 func TriggerPsGetProperty(appName string, property string) error {

--- a/tests/unit/ps-dockerfile-2.bats
+++ b/tests/unit/ps-dockerfile-2.bats
@@ -171,3 +171,18 @@ teardown() {
     assert_success
   done
 }
+
+@test "(ps:scale) dockerfile unchanged process" {
+  run deploy_app dockerfile
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku ps:scale $TEST_APP worker=2"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output_contains "Scaling $TEST_APP processes: worker=2"
+  assert_output_contains "Deploying worker"
+  assert_output_contains "Deploying web" 0
+  assert_success
+}


### PR DESCRIPTION
Rather than redeploy every formation, only deploy formations that have had their values changed from the defaults.

This still doesn't handle the case where we touch existing processes when scaling _up_, but should decrease the number of services touched otherwise during scaling.

Also note that there are no tests for this new behavior yet (tests incoming).

Refs #7396