### PR TITLE
Improve error handling in docker operations

### DIFF
--- a/plugins/registry/triggers.go
+++ b/plugins/registry/triggers.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -108,9 +107,8 @@ func TriggerPostReleaseBuilder(appName string, image string) error {
 	newImage := strings.Replace(image, imageRepo+":", computedImageRepo+":", 1)
 
 	if computedImageRepo != imageRepo {
-		if !dockerTag(imageID, newImage) {
-			// TODO: better error
-			return errors.New("Unable to tag image")
+		if err := dockerTag(imageID, newImage); err != nil {
+			return fmt.Errorf("unable to tag image %s as %s: %w", imageID, newImage, err)
 		}
 	}
 


### PR DESCRIPTION
- Replace boolean return values with proper error handling in dockerTag and dockerPush functions
- Add detailed error context including Docker command exit codes and stderr output
- Remove TODO comments and improve error messages for better debugging
- Fix error message formatting in defer function

This addresses the TODO comments for better error handling and provides users with actionable error information when Docker registry operations fail.
