### PR TITLE
Include troubleshooting details about app A being served when app B was expected due to in-app SSL redirects

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -226,11 +226,20 @@ sudo ufw disable
 
 ### I can't connect to my application because the server is sending an invalid response, or can't provide a secure connection
 
-This isn't usually an issue with Dokku, but rather an app config problem. This can happen when your application is configured to enforce secure connections/HSTS, but you don't have SSL set up for the app.
+This is normally a config problem with your app, rather than an issue with Dokku. 
 
-In Rails at least, if your `application.rb` or `environmnents/production.rb` include the line `configure.force_ssl = true` which includes HSTS, try commenting that out and redeploying.
+One common cause is an application configured to enforce secure connections/HSTS, but SSL is not set up. In Ruby on Rails, if your `application.rb` or `config/environments/production.rb` include the line `configure.force_ssl = true`, try commenting that line out and redeploying. If this solves the issue temporarily, longer-term you should consider [configuring SSL](/docs/configuration/ssl.md).
 
-If this solves the issue temporarily, longer term you should consider [configuring SSL](/docs/configuration/ssl.md).
+
+### I deployed a new application, but an existing application is being served when I visit it
+
+This problem has the same cause as the previous issue: your application is attempting to enforce SSL, but SSL is not configured. Disabling SSL enforcement should solve the problem.
+
+The underlying cause is best understood with an example. Let's say you already have `https://apples.example.com/` working, and you're trying to deploy `bananas.example.com/`. But whenever you visit `bananas.example.com` you see `apples.example.com` instead. This is caused by `bananas.example.com` forcing SSL: 
+1. Your browser sends a request to `http://bananas.example.com`.
+1. `bananas.example.com` issues a redirect to `https://bananas.example.com`.
+1. Your browser sends a request to `https://bananas.example.com`. But you haven't configured SSL for `bananas.example.com` yet! So this request ends up routed to `https://apples.example.com`, which _does_ have an SSL config.
+
 
 ### My application deploys properly, but won't load in browser "connection refused"
 


### PR DESCRIPTION
A while back I ran into trouble deploying a new application to my Dokku instance. After some troubleshooting in the Dokku IRC channel (thanks!) we figured out it was related to the SSL config: my new app B didn't have SSL set up yet, but was configured to enforce SSL. My new app was issuing a 301 redirect to an `https://` URL, and Dokku's nginx routed that request to an existing app with SSL configured. 

This PR: 
* Adds a new "I deployed a new application, but an existing application is being served when I visit it" section describing the cause of this problem, and the solution;
* Tweaks the wording on the preceding SSL section.