### PR TITLE
Skip invalid apps when listing applications

### DIFF
--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -687,8 +687,7 @@ func IsDeployed(appName string) bool {
 		}
 
 		EnvWrap(func() error {
-			CommandPropertySet("common", appName, "deployed", deployed, DefaultProperties, GlobalProperties)
-			return nil
+			return PropertyWrite("common", appName, "deployed", deployed)
 		}, map[string]string{"DOKKU_QUIET_OUTPUT": "1"})
 	}
 

--- a/plugins/common/common.go
+++ b/plugins/common/common.go
@@ -640,6 +640,11 @@ func UnfilteredDokkuApps() ([]string, error) {
 		if strings.HasPrefix(f.Name(), ".") {
 			continue
 		}
+		// skip apps that start with an uppercase letter
+		if unicode.IsUpper(rune(f.Name()[0])) {
+			continue
+		}
+
 		apps = append(apps, f.Name())
 	}
 

--- a/plugins/common/triggers.go
+++ b/plugins/common/triggers.go
@@ -23,8 +23,7 @@ func TriggerAppList(filtered bool) error {
 // TriggerCorePostDeploy associates the container with a specified network
 func TriggerCorePostDeploy(appName string) error {
 	return EnvWrap(func() error {
-		CommandPropertySet("common", appName, "deployed", "true", DefaultProperties, GlobalProperties)
-		return nil
+		return PropertyWrite("common", appName, "deployed", "true")
 	}, map[string]string{"DOKKU_QUIET_OUTPUT": "1"})
 }
 


### PR DESCRIPTION
This also stops us from running app name verification internally (that should only happen at the command invocation level).

Closes #7959