### PR TITLE
tests: add test to prove Dokku respects the Procfile when deploying from an image

### DIFF
--- a/plugins/git/git-from-image
+++ b/plugins/git/git-from-image
@@ -22,7 +22,6 @@ trigger-git-git-from-image() {
     rsync -a "$BUILD_DIR/" "$TMP_WORK_DIR"
   fi
 
-  dokku_log_verbose "Setting Dockerfile"
   touch "$TMP_WORK_DIR/Dockerfile"
   echo "FROM $DOCKER_IMAGE" >>"$TMP_WORK_DIR/Dockerfile"
   echo "LABEL com.dokku.docker-image-labeler/alternate-tags=[\\\"$DOCKER_IMAGE\\\"]" >>"$TMP_WORK_DIR/Dockerfile"

--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -90,7 +90,7 @@ trigger-scheduler-docker-local-scheduler-deploy() {
       trap '' INT HUP
       sleep "$DOKKU_WAIT_TO_RETIRE"
       for oldid in $oldids; do
-        if ! docker container inspect "$oldid" &>/dev/null; then
+        if ! "$DOCKER_BIN" container inspect "$oldid" &>/dev/null; then
           continue
         fi
         # Disable the container restart policy

--- a/tests/unit/builder-dockerfile.bats
+++ b/tests/unit/builder-dockerfile.bats
@@ -94,3 +94,15 @@ EOF
   echo "status: $status"
   assert_output "3001/udp 3000/tcp 3003"
 }
+
+@test "(builder-dockerfile) ps:rebuild fetches files from image" {
+  run /bin/bash -c "dokku --trace git:from-image $TEST_APP dokku/smoke-test-app:dockerfile"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}


### PR DESCRIPTION
Any subsequent ps:rebuild should always respect the image for fetching files. This test proves this works.

Closes #7375