### PR TITLE
Fix cron key in app.json docs

### DIFF
--- a/docs/appendices/file-formats/app-json.md
+++ b/docs/appendices/file-formats/app-json.md
@@ -9,7 +9,7 @@
 
 ```json
 {
-  "crons": [
+  "cron": [
     {
       "command": "echo 'hello'",
       "schedule": "0 1 * * *"


### PR DESCRIPTION
The docs page for app.json has the wrong key for modifying cron jobs. It's `"crons"` when it should be `"cron"`. Suggesting a tiny fix.