### PR TITLE
fix: update test for newer git version

### DIFF
--- a/tests/unit/git_1.bats
+++ b/tests/unit/git_1.bats
@@ -83,11 +83,15 @@ teardown() {
   echo "status: $status"
   assert_success
 
+  run /bin/bash -c "dokku enter $TEST_APP web git status"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run /bin/bash -c "dokku enter $TEST_APP web ls .git"
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains "branches"
   assert_output_contains "config"
   assert_output_contains "description"
   assert_output_contains "HEAD"


### PR DESCRIPTION
The newer git version seems to remove the branches directory for some odd reason. I've attempted debugging this but that git version isn't available for Ubuntu 24.04 - Github Actions seems to install it regardless.

Rather than waste cycles, just remove it from CI.