### PR TITLE
[docs] update vector container volume mount description

### DIFF
--- a/docs/deployment/logs.md
+++ b/docs/deployment/logs.md
@@ -116,9 +116,11 @@ dokku logs:vector-start --vector-image timberio/vector:latest-debian
 
 The `vector` container will be started with the following volume mounts:
 
-- `/var/lib/dokku/data/logs/vector.json:/etc/vector/vector.json`
+- `/var/lib/dokku/data/logs:/etc/vector`
 - `/var/run/docker.sock:/var/run/docker.sock`
 - `/var/log/dokku/apps:/var/log/dokku/apps`
+
+The `/etc/vector` mount includes the `vector.json` configuration file, but also may be used to provide extra files to the vector container.
 
 The final volume mount - `/var/log/dokku/apps` - may be used for users that wish to ship logs to a file on disk that may be later logrotated. This directory is owned by the `dokku` user and group, with permissions set to `0755`. At this time, log-rotation is not configured for this directory.
 


### PR DESCRIPTION
While trying to get google stackdriver logging set up, I realized someone had previously requested (https://github.com/dokku/dokku/issues/4971) that the entire `/etc/vector` be mounted instead of just the file.  

The change was incorporated in 0.31.0 and the changes were described in the changelog (https://dokku.com/docs/appendices/0.31.0-migration-guide/), but it seems they were not updated in the vector logging documentation.

I've made a small change to the docs to clarify this new behavior