### PR TITLE
Add deanmarano to community plugins list

### DIFF
--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -271,6 +271,7 @@ The following plugins are no longer maintained by their developers.
 [crisward]: https://github.com/crisward
 [cu12]: https://github.com/cu12
 [darkpixel]: https://github.com/darkpixel
+[deanmarano]: https://github.com/deanmarano
 [dokku]: https://github.com/dokku
 [dokku-community]: https://github.com/dokku-community
 [dyson]: https://github.com/dyson


### PR DESCRIPTION
I added a link to my name when adding my DNS plugin, but I did not give that link a destination.