### PR TITLE
Fix typo in 0.36.0 migration guide

### DIFF
--- a/docs/appendices/0.36.0-migration-guide.md
+++ b/docs/appendices/0.36.0-migration-guide.md
@@ -1,4 +1,4 @@
-# 0.35.0 Migration Guide
+# 0.36.0 Migration Guide
 
 ## Changes
 


### PR DESCRIPTION
corrects typo