### PR TITLE
Do not set network flag when building dockerfile images

### DIFF
--- a/plugins/network/src/triggers/triggers.go
+++ b/plugins/network/src/triggers/triggers.go
@@ -20,13 +20,16 @@ func main() {
 	switch trigger {
 	case "docker-args-process-build":
 		appName := flag.Arg(0)
-		err = network.TriggerDockerArgsProcess(appName)
+		imageSourceType := flag.Arg(1)
+		err = network.TriggerDockerArgsProcess("build", appName, imageSourceType)
 	case "docker-args-process-deploy":
 		appName := flag.Arg(0)
-		err = network.TriggerDockerArgsProcess(appName)
+		imageSourceType := flag.Arg(1)
+		err = network.TriggerDockerArgsProcess("deploy", appName, imageSourceType)
 	case "docker-args-process-run":
 		appName := flag.Arg(0)
-		err = network.TriggerDockerArgsProcess(appName)
+		imageSourceType := flag.Arg(1)
+		err = network.TriggerDockerArgsProcess("run", appName, imageSourceType)
 	case "install":
 		err = network.TriggerInstall()
 	case "network-build-config":

--- a/plugins/network/triggers.go
+++ b/plugins/network/triggers.go
@@ -10,10 +10,15 @@ import (
 )
 
 // TriggerDockerArgsProcess outputs the network plugin docker options for an app
-func TriggerDockerArgsProcess(appName string) error {
+func TriggerDockerArgsProcess(stage string, appName string, imageSourceType string) error {
 	stdin, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
+	}
+
+	if stage == "build" && imageSourceType == "dockerfile" {
+		fmt.Print(string(stdin))
+		return nil
 	}
 
 	initialNetwork := reportComputedInitialNetwork(appName)


### PR DESCRIPTION
The network flag is unsupported by the docker image build command under buildx (which is default now).

Closes #7520