### PR TITLE
Fix: Add missing `systemctl` path detection in nginx-vhost plugin

### DIFF
--- a/plugins/nginx-vhosts/internal-functions
+++ b/plugins/nginx-vhosts/internal-functions
@@ -679,6 +679,11 @@ fn-nginx-vhosts-nginx-is-running() {
     NGINX_INIT_NAME=openresty
   fi
 
+  local systemctl_path=/bin/systemctl
+  if [[ -x /usr/bin/systemctl ]]; then
+    systemctl_path=/usr/bin/systemctl
+  fi
+
   case "$DOKKU_DISTRO" in
     debian | raspbian)
       if [[ -x "$systemctl_path" ]]; then


### PR DESCRIPTION
### What

This PR restores missing logic to set the correct `systemctl` path in the `nginx-vhosts-nginx-is-running()` function:

````bash
# plugins/nginx-vhosts/internal-functions line 682
local systemctl_path=/bin/systemctl
if [[ -x /usr/bin/systemctl ]]; then
  systemctl_path=/usr/bin/systemctl
fi
````

### Why

**Bug:**  
Previously, `$systemctl_path` was used without being set, resulting in empty commands like ` is-active --quiet ...` instead of the expected `/bin/systemctl is-active --quiet ...`. This caused service management commands to fail silently or behave unexpectedly.

**Fix:**  
This change ensures `$systemctl_path` is always set in fn-nginx-vhosts-nginx-is-running like in others functions. This restores expected behavior for service management across different Linux distributions.