### PR TITLE
Ensure keda usage does not cause jank in scaling deployments

### DIFF
--- a/plugins/scheduler-k3s/templates/chart/deployment.yaml
+++ b/plugins/scheduler-k3s/templates/chart/deployment.yaml
@@ -30,7 +30,9 @@ metadata:
   name: {{ $.Values.global.app_name }}-{{ $processName }}
   namespace: {{ $.Values.global.namespace }}
 spec:
+  {{- if not (and $config.autoscaling (and $config.autoscaling.enabled (eq $config.autoscaling.type "keda"))) }}
   replicas: {{ $config.replicas }}
+  {{- end }}
   revisionHistoryLimit: 5
   selector:
     matchLabels:


### PR DESCRIPTION
If the values set by keda do not match the current deployment replicas value, the deployment object may be scaled in unexpected ways during a helm release. This change ensures keda will continue to manage that value correctly without the deployment object setting it back to something else.