### PR TITLE
Do not change permissions on config directory symlinks

### DIFF
--- a/plugins/common/io.go
+++ b/plugins/common/io.go
@@ -108,6 +108,17 @@ func IsAbsPath(path string) bool {
 	return strings.HasPrefix(path, "/")
 }
 
+// IsSymlink returns true if the path is a symlink
+// if lstat fails, it returns false
+func IsSymlink(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+
+	return info.Mode()&os.ModeSymlink == os.ModeSymlink
+}
+
 // ListFilesWithPrefix lists files within a given path that have a given prefix
 func ListFilesWithPrefix(path string, prefix string) []string {
 	names, err := os.ReadDir(path)

--- a/plugins/common/properties.go
+++ b/plugins/common/properties.go
@@ -516,19 +516,24 @@ func PropertyWrite(pluginName string, appName string, property string, value str
 
 // PropertySetup creates the plugin config root
 func PropertySetup(pluginName string) error {
+	configRoot := filepath.Join(MustGetEnv("DOKKU_LIB_ROOT"), "config")
 	pluginConfigRoot := getPluginConfigPath(pluginName)
 	if err := os.MkdirAll(pluginConfigRoot, 0755); err != nil {
 		return err
 	}
 
-	input := SetPermissionInput{
-		Filename: filepath.Join(MustGetEnv("DOKKU_LIB_ROOT"), "config"),
-		Mode:     os.FileMode(0755),
+	// check if configRoot is a symlink
+	if !IsSymlink(configRoot) {
+		input := SetPermissionInput{
+			Filename: configRoot,
+			Mode:     os.FileMode(0755),
+		}
+
+		if err := SetPermissions(input); err != nil {
+			return err
+		}
 	}
 
-	if err := SetPermissions(input); err != nil {
-		return err
-	}
 	return SetPermissions(SetPermissionInput{
 		Filename: pluginConfigRoot,
 		Mode:     os.FileMode(0755),


### PR DESCRIPTION
When running in docker, the 'config' directory can be a symlink, which causes issues during plugin installation.

Refs #7308