### PR TITLE
Restore the git head ref when running repo:gc

### DIFF
--- a/plugins/repo/subcommands.go
+++ b/plugins/repo/subcommands.go
@@ -1,8 +1,6 @@
 package repo
 
 import (
-	"fmt"
-
 	"github.com/dokku/dokku/plugins/common"
 )
 
@@ -12,25 +10,7 @@ func CommandGc(appName string) error {
 		return err
 	}
 
-	appRoot := common.AppRoot(appName)
-	cmdEnv := map[string]string{
-		"GIT_DIR": appRoot,
-	}
-
-	result, err := common.CallExecCommand(common.ExecCommandInput{
-		Command:     "git",
-		Args:        []string{"gc", "--aggressive"},
-		Env:         cmdEnv,
-		StreamStdio: true,
-	})
-	if err != nil {
-		return fmt.Errorf("Unable to run git gc: %w", err)
-	}
-	if result.ExitCode != 0 {
-		return fmt.Errorf("Unable to run git gc: %s", result.StderrContents())
-	}
-
-	return nil
+	return RepoGc(appName)
 }
 
 // CommandPurgeCache deletes the contents of the build cache stored in the repository


### PR DESCRIPTION
When git --aggressive is run on a bare repo, it deletes all head refs. This change copies the contents into memory and then writes them out at the end of the repo:gc call.

Closes #6973