### PR TITLE
feat: delegate authorized_keys file validation to sshcommand

### DIFF
--- a/contrib/dependencies.json
+++ b/contrib/dependencies.json
@@ -42,10 +42,10 @@
     },
     {
       "name": "sshcommand",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "urls": {
-        "amd64": "https://github.com/dokku/sshcommand/releases/download/v0.18.0/sshcommand",
-        "arm64": "https://github.com/dokku/sshcommand/releases/download/v0.18.0/sshcommand"
+        "amd64": "https://github.com/dokku/sshcommand/releases/download/v0.19.0/sshcommand",
+        "arm64": "https://github.com/dokku/sshcommand/releases/download/v0.19.0/sshcommand"
       }
     }
   ],

--- a/plugins/ssh-keys/subcommands/list
+++ b/plugins/ssh-keys/subcommands/list
@@ -23,7 +23,6 @@ cmd-ssh-keys-list() {
     FORMAT=""
   fi
 
-  verify_ssh_key_file
   if [[ "$FORMAT" == "json" ]]; then
     if [[ -n "$NAME" ]]; then
       sshcommand list dokku "" "$FORMAT" | jq -cM "[.[] | select(.name == \"$NAME\")]"


### PR DESCRIPTION
Rather than try and validate this out of band, depend on sshcommand for performing any such checks on the file. There isn't any need for dokku to duplicate this when listing the contents of the file.