### PR TITLE
fix: set the correct default ingress class for k3s clusters

### DIFF
--- a/plugins/scheduler-k3s/src/subcommands/subcommands.go
+++ b/plugins/scheduler-k3s/src/subcommands/subcommands.go
@@ -83,7 +83,7 @@ func main() {
 		args := flag.NewFlagSet("scheduler-k3s:initialize", flag.ExitOnError)
 		taintScheduling := args.Bool("taint-scheduling", false, "taint-scheduling: add a taint against scheduling app workloads")
 		serverIP := args.String("server-ip", "", "server-ip: IP address of the dokku server node")
-		ingressClass := args.String("ingress-class", "traefik", "ingress-class: ingress-class to use for all outbound traffic")
+		ingressClass := args.String("ingress-class", "nginx", "ingress-class: ingress-class to use for all outbound traffic")
 		args.Parse(os.Args[2:])
 		err = scheduler_k3s.CommandInitialize(*ingressClass, *serverIP, *taintScheduling)
 	case "labels:set":


### PR DESCRIPTION
This was accidentally left as traefik, but we document the correct value as nginx.