### PR TITLE
Exclude cnb launcher from herokuish images

### DIFF
--- a/plugins/app-json/functions.go
+++ b/plugins/app-json/functions.go
@@ -255,7 +255,7 @@ func executeScript(appName string, image string, imageTag string, phase string) 
 	if os.Getenv("DOKKU_TRACE") != "" {
 		dockerArgs = append(dockerArgs, "--env", "DOKKU_TRACE="+os.Getenv("DOKKU_TRACE"))
 	}
-	if isCnbImage {
+	if !isHerokuishImage && isCnbImage {
 		// TODO: handle non-linux lifecycles
 		// Ideally we don't have to override this but `pack` injects the web process
 		// as the default entrypoint, so we need to specify the launcher so the script


### PR DESCRIPTION
Potentially fixes #7720

The most recent herokuish image includes `io.buildpacks.stack.id` tag. See:

https://github.com/heroku/base-images/blob/411d6d40bd7e450dcec565adaeccc40252290a09/heroku-24/Dockerfile

However, it does not include the CNB launcher.