### PR TITLE
Add continuous integration example for woodpecker ci

### DIFF
--- a/docs/deployment/continuous-integration/generic.md
+++ b/docs/deployment/continuous-integration/generic.md
@@ -11,6 +11,7 @@ Assuming a Docker image can be run as a CI task with environment variables injec
 - [gitlab-ci](https://about.gitlab.com/stages-devops-lifecycle/continuous-integration/)
 - [semaphoreci](https://semaphoreci.com/)
 - [travisci](https://travis-ci.com/)
+- [woodpecker ci](https://woodpecker-ci.org/)
 
 ## Simple Usage
 

--- a/docs/deployment/continuous-integration/woodpecker-ci.md
+++ b/docs/deployment/continuous-integration/woodpecker-ci.md
@@ -1,0 +1,29 @@
+# Woodpecker CI
+
+[Woodpecker CI](https://woodpecker-ci.org/docs/intro) can be used to automatically deploy a Dokku application via the official [dokku/ci-docker-image](https://github.com/dokku/ci-docker-image). The simplest example is as follows:
+
+```yaml
+when:
+  - event: push
+    branch: main
+
+clone:
+  git:
+    image: woodpeckerci/plugin-git
+    settings:
+      partial: false
+      depth: 0
+
+steps:
+  - name: deploy
+    image: dokku/ci-docker-image
+    environment:
+      GIT_REMOTE_URL: ssh://dokku@dokku.me:22/appname
+      SSH_PRIVATE_KEY:
+          from_secret: DOKKU_ME_SSH_DEPLOY_KEY
+    commands:
+      - dokku-deploy
+```
+
+- The standard `clone` stage is replaced with one that performs a complete clone of the repository (the default is a shallow clone, which dokku would reject).
+- A `GIT_REMOTE_URL` and a `SSH_PRIVATE_KEY` (with help of the `from_secret` directive) suffice to carry out a deployment.

--- a/docs/template.html
+++ b/docs/template.html
@@ -215,6 +215,7 @@
             <a href="/{{NAME}}/deployment/continuous-integration/github-actions/" class="list-group-item">GitHub Actions</a>
             <a href="/{{NAME}}/deployment/continuous-integration/gitlab-ci/" class="list-group-item">GitLab CI</a>
             <a href="/{{NAME}}/deployment/continuous-integration/generic/" class="list-group-item">Generic</a>
+            <a href="/{{NAME}}/deployment/continuous-integration/woodpecker-ci/" class="list-group-item">Woodpecker CI</a>
 
             <a href="#" class="list-group-item disabled">Community Contributions</a>
             <a href="/{{NAME}}/community/clients/" class="list-group-item">Clients</a>


### PR DESCRIPTION
Adds a section to the docs showing how to configure a Woodpecker CI workflow to play nicely with dokku.