### PR TITLE
Drop dokku-client gem, homepage 404s

### DIFF
--- a/docs/community/clients.md
+++ b/docs/community/clients.md
@@ -28,16 +28,6 @@ gem install dokku-cli
 
 See [documentation here](https://github.com/SebastianSzturo/dokku-cli) for more information.
 
-## (ruby) DokkuClient
-
-DokkuClient is another rubygem that acts as a client for your Dokku installation with built-in support for certain external plugins. You can install it via the following shell command (assuming you have ruby and rubygems installed):
-
-```shell
-gem install dokku_client
-```
-
-See [documentation here](https://github.com/netguru/dokku_client) for more information.
-
 ## (ruby) Dokkufy
 
 Dokkufy is a rubygem that handles automation of certain tasks, such as Dokku setup, plugin installation, etc. You can install it via the following shell command (assuming you have ruby and rubygems installed):


### PR DESCRIPTION
This PR focuses the docs on unofficial clients by dropping now-404ing homepage for dokku-client gem.