### PR TITLE
Use -t instead of deprecated --time in stop commands

### DIFF
--- a/plugins/scheduler-docker-local/scheduler-deploy
+++ b/plugins/scheduler-docker-local/scheduler-deploy
@@ -33,7 +33,7 @@ trigger-scheduler-docker-local-scheduler-deploy() {
 
   DOKKU_NETWORK_BIND_ALL="$(plugn trigger network-get-property "$APP" bind-all-interfaces)"
   DOKKU_DOCKER_STOP_TIMEOUT="$(plugn trigger ps-get-property "$APP" stop-timeout-seconds)"
-  [[ $DOKKU_DOCKER_STOP_TIMEOUT ]] && DOCKER_STOP_TIME_ARG="--time=${DOKKU_DOCKER_STOP_TIMEOUT}"
+  [[ $DOKKU_DOCKER_STOP_TIMEOUT ]] && DOCKER_STOP_TIME_ARG="-t=${DOKKU_DOCKER_STOP_TIMEOUT}"
 
   DOKKU_START_CMD="$(config_get "$APP" DOKKU_START_CMD || true)"
 

--- a/plugins/scheduler-docker-local/scheduler-run-stop
+++ b/plugins/scheduler-docker-local/scheduler-run-stop
@@ -12,7 +12,7 @@ fn-scheduler-docker-local-stop-container() {
     return 0
   fi
 
-  [[ $DOKKU_DOCKER_STOP_TIMEOUT ]] && DOCKER_STOP_TIME_ARG="--time=${DOKKU_DOCKER_STOP_TIMEOUT}"
+  [[ $DOKKU_DOCKER_STOP_TIMEOUT ]] && DOCKER_STOP_TIME_ARG="-t=${DOKKU_DOCKER_STOP_TIMEOUT}"
   if "$DOCKER_BIN" container stop $DOCKER_STOP_TIME_ARG "$CONTAINER_ID_OR_NAME"; then
     return
   fi

--- a/plugins/scheduler-docker-local/scheduler-stop
+++ b/plugins/scheduler-docker-local/scheduler-stop
@@ -22,7 +22,7 @@ trigger-scheduler-docker-local-scheduler-stop() {
   local DOKKU_APP_RUNNING_CONTAINER_IDS=$(get_app_running_container_ids "$APP" 2>/dev/null)
   local DOKKU_DOCKER_STOP_TIMEOUT="$(plugn trigger ps-get-property "$APP" stop-timeout-seconds || true)"
 
-  [[ -n "$DOKKU_DOCKER_STOP_TIMEOUT" ]] && DOCKER_STOP_TIME_ARG="--time=${DOKKU_DOCKER_STOP_TIMEOUT}"
+  [[ -n "$DOKKU_DOCKER_STOP_TIMEOUT" ]] && DOCKER_STOP_TIME_ARG="-t=${DOKKU_DOCKER_STOP_TIMEOUT}"
 
   if [[ -n "$DOKKU_APP_RUNNING_CONTAINER_IDS" ]]; then
     for CID in $DOKKU_APP_RUNNING_CONTAINER_IDS; do


### PR DESCRIPTION
The --time option was deprecated in v28. I don't know when --timeout was added as an alias, but -t should be valid for both.

Docker prints a deprecation message when using the stop command.