### PR TITLE
Update checkout action version in github actions documentation

### DIFF
--- a/docs/deployment/continuous-integration/github-actions.md
+++ b/docs/deployment/continuous-integration/github-actions.md
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This PR changes the version used for a GitHub Action, to avoid deprecation warnings.