### PR TITLE
fix: update CID count in ps tests

### DIFF
--- a/tests/unit/ps-general-1.bats
+++ b/tests/unit/ps-general-1.bats
@@ -42,7 +42,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains "$CID" 7
+  assert_output_contains "$CID" 6
 }
 
 @test "(ps:set) procfile" {


### PR DESCRIPTION
Docker updated the output of inspect so now it's there 6 times, not 7.