### PR TITLE
Add DNS plugin to community plugins list

### DIFF
--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -113,6 +113,7 @@ The following plugins are available and provided by Dokku maintainers.  Please f
 | [APT](https://github.com/dokku-community/dokku-apt)                                               | [dokku-community][]   | 0.18.x+               |
 | [Auto Sync](https://github.com/IdeaSynthesis/dokku-autosync)<sup>1</sup>                          | [fomojola][]          | 0.8.1+                |
 | [Deploy Webhook](https://github.com/IdeaSynthesis/dokku-deploy-webhook)<sup>2</sup>               | [fomojola][]          | 0.8.1+                |
+| [DNS](https://github.com/deanmarano/dokku-dns)                                                    | [deanmarano][]        | 0.31.0+               |
 | [Docker auto persist volumes](https://github.com/Flink/dokku-docker-auto-volumes)                 | [flink][]             | 0.4.0+                |
 | [Docker Direct](https://github.com/dokku-community/dokku-docker-direct)                           | [josegonzalez][]      | 0.4.0+                |
 | [Dokku Clone](https://github.com/crisward/dokku-clone)                                            | [crisward][]          | 0.4.0+                |


### PR DESCRIPTION
I created a plugin to help managed cloud DNS services https://github.com/deanmarano/dokku-dns

It works with AWS, Cloudflare, and DigitalOcean cloud providers. It includes a trigger based workflow that creates DNS records automatically for added apps and domains.

I wrote a post about how I use it on my home server https://dean.is/blogging-about/dokku-dns-automation

Would love to have it added to the plugin list!