### PR TITLE
Implement proxy container :label feature

### DIFF
--- a/plugins/caddy-vhosts/command-functions
+++ b/plugins/caddy-vhosts/command-functions
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/command-functions"
 source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
+
+cmd-caddy-label() {
+  declare desc="set/unset/show container proxy labels"
+  declare cmd="caddy:label"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1"
+
+  set -- caddy "$@"
+  cmd-proxy-label "$@"
+}
 
 cmd-caddy-report() {
   declare desc="displays a caddy report for one or more apps"

--- a/plugins/caddy-vhosts/docker-args-process-deploy
+++ b/plugins/caddy-vhosts/docker-args-process-deploy
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
@@ -126,6 +127,15 @@ trigger-caddy-vhosts-docker-args-process-deploy() {
 
       output="$output --label \"caddy.reverse_proxy={{ upstreams $proxy_container_http_port }}\""
     fi
+  fi
+
+  local proxy_labels_file_path=$(fn-get-proxy-labels-file-path "$APP" caddy)
+  fn-report-proxy-label-overwrite "$output" "$proxy_labels_file_path"
+
+  if [[ -f "$proxy_labels_file_path" ]]; then
+    local user_proxy_labels="$(<"$proxy_labels_file_path")"
+    user_proxy_labels="$(echo "$user_proxy_labels" | tr '\r\n' ' ')"
+    output="$output $user_proxy_labels"
   fi
 
   echo -n "$STDIN$output"

--- a/plugins/caddy-vhosts/help-functions
+++ b/plugins/caddy-vhosts/help-functions
@@ -30,6 +30,7 @@ fn-help-content() {
     caddy:report [<app>] [<flag>], Displays an caddy report for one or more apps
     caddy:set <app> <property> (<value>), Set or clear an caddy property for an app
     caddy:show-config <app>, Display caddy compose config
+    caddy:label <app> <show | set | unset> <property> (<value>), Show, set or clear a caddy label for an app
     caddy:start, Starts the caddy server
     caddy:stop, Stops the caddy server
 help_content

--- a/plugins/caddy-vhosts/subcommands/label
+++ b/plugins/caddy-vhosts/subcommands/label
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-caddy-label "$@"

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -416,6 +416,12 @@ fn-is-compose-installed() {
   return 1
 }
 
+escape_extended_sed() {
+  # Escaped delimiter is '/'
+  local input="$1"
+  echo "$input" | sed -E 's#[][()\.^$?*+{}|/]#\\&#g'
+}
+
 is_number() {
   declare desc="returns 0 if input is a number"
   local NUMBER=$1

--- a/plugins/haproxy-vhosts/command-functions
+++ b/plugins/haproxy-vhosts/command-functions
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/command-functions"
 source "$PLUGIN_AVAILABLE_PATH/haproxy-vhosts/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
+
+cmd-haproxy-label() {
+  declare desc="set/unset/show container proxy labels"
+  declare cmd="haproxy:label"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1"
+
+  set -- haproxy "$@"
+  cmd-proxy-label "$@"
+}
 
 cmd-haproxy-report() {
   declare desc="displays a haproxy report for one or more apps"

--- a/plugins/haproxy-vhosts/docker-args-process-deploy
+++ b/plugins/haproxy-vhosts/docker-args-process-deploy
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 source "$PLUGIN_AVAILABLE_PATH/haproxy-vhosts/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
@@ -121,6 +122,15 @@ trigger-haproxy-vhosts-docker-args-process-deploy() {
     else
       output="$output --label haproxy.$APP-$PROC_TYPE.redirect_ssl=false"
     fi
+  fi
+
+  local proxy_labels_file_path=$(fn-get-proxy-labels-file-path "$APP" haproxy)
+  fn-report-proxy-label-overwrite "$output" "$proxy_labels_file_path"
+
+  if [[ -f "$proxy_labels_file_path" ]]; then
+    local user_proxy_labels="$(<"$proxy_labels_file_path")"
+    user_proxy_labels="$(echo "$user_proxy_labels" | tr '\r\n' ' ')"
+    output="$output $user_proxy_labels"
   fi
 
   echo -n "$STDIN$output"

--- a/plugins/haproxy-vhosts/help-functions
+++ b/plugins/haproxy-vhosts/help-functions
@@ -30,6 +30,7 @@ fn-help-content() {
     haproxy:report [<app>] [<flag>], Displays an haproxy report for one or more apps
     haproxy:set <app> <property> (<value>), Set or clear an haproxy property for an app
     haproxy:show-config <app>, Display haproxy compose config
+    haproxy:label <app> <show | set | unset> <property> (<value>), Show, set or clear a haproxy label for an app
     haproxy:start, Starts the haproxy server
     haproxy:stop, Stops the haproxy server
 help_content

--- a/plugins/haproxy-vhosts/subcommands/label
+++ b/plugins/haproxy-vhosts/subcommands/label
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/haproxy-vhosts/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-haproxy-label "$@"

--- a/plugins/openresty-vhosts/command-functions
+++ b/plugins/openresty-vhosts/command-functions
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/command-functions"
 source "$PLUGIN_AVAILABLE_PATH/openresty-vhosts/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
+
+cmd-openresty-label() {
+  declare desc="set/unset/show container proxy labels"
+  declare cmd="openresty:label"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1"
+
+  set -- openresty "$@"
+  cmd-proxy-label "$@"
+}
 
 cmd-openresty-report() {
   declare desc="displays a openresty report for one or more apps"

--- a/plugins/openresty-vhosts/docker-args-process-deploy
+++ b/plugins/openresty-vhosts/docker-args-process-deploy
@@ -2,6 +2,7 @@
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 source "$PLUGIN_AVAILABLE_PATH/openresty-vhosts/internal-functions"
 
 trigger-openresty-vhosts-docker-args-process-deploy() {
@@ -180,6 +181,15 @@ trigger-openresty-vhosts-docker-args-process-deploy() {
   [[ -n "$value" ]] && output="$output '--label=openresty.x-forwarded-proto-value=$value'"
   value="$(fn-openresty-x-forwarded-ssl "$APP")"
   [[ -n "$value" ]] && output="$output '--label=openresty.x-forwarded-ssl=$value'"
+
+  local proxy_labels_file_path=$(fn-get-proxy-labels-file-path "$APP" openresty)
+  fn-report-proxy-label-overwrite "$output" "$proxy_labels_file_path"
+
+  if [[ -f "$proxy_labels_file_path" ]]; then
+    local user_proxy_labels="$(<"$proxy_labels_file_path")"
+    user_proxy_labels="$(echo "$user_proxy_labels" | tr '\r\n' ' ')"
+    output="$output $user_proxy_labels"
+  fi
 
   echo -n "$STDIN$output"
 }

--- a/plugins/openresty-vhosts/help-functions
+++ b/plugins/openresty-vhosts/help-functions
@@ -30,6 +30,7 @@ fn-help-content() {
     openresty:report [<app>] [<flag>], Displays an openresty report for one or more apps
     openresty:set <app> <property> (<value>), Set or clear an openresty property for an app
     openresty:show-config <app>, Display openresty compose config
+    openresty:label <app> <show | set | unset> <property> (<value>), Show, set or clear an openresty label for an app
     openresty:start, Starts the openresty server
     openresty:stop, Stops the openresty server
 help_content

--- a/plugins/openresty-vhosts/subcommands/label
+++ b/plugins/openresty-vhosts/subcommands/label
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/openresty-vhosts/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-openresty-label "$@"

--- a/plugins/proxy/command-functions
+++ b/plugins/proxy/command-functions
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-proxy-label() {
+  local PROXY="$1" && shift 1
+  [[ -z "$PROXY" ]] && dokku_log_fail "Please specify a proxy name"
+
+  local APP="$1" && shift 1
+  [[ -z "$APP" ]] && dokku_log_fail "Please specify an app name"
+
+  local action="$1" && shift 1
+  [[ "$action" != "set" && "$action" != "unset" && "$action" != "show" ]] && dokku_log_fail "Please specify a valid action ('set', 'unset' or 'show')"
+
+  if [[ "$action" == "show" && "$#" == "0" ]]; then
+    display_proxy_labels "$APP" "$PROXY"
+    return 0
+  fi
+
+  local passed_label_name="$1" && shift 1
+  [[ -z "$passed_label_name" ]] && dokku_log_fail "Please specify a container label for the app"
+  [[ ! "$passed_label_name" =~ ^$PROXY ]] && dokku_log_fail "Please specify a valid $PROXY label name for the app"
+
+  if [[ "$action" == "show" ]]; then
+    show_proxy_label "$APP" "$PROXY" "$passed_label_name"
+    return 0
+  fi
+
+  # set/unset
+  local passed_label_value="$1"
+
+  if [[ "$action" == "set" ]]; then
+    add_passed_proxy_label "$APP" "$PROXY" "${passed_label_name}" "${passed_label_value}"
+  elif [[ "$action" == "unset" ]]; then
+    remove_passed_proxy_label "$APP" "$PROXY" "${passed_label_name}"
+  else
+    dokku_log_fail "Internal error"
+  fi
+}

--- a/plugins/proxy/functions
+++ b/plugins/proxy/functions
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+
+fn-report-proxy-label-overwrite() {
+  LABELS="$1"
+  PROXY_LABELS_FILE_PATH="$2"
+  shift 2
+
+  if [[ -f "$PROXY_LABELS_FILE_PATH" ]]; then
+    local DONE=false
+    until $DONE; do
+      local line
+      read -r line || local DONE=true
+
+      [[ -z "$line" ]] && continue
+
+      case "$line" in
+        \#*)
+          continue
+          ;;
+
+        --label*)
+          local label_name="$(echo "$line" | sed -E "s/^--label ['\"]([^=]+)=.*/\1/")"
+          local escaped_label_name="$(escape_extended_sed "$passed_label_name")"
+          local match="$(echo "$LABELS" | sed -E "s/.*--label ['\"]($escaped_label_name)=.*/\1/")"
+          if [[ -n "$match" ]]; then
+            dokku_log_warn "Dokku label \"$match\" will be overwritten by user-set proxy label."
+          fi
+          continue
+          ;;
+
+        *)
+          dokku_log_warn "Invalid line '$line' in proxy label file $PROXY_FILE_PATH"
+          ;;
+      esac
+    done <"$PROXY_LABELS_FILE_PATH"
+  fi
+}
+
+fn-get-proxy-labels-file-path() {
+  declare desc="return proxy labels config file path for specified proxy"
+  local APP="$1"
+  local PROXY="$2"
+  local PROXY_FILE="${DOKKU_ROOT}/${APP}/PROXY_LABELS_${PROXY^^}"
+  echo "$PROXY_FILE"
+}
+
+get_proxy_labels_file_path() {
+  declare desc="return proxy labels config file path for specified proxy"
+  local proxy_labels_file_prefix="PROXY_LABELS_"
+  local APP="$1"
+  local PROXY="$2"
+  [[ "$APP" && "$PROXY" ]] || dokku_log_fail "Error: proxy_labels_file_path is incomplete."
+  fn-get-proxy-labels-file-path "$APP" "$PROXY"
+}
+
+create_proxy_labels_file_if_required() {
+  declare desc="create proxy labels file for app"
+  local proxy_labels_file_path="$1"
+  [[ -f "$proxy_labels_file_path" ]] || {
+    touch "$proxy_labels_file_path"
+  }
+}
+
+display_proxy_labels() {
+  declare desc="print user-set app container labels for specified proxy"
+  local APP="$1"
+  local PROXY="$2"
+  shift 2
+
+  local proxy_labels_file_path="$(get_proxy_labels_file_path "$APP" "$PROXY")"
+  echo "${PROXY^} labels:"
+  sed -e 's/^/    /' "$proxy_labels_file_path"
+}
+
+show_proxy_label() {
+  declare desc="print single user-set app container label for specified proxy"
+  local APP="$1"
+  local PROXY="$2"
+  local passed_label_name="$3"
+  shift 3
+
+  local proxy_labels_file_path="$(get_proxy_labels_file_path "$APP" "$PROXY")"
+  [[ ! -s "$proxy_labels_file_path" ]] || {
+    local all_proxy_labels="$(<"$proxy_labels_file_path")"
+    local escaped_label_name="$(escape_extended_sed "$passed_label_name")"
+    local proxy_label_value="$(echo -e "${all_proxy_labels}" | sed -E -n "s/^--label ['\"]${escaped_label_name}=(.*)['\"] \$/\1/p")"
+
+    echo "${PROXY^} label:"
+    echo "    ${passed_label_name}: ${proxy_label_value}"
+  }
+}
+
+add_passed_proxy_label() {
+  declare desc="adds container label to app for specified proxy"
+  local APP="$1"
+  local PROXY="$2"
+  local passed_label_name="$3"
+  local passed_label_value="$4"
+  shift 4
+
+  local proxy_labels_file_path="$(get_proxy_labels_file_path "$APP" "$PROXY")"
+  create_proxy_labels_file_if_required "$proxy_labels_file_path"
+  remove_passed_proxy_label "$APP" "$PROXY" "$passed_label_name" >/dev/null
+  echo "--label '${passed_label_name}=${passed_label_value}' " >>"$proxy_labels_file_path"
+  local all_proxy_labels="$(<"$proxy_labels_file_path")"
+  echo -e "${all_proxy_labels}" | sed '/^$/d' | sort -u >"$proxy_labels_file_path"
+}
+
+remove_passed_proxy_label() {
+  declare desc="removes container label from app for specified proxy"
+  local APP="$1"
+  local PROXY="$2"
+  local passed_label_name="$3"
+  shift 3
+
+  local proxy_labels_file_path="$(get_proxy_labels_file_path "$APP" "$PROXY")"
+  [[ ! -s "$proxy_labels_file_path" ]] || {
+    local all_proxy_labels="$(<"$proxy_labels_file_path")"
+    local escaped_label_name="$(escape_extended_sed "$passed_label_name")"
+    local all_proxy_labels="$(echo -e "${all_proxy_labels}" | sed -E "s/^--label ['\"]${escaped_label_name}=.*\$//")"
+    echo -e "${all_proxy_labels}" | sed '/^$/d' | sort -u >"$proxy_labels_file_path"
+  }
+}

--- a/plugins/traefik-vhosts/command-functions
+++ b/plugins/traefik-vhosts/command-functions
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/command-functions"
 source "$PLUGIN_AVAILABLE_PATH/traefik-vhosts/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
+
+cmd-traefik-label() {
+  declare desc="set/unset/show container proxy labels"
+  declare cmd="traefik:label"
+  [[ "$1" == "$cmd" ]] && shift 1
+  declare APP="$1"
+
+  set -- traefik "$@"
+  cmd-proxy-label "$@"
+}
 
 cmd-traefik-report() {
   declare desc="displays a traefik report for one or more apps"

--- a/plugins/traefik-vhosts/docker-args-process-deploy
+++ b/plugins/traefik-vhosts/docker-args-process-deploy
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_AVAILABLE_PATH/proxy/functions"
 source "$PLUGIN_AVAILABLE_PATH/traefik-vhosts/internal-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
@@ -128,6 +129,15 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
         output="$output --label \"traefik.http.routers.$APP-$PROC_TYPE-https.rule=$traefik_domains\""
       fi
     fi
+  fi
+
+  local proxy_labels_file_path=$(fn-get-proxy-labels-file-path "$APP" traefik)
+  fn-report-proxy-label-overwrite "$output" "$proxy_labels_file_path"
+
+  if [[ -f "$proxy_labels_file_path" ]]; then
+    local user_proxy_labels="$(<"$proxy_labels_file_path")"
+    user_proxy_labels="$(echo "$user_proxy_labels" | tr '\r\n' ' ')"
+    output="$output $user_proxy_labels"
   fi
 
   echo -n "$STDIN$output"

--- a/plugins/traefik-vhosts/help-functions
+++ b/plugins/traefik-vhosts/help-functions
@@ -30,6 +30,7 @@ fn-help-content() {
     traefik:report [<app>] [<flag>], Displays an traefik report for one or more apps
     traefik:set <app> <property> (<value>), Set or clear an traefik property for an app
     traefik:show-config <app>, Display traefik compose config
+    traefik:label <app> <show | set | unset> <property> (<value>), Show, set or clear a traefik label for an app
     traefik:start, Starts the traefik server
     traefik:stop, Stops the traefik server
 help_content

--- a/plugins/traefik-vhosts/subcommands/label
+++ b/plugins/traefik-vhosts/subcommands/label
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+source "$PLUGIN_AVAILABLE_PATH/traefik-vhosts/command-functions"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+cmd-traefik-label "$@"


### PR DESCRIPTION
## Implement proxy container label feature

Container labels can be set with:
`proxy-name:label <app> <show | set | unset> <property> (<value>)`

`proxy-name` can be: `caddy` `haproxy` `openresty` `traefik`

Labels set with this command can override Dokku-set labels (user is warned with a message on build) #7600