### PR TITLE
Reference new packeto buildpack urls

### DIFF
--- a/tests/apps/python/project2.toml
+++ b/tests/apps/python/project2.toml
@@ -10,7 +10,7 @@ uri = "./cnb/1"
 uri = "./cnb/1"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/python"
+uri = "docker.io/paketobuildpacks/python"
 
 [[order.group]]
-uri = "gcr.io/paketo-buildpacks/procfile"
+uri = "docker.io/paketobuildpacks/procfile"


### PR DESCRIPTION
See https://blog.paketo.io/posts/paketo-gcr-registry-sunset/ for details.