### PR TITLE
Fix display of numbered list in docs

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -236,6 +236,7 @@ One common cause is an application configured to enforce secure connections/HSTS
 This problem has the same cause as the previous issue: your application is attempting to enforce SSL, but SSL is not configured. Disabling SSL enforcement should solve the problem.
 
 The underlying cause is best understood with an example. Let's say you already have `https://apples.example.com/` working, and you're trying to deploy `bananas.example.com/`. But whenever you visit `bananas.example.com` you see `apples.example.com` instead. This is caused by `bananas.example.com` forcing SSL: 
+
 1. Your browser sends a request to `http://bananas.example.com`.
 1. `bananas.example.com` issues a redirect to `https://bananas.example.com`.
 1. Your browser sends a request to `https://bananas.example.com`. But you haven't configured SSL for `bananas.example.com` yet! So this request ends up routed to `https://apples.example.com`, which _does_ have an SSL config.


### PR DESCRIPTION
_See also: #7542._

I recently added some [troubleshooting documentation](https://github.com/dokku/dokku/pull/7542) that included a Markdown numbered list. Unfortunately, this needs a blank line before the list for `mkdocs` to recognise it. This PR fixes the rendering on the Dokku site. 

---

Before: 
<img width="696" alt="image" src="https://github.com/user-attachments/assets/2b914fc4-f279-4a78-88a6-320729560aac" />

---

After: 
<img width="713" alt="image" src="https://github.com/user-attachments/assets/e51a76be-e551-4b43-a70f-5c66820ad5a2" />
