### PR TITLE
Allow specifying kubelet-args when adding a new node to the cluster

### DIFF
--- a/plugins/scheduler-k3s/src/subcommands/subcommands.go
+++ b/plugins/scheduler-k3s/src/subcommands/subcommands.go
@@ -59,10 +59,11 @@ func main() {
 		allowUknownHosts := args.Bool("insecure-allow-unknown-hosts", false, "insecure-allow-unknown-hosts: allow unknown hosts")
 		taintScheduling := args.Bool("taint-scheduling", false, "taint-scheduling: add a taint against scheduling app workloads")
 		serverIP := args.String("server-ip", "", "server-ip: IP address of the dokku server node")
+		kubeletArgs := args.StringToString("kubelet-args", map[string]string{}, "kubelet-args: a key=value map of kubelet arguments")
 		role := args.String("role", "worker", "role: [ server | worker ]")
 		args.Parse(os.Args[2:])
 		remoteHost := args.Arg(0)
-		err = scheduler_k3s.CommandClusterAdd(*role, remoteHost, *serverIP, *allowUknownHosts, *taintScheduling)
+		err = scheduler_k3s.CommandClusterAdd(*role, remoteHost, *serverIP, *allowUknownHosts, *taintScheduling, *kubeletArgs)
 	case "cluster-list":
 		args := flag.NewFlagSet("scheduler-k3s:cluster-list", flag.ExitOnError)
 		format := args.String("format", "stdout", "format: [ stdout | json ]")

--- a/plugins/scheduler-k3s/subcommands.go
+++ b/plugins/scheduler-k3s/subcommands.go
@@ -400,7 +400,7 @@ func CommandInitialize(ingressClass string, serverIP string, taintScheduling boo
 }
 
 // CommandClusterAdd adds a server to the k3s cluster
-func CommandClusterAdd(role string, remoteHost string, serverIP string, allowUknownHosts bool, taintScheduling bool) error {
+func CommandClusterAdd(role string, remoteHost string, serverIP string, allowUknownHosts bool, taintScheduling bool, kubeletArgs map[string]string) error {
 	if err := isK3sInstalled(); err != nil {
 		return fmt.Errorf("k3s not installed, cannot add node to cluster: %w", err)
 	}
@@ -663,6 +663,10 @@ export INSTALL_K3S_VERSION=%s
 
 	if taintScheduling {
 		args = append(args, "--node-taint", "CriticalAddonsOnly=true:NoSchedule")
+	}
+
+	for key, value := range kubeletArgs {
+		args = append(args, "--kubelet-arg", fmt.Sprintf("%s=%s", key, value))
 	}
 
 	common.LogInfo2Quiet(fmt.Sprintf("Adding %s k3s cluster", nodeName))


### PR DESCRIPTION
Kubelet arguments are useful for specifying settings such as supported sysctl fields.