### PR TITLE
fix: bump dokku version in main.bicep when bumping azure versions

### DIFF
--- a/.github/commands/bump-azure
+++ b/.github/commands/bump-azure
@@ -18,7 +18,11 @@ main() {
 
   cd tmp
 
-  $GH_FOLDER/bin/gh auth login --with-token <<<"$BOT_GITHUB_API_TOKEN"
+  if [[ -n "$BOT_GITHUB_API_TOKEN" ]]; then
+    $GH_FOLDER/bin/gh auth login --with-token <<<"$BOT_GITHUB_API_TOKEN"
+  else
+    echo "BOT_GITHUB_API_TOKEN is not set, skipping gh auth login"
+  fi
 
   echo "=====> Cloning quickstart templates"
   rm -rf azure-quickstart-templates >/dev/null
@@ -35,15 +39,29 @@ main() {
   contents="$(jq --arg VERSION "$VERSION" '.parameters.dokkuVersion.defaultValue = $VERSION' application-workloads/dokku/dokku-vm/azuredeploy.json)"
   echo "${contents}" >application-workloads/dokku/dokku-vm/azuredeploy.json
 
+  # update the version in main.bicep
+  # the line being updated looks like this:
+  # param dokkuVersion string = '0.28.4'
+  # we need to update the value of dokkuVersion to the new version
+  sed -i "s/param dokkuVersion string = '[^']*'/param dokkuVersion string = '$VERSION'/" application-workloads/dokku/dokku-vm/main.bicep
+
   echo "=====> Updating remote repository"
   git add application-workloads/dokku/dokku-vm
   git checkout -b dokku-$VERSION
   git commit -m "Update dokku-vm dokku version to $VERSION"
-  git remote set-url origin "https://$BOT_GITHUB_USERNAME:$BOT_GITHUB_API_TOKEN@github.com/dokku/azure-quickstart-templates.git"
-  git push -f origin dokku-$VERSION
+  if [[ -z "$BOT_GITHUB_API_TOKEN" ]] || [[ -z "$BOT_GITHUB_USERNAME" ]]; then
+    echo "BOT_GITHUB_API_TOKEN or BOT_GITHUB_USERNAME is not set, skipping git remote set-url"
+  else
+    git remote set-url origin "https://$BOT_GITHUB_USERNAME:$BOT_GITHUB_API_TOKEN@github.com/dokku/azure-quickstart-templates.git"
+    git push -f origin dokku-$VERSION
+  fi
 
-  echo "=====> Creating upstream pull request"
-  ../$GH_FOLDER/bin/gh pr create --head dokku:dokku-$VERSION --repo Azure/azure-quickstart-templates --title "Update dokku-vm dokku version to $VERSION" --body ''
+  if [[ -z "$BOT_GITHUB_API_TOKEN" ]] || [[ -z "$BOT_GITHUB_USERNAME" ]]; then
+    echo "BOT_GITHUB_API_TOKEN or BOT_GITHUB_USERNAME is not set, skipping gh pr create"
+  else
+    echo "=====> Creating upstream pull request"
+    ../$GH_FOLDER/bin/gh pr create --head dokku:dokku-$VERSION --repo Azure/azure-quickstart-templates --title "Update dokku-vm dokku version to $VERSION" --body ''
+  fi
 
   popd &>/dev/null
 }


### PR DESCRIPTION
This file autogenerates azuredeploy.json, so we need to bump it as well.