### PR TITLE
Drop compromisde tj-actions/changed-files from Ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,15 +56,9 @@ jobs:
         run: "make image/init/digitalocean"
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get changed files in the docs folder
-        id: changed-files-specific
-        uses: tj-actions/changed-files@v45.0.8
-        with:
-          files: contrib/images/digitalocean/**
       - name: Run `packer validate`
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: "make image/validate/digitalocean"
 
   shellcheck:


### PR DESCRIPTION
I've manually audited our usage and it doesn't look like credentials were printed anywhere, but before they do for another PR, just remove the usage.

If this ends up failing CI, thats also fine, I'll just remove packer validation and manually run it if that file changes.

Note: This should have had no impact on the dokku project - I've rotated credentials regardless - just posting this here for visibility.

See https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised for details.