### PR TITLE
Allow skipping the install trigger when installing a plugin

### DIFF
--- a/docker/etc/my_init.d/10_dokku_init
+++ b/docker/etc/my_init.d/10_dokku_init
@@ -86,7 +86,7 @@ main() {
   fi
 
   # run core install triggers to force create any folders that may be missing
-  dokku plugin:install --core
+  dokku plugin:install
 
   if [[ -n "$DOKKU_HOSTNAME" ]]; then
     echo "dokku dokku/hostname string $DOKKU_HOSTNAME" | debconf-set-selections

--- a/docs/advanced-usage/plugin-management.md
+++ b/docs/advanced-usage/plugin-management.md
@@ -6,7 +6,7 @@
 ```
 plugin:disable <name>                    # Disable an installed plugin (third-party only)
 plugin:enable <name>                     # Enable a previously disabled plugin
-plugin:install [--core|git-url] [--committish branch|commit|tag] [--name custom-plugin-name]           # Optionally download git-url (and pin to the specified branch/commit/tag) & run install trigger for active plugins (or only core ones)
+plugin:install [--core|git-url] [--committish branch|commit|tag] [--name custom-plugin-name] [--skip-install-trigger] # Optionally download git-url (and pin to the specified branch/commit/tag) & run install trigger for active plugins (or only core ones)
 plugin:installed <name>                  # Checks if a plugin is installed
 plugin:install-dependencies [--core]     # Run install-dependencies trigger for active plugins (or only core ones)
 plugin:list                              # Print active plugins
@@ -126,6 +126,12 @@ The `--core` flag may also be indicated as the sole argument, though it is only 
 
 ```shell
 dokku plugin:install --core
+```
+
+If installing plugins in a Dockerfile, you will want to skip the `install` trigger. This will be run on container boot.
+
+```shell
+dokku plugin:install https://github.com/dokku/smoke-test-plugin.git --name smoke-test-plugin --skip-install-trigger
 ```
 
 Finally, all flags may be omitted to trigger the `install` procedures for both core and third-party plugins:

--- a/docs/getting-started/install/docker.md
+++ b/docs/getting-started/install/docker.md
@@ -84,8 +84,8 @@ The alternative is to build a custom docker image via a custom Dockerfile. This 
 
 ```Dockerfile
 FROM dokku/dokku:0.36.11
-RUN dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
-RUN dokku plugin:install https://github.com/dokku/dokku-redis.git redis
+RUN dokku plugin:install https://github.com/dokku/dokku-postgres.git --skip-install-trigger
+RUN dokku plugin:install https://github.com/dokku/dokku-redis.git --skip-install-trigger
 ```
 
 ## SSH Key Management

--- a/plugins/plugin/functions
+++ b/plugins/plugin/functions
@@ -33,6 +33,7 @@ download_and_enable_plugin() {
   declare desc="wrapper to download and enable specified version of plugin"
   local PLUGIN_GIT_URL="$1"
   shift
+  local SKIP_INSTALL_TRIGGER=false
   while getopts ":-:" opt "$@"; do
     case "$opt" in
       -)
@@ -47,6 +48,9 @@ download_and_enable_plugin() {
             OPTIND=$((OPTIND + 1))
             local CUSTOM_NAME="$val"
             ;;
+          skip-install-trigger)
+            SKIP_INSTALL_TRIGGER=true
+            ;;
         esac
         ;;
     esac
@@ -57,6 +61,9 @@ download_and_enable_plugin() {
   enable_plugin "$PLUGIN_NAME"
   if [[ -n "$PLUGIN_COMMITTISH" ]]; then
     update_plugin "$PLUGIN_NAME" "$PLUGIN_COMMITTISH"
+  fi
+  if [[ "$SKIP_INSTALL_TRIGGER" == "false" ]]; then
+    plugn trigger install
   fi
 }
 

--- a/plugins/plugin/help-functions
+++ b/plugins/plugin/help-functions
@@ -29,7 +29,7 @@ fn-help-content() {
   cat <<help_content
     plugin:disable <name>, Disable an installed plugin (third-party only)
     plugin:enable <name>, Enable a previously disabled plugin
-    plugin:install [--core|--git-url] [--committish branch|commit|commit] [--name custom-plugin-name], Optionally download git-url (and pin to the specified branch/commit/tag) & run install trigger for active plugins (or only core ones)
+    plugin:install [--core|--git-url] [--committish branch|commit|commit] [--name custom-plugin-name] [--skip-install-trigger], Optionally download git-url (and pin to the specified branch/commit/tag) & run install trigger for active plugins (or only core ones)
     plugin:install-dependencies [--core], Run install-dependencies trigger for active plugins (or only core ones)
     plugin:list, Print active plugins
     plugin:trigger <args...>, Trigger an arbitrary plugin hook

--- a/plugins/plugin/subcommands/install
+++ b/plugins/plugin/subcommands/install
@@ -18,7 +18,6 @@ cmd-plugin-install() {
       ;;
     https:* | git* | ssh:* | file:* | *.tar.gz | *.tgz)
       download_and_enable_plugin "$@"
-      plugn trigger install
       ;;
     *)
       if [[ -n "$FLAG" ]]; then


### PR DESCRIPTION
During docker image generation, certain folders either do not exist or are symlinked in an odd fashion, causing the install trigger to fail. This is not the case at runtime, so we should defer the install trigger until container start and provide a method of skipping it when generating a docker image.

Closes #7308