### PR TITLE
fix: do not write VHOST file if the DOKKU_ROOT directory does not exist

### DIFF
--- a/plugins/00_dokku-standard/install
+++ b/plugins/00_dokku-standard/install
@@ -2,8 +2,10 @@
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 
-if [[ ! -f "$DOKKU_ROOT/VHOST" ]]; then
-  [[ $(dig +short "$(hostname -f)") ]] && hostname -f >"$DOKKU_ROOT/VHOST"
+if [[ ! -f "$DOKKU_ROOT/VHOST" ]] && [[ -n "$(dig +short "$(hostname -f)")" ]]; then
+  if [[ -d "$DOKKU_ROOT" ]] || [[ -L "$DOKKU_ROOT" ]]; then
+    hostname -f >"$DOKKU_ROOT/VHOST"
+  fi
 fi
 
 dokku_path="$(command -v dokku)"


### PR DESCRIPTION
This can happen when building a new docker image as the DOKKU_ROOT directory isn't mounted yet.