### PR TITLE
clients.md: Drop mention of dokkufy gem archived in 2017

### DIFF
--- a/docs/community/clients.md
+++ b/docs/community/clients.md
@@ -38,16 +38,6 @@ gem install dokku_client
 
 See [documentation here](https://github.com/netguru/dokku_client) for more information.
 
-## (ruby) Dokkufy
-
-Dokkufy is a rubygem that handles automation of certain tasks, such as Dokku setup, plugin installation, etc. You can install it via the following shell command (assuming you have ruby and rubygems installed):
-
-```shell
-gem install dokkufy
-```
-
-See [documentation here](https://github.com/cbetta/dokkufy) for more information.
-
 ## (ruby) Dockland
 
 Dockland is a rubygem that acts as a client for your Dokku installation. You can install it via the following shell command (assuming you have ruby and rubygems installed):


### PR DESCRIPTION
This PR focuses the docs by removing mention of an outdated tool, which has become archived.