### PR TITLE
Allow specifying a custom top-level label key for the caddy proxy

### DIFF
--- a/docs/networking/proxies/caddy.md
+++ b/docs/networking/proxies/caddy.md
@@ -117,6 +117,16 @@ dokku caddy:set --global log-level DEBUG
 
 After modifying,  the Caddy container will need to be restarted.
 
+### Changing the label key for the app
+
+The default label key for the app is `caddy`. This can be changed by setting the `label-key` property:
+
+```shell
+dokku caddy:set node-js-app label-key caddy_0
+```
+
+This will update the app's label key to `caddy_0`. The label key is used to identify the app in the Caddy configuration. If you change the label key, you will need to restart or rebuild the app to apply the updates.
+
 ### SSL Configuration
 
 The caddy plugin only supports automatic ssl certificates from it's letsencrypt integration. Managed certificates provided by the `certs` plugin are ignored.

--- a/plugins/caddy-vhosts/docker-args-process-deploy
+++ b/plugins/caddy-vhosts/docker-args-process-deploy
@@ -8,7 +8,7 @@ trigger-caddy-vhosts-docker-args-process-deploy() {
   declare desc="nginx-vhosts core-post-deploy plugin trigger"
   declare trigger="docker-args-process-deploy"
   declare APP="$1" IMAGE_SOURCE_TYPE="$2" IMAGE_TAG="$3" PROC_TYPE="$4" CONTAINER_INDEX="$5"
-  local app_domains caddy_domains is_app_listening letsencrypt_email output proxy_container_port proxy_host_port port_map proxy_scheme proxy_schemes scheme tls_internal
+  local app_domains caddy_domains is_app_listening letsencrypt_email output proxy_container_port proxy_host_port port_map proxy_scheme proxy_schemes scheme tls_internal label_key
   local proxy_container_http_port proxy_container_http_port_candidate proxy_host_http_port_candidate
   local proxy_container_https_port proxy_container_https_port_candidate proxy_host_https_port_candidate
   local STDIN=$(cat)
@@ -88,13 +88,14 @@ trigger-caddy-vhosts-docker-args-process-deploy() {
   if [[ -n "$is_app_listening" ]] && [[ -n "$caddy_domains" ]]; then
     has_443_mapping=false
     tls_internal="$(fn-caddy-tls-internal)"
+    label_key="$(fn-caddy-label-key "$APP")"
     if [[ -n "$proxy_container_https_port" ]] || [[ -n "$proxy_container_https_port_candidate" ]]; then
       has_443_mapping=true
     fi
 
     ssl_warning_mapping="https:443"
     if [[ "$tls_internal" == "true" ]]; then
-      output="--label caddy.tls=internal"
+      output="--label ${label_key}.tls=internal"
       if [[ "$has_443_mapping" == "false" ]]; then
         ssl_warning_mapping="http:80"
         proxy_host_https_port_candidate="$proxy_host_http_port_candidate"
@@ -105,7 +106,7 @@ trigger-caddy-vhosts-docker-args-process-deploy() {
 
     scheme="http"
     if [[ -n "$letsencrypt_email" ]] && [[ "$has_443_mapping" == "true" ]]; then
-      output="--label 'caddy=${caddy_domains}'"
+      output="--label '${label_key}=${caddy_domains}'"
       scheme="https"
       if [[ -z "$proxy_container_https_port" ]]; then
         warning_scheme="$(awk -F ':' '{ print $1 }' <<<"$ssl_warning_mapping")"
@@ -114,17 +115,17 @@ trigger-caddy-vhosts-docker-args-process-deploy() {
         proxy_container_https_port="$proxy_container_https_port_candidate"
       fi
 
-      output="$output --label \"caddy.reverse_proxy={{ upstreams $proxy_container_https_port }}\""
+      output="$output --label \"${label_key}.reverse_proxy={{ upstreams $proxy_container_https_port }}\""
     elif [[ -n "$proxy_container_http_port" ]] || [[ -n "$proxy_container_http_port_candidate" ]]; then
       caddy_domains="${caddy_domains//, /:80, }"
-      output="--label 'caddy=${caddy_domains}:80'"
+      output="--label '${label_key}=${caddy_domains}:80'"
       if [[ -z "$proxy_container_http_port" ]]; then
         dokku_log_warn "Warning: http:80 port mapping not found"
         dokku_log_warn "Utilizing first http port mapping, http:$proxy_host_http_port_candidate:$proxy_container_http_port_candidate"
         proxy_container_http_port="$proxy_container_http_port_candidate"
       fi
 
-      output="$output --label \"caddy.reverse_proxy={{ upstreams $proxy_container_http_port }}\""
+      output="$output --label \"${label_key}.reverse_proxy={{ upstreams $proxy_container_http_port }}\""
     fi
   fi
 

--- a/plugins/caddy-vhosts/internal-functions
+++ b/plugins/caddy-vhosts/internal-functions
@@ -71,3 +71,8 @@ fn-caddy-tls-internal() {
   declare APP="$1"
   fn-plugin-property-get-default "caddy" "$APP" "tls-internal" "false"
 }
+
+fn-caddy-label-key() {
+  declare APP="$1"
+  fn-plugin-property-get-default "caddy" "$APP" "label-key" "caddy"
+}

--- a/plugins/caddy-vhosts/subcommands/set
+++ b/plugins/caddy-vhosts/subcommands/set
@@ -9,13 +9,13 @@ cmd-caddy-set() {
   declare cmd="caddy:set"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval" "tls-internal")
+  local VALID_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval" "label-key" "tls-internal")
   local GLOBAL_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval")
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}"; then
-    dokku_log_fail "Invalid key specified, valid keys include: image letsencrypt-email letsencrypt-server log-level polling-interval tls-internal"
+    dokku_log_fail "Invalid key specified, valid keys include: image letsencrypt-email letsencrypt-server log-level polling-interval label-key tls-internal"
   fi
 
   if ! fn-in-array "$KEY" "${GLOBAL_KEYS[@]}"; then

--- a/tests/unit/caddy.bats
+++ b/tests/unit/caddy.bats
@@ -50,6 +50,34 @@ teardown() {
   assert_output_contains "python/http.server"
 }
 
+@test "(caddy) custom label key" {
+  run /bin/bash -c "dokku builder-herokuish:set $TEST_APP allowed true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku proxy:set $TEST_APP caddy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku caddy:set $TEST_APP label-key caddy_0"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "docker inspect $TEST_APP.web.1 --format '{{ index .Config.Labels \"caddy_0\" }}'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "$TEST_APP.${DOKKU_DOMAIN}:80"
+}
+
 @test "(caddy) multiple domains" {
   run /bin/bash -c "dokku proxy:set $TEST_APP caddy"
   echo "output: $output"


### PR DESCRIPTION
## What

Allow to set a custom label key (`caddy` by default) per app for Caddy Proxy.

## Why

For more complex Caddy configurations, it may be necessary to set a different key.

Example: https://github.com/lucaslorentz/caddy-docker-proxy/wiki/Use-on_demand_tls

## How

A new set option called `label-key`, which can be used per app. 

The `caddy` value is used by default to prevent issues for existing configurations.

I was unable to run tests locally, but I tried it on an existing dokku server with a Caddy proxy set.