### PR TITLE
Support custom entrypoint for api and dashboard

### DIFF
--- a/plugins/traefik-vhosts/command-functions
+++ b/plugins/traefik-vhosts/command-functions
@@ -69,6 +69,8 @@ cmd-traefik-report-single() {
   verify_app_name "$APP"
   local flag_map=(
     "--traefik-api-enabled: $(fn-traefik-api-enabled)"
+    "--traefik-api-entry-point: $(fn-traefik-api-entry-point)"
+    "--traefik-api-entry-point-address: $(fn-traefik-api-entry-point-address)"
     "--traefik-api-vhost: $(fn-traefik-api-vhost)"
     "--traefik-basic-auth-password: $(fn-traefik-basic-auth-password)"
     "--traefik-basic-auth-username: $(fn-traefik-basic-auth-username)"

--- a/plugins/traefik-vhosts/internal-functions
+++ b/plugins/traefik-vhosts/internal-functions
@@ -49,7 +49,16 @@ fn-traefik-template-compose-file() {
     dns_provider_env_vars="$(fn-traefik-dns-provider-env-vars)"
   fi
 
+  local api_entry_point_address api_entry_point_port=""
+  api_entry_point_address="$(fn-traefik-api-entry-point-address)"
+  if [[ -n "$api_entry_point_address" ]]; then
+    api_entry_point_port="${api_entry_point_address##*:}"
+  fi
+
   local SIGIL_PARAMS=(TRAEFIK_API_ENABLED="$(fn-traefik-api-enabled)"
+  TRAEFIK_API_ENTRY_POINT="$(fn-traefik-api-entry-point)"
+  TRAEFIK_API_ENTRY_POINT_ADDRESS="$api_entry_point_address"
+  TRAEFIK_API_ENTRY_POINT_PORT="$api_entry_point_port"
   TRAEFIK_API_VHOST="$(fn-traefik-api-vhost)"
   TRAEFIK_BASIC_AUTH="$basic_auth"
   TRAEFIK_CHALLENGE_MODE="$(fn-traefik-challenge-mode)"
@@ -109,6 +118,14 @@ fn-traefik-http-entry-point() {
 
 fn-traefik-https-entry-point() {
   fn-plugin-property-get-default "traefik" "--global" "https-entry-point" "https"
+}
+
+fn-traefik-api-entry-point() {
+  fn-plugin-property-get-default "traefik" "--global" "api-entry-point" ""
+}
+
+fn-traefik-api-entry-point-address() {
+  fn-plugin-property-get-default "traefik" "--global" "api-entry-point-address" ""
 }
 
 fn-traefik-challenge-mode() {

--- a/plugins/traefik-vhosts/subcommands/set
+++ b/plugins/traefik-vhosts/subcommands/set
@@ -9,9 +9,9 @@ cmd-traefik-set() {
   declare cmd="traefik:set"
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
-  local VALID_KEYS=("api-enabled" "api-vhost" "challenge-mode" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "dns-provider" "image" "letsencrypt-email" "letsencrypt-server" "log-level" "http-entry-point" "https-entry-point")
-  local GLOBAL_KEYS=("api-enabled" "api-vhost" "challenge-mode" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "dns-provider" "image" "letsencrypt-email" "letsencrypt-server" "log-level" "http-entry-point" "https-entry-point")
-  local GLOBAL_ONLY_KEYS=("challenge-mode" "dns-provider")
+  local VALID_KEYS=("api-enabled" "api-entry-point" "api-entry-point-address" "api-vhost" "challenge-mode" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "dns-provider" "image" "letsencrypt-email" "letsencrypt-server" "log-level" "http-entry-point" "https-entry-point")
+  local GLOBAL_KEYS=("api-enabled" "api-entry-point" "api-entry-point-address" "api-vhost" "challenge-mode" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "dns-provider" "image" "letsencrypt-email" "letsencrypt-server" "log-level" "http-entry-point" "https-entry-point")
+  local GLOBAL_ONLY_KEYS=("api-entry-point" "api-entry-point-address" "challenge-mode" "dns-provider")
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
@@ -22,7 +22,7 @@ cmd-traefik-set() {
   fi
 
   if ! fn-in-array "$KEY" "${VALID_KEYS[@]}" && [[ "$is_dns_provider_env_var" != "true" ]]; then
-    dokku_log_fail "Invalid key specified, valid keys include: api-enabled api-vhost challenge-mode dashboard-enabled basic-auth-username basic-auth-password dns-provider dns-provider-<ENV_VAR> image letsencrypt-email letsencrypt-server log-level http-entry-point https-entry-point"
+    dokku_log_fail "Invalid key specified, valid keys include: api-enabled api-entry-point api-entry-point-address api-vhost challenge-mode dashboard-enabled basic-auth-username basic-auth-password dns-provider dns-provider-<ENV_VAR> image letsencrypt-email letsencrypt-server log-level http-entry-point https-entry-point"
   fi
 
   if ! fn-in-array "$KEY" "${GLOBAL_KEYS[@]}" && [[ "$is_dns_provider_env_var" != "true" ]]; then

--- a/plugins/traefik-vhosts/templates/compose.yml.sigil
+++ b/plugins/traefik-vhosts/templates/compose.yml.sigil
@@ -9,6 +9,9 @@ services:
       - --entrypoints.http.http.redirections.entrypoint.scheme=https
       - --entrypoints.https.address=:443
       {{ end }}
+      {{ if and ($.TRAEFIK_API_ENTRY_POINT) ($.TRAEFIK_API_ENTRY_POINT_ADDRESS) }}
+      - --entrypoints.{{ $.TRAEFIK_API_ENTRY_POINT }}.address={{ $.TRAEFIK_API_ENTRY_POINT_ADDRESS }}
+      {{ end }}
       - --providers.docker
       - --providers.docker.exposedByDefault=false
       - --api={{ $.TRAEFIK_API_ENABLED }}
@@ -52,7 +55,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.api.rule=Host(`{{ $.TRAEFIK_API_VHOST }}`)"
       - "traefik.http.routers.api.service=api@internal"
-      - "traefik.http.routers.api.entrypoints={{ if $.TRAEFIK_LETSENCRYPT_EMAIL }}https{{ else }}http{{ end }}"
+      - "traefik.http.routers.api.entrypoints={{ if $.TRAEFIK_API_ENTRY_POINT }}{{ $.TRAEFIK_API_ENTRY_POINT }}{{ else if $.TRAEFIK_LETSENCRYPT_EMAIL }}https{{ else }}http{{ end }}"
       {{ end }}
 
       {{ if $.TRAEFIK_BASIC_AUTH }}
@@ -60,7 +63,7 @@ services:
       - "traefik.http.middlewares.auth.basicauth.users={{ $.TRAEFIK_BASIC_AUTH }}"
       {{ end }}
 
-      {{ if $.TRAEFIK_LETSENCRYPT_EMAIL }}
+      {{ if and ($.TRAEFIK_LETSENCRYPT_EMAIL) (not $.TRAEFIK_API_ENTRY_POINT) }}
       - "traefik.http.routers.api.tls.certresolver=leresolver"
       {{ end }}
 
@@ -70,6 +73,9 @@ services:
       - "80:80"
       {{ if $.TRAEFIK_LETSENCRYPT_EMAIL }}
       - "443:443"
+      {{ end }}
+      {{ if and ($.TRAEFIK_API_ENTRY_POINT) ($.TRAEFIK_API_ENTRY_POINT_ADDRESS) }}
+      - "{{ $.TRAEFIK_API_ENTRY_POINT_ADDRESS }}:{{ $.TRAEFIK_API_ENTRY_POINT_PORT }}"
       {{ end }}
 
     restart: unless-stopped

--- a/tests/unit/traefik.bats
+++ b/tests/unit/traefik.bats
@@ -8,6 +8,8 @@ setup() {
   dokku traefik:set --global letsencrypt-server https://acme-staging-v02.api.letsencrypt.org/directory
   dokku traefik:set --global letsencrypt-email
   dokku traefik:set --global api-enabled
+  dokku traefik:set --global api-entry-point
+  dokku traefik:set --global api-entry-point-address
   dokku traefik:set --global challenge-mode
   dokku traefik:set --global dns-provider
   dokku traefik:start
@@ -554,6 +556,120 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output_not_exists
+}
+
+@test "(traefik) api-entry-point property" {
+  run /bin/bash -c "dokku traefik:report $TEST_APP --traefik-api-entry-point"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run /bin/bash -c "dokku traefik:set --global api-entry-point private"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:report $TEST_APP --traefik-api-entry-point"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "private"
+
+  run /bin/bash -c "dokku traefik:set --global api-entry-point"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:report $TEST_APP --traefik-api-entry-point"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+}
+
+@test "(traefik) api-entry-point can only be set globally" {
+  run /bin/bash -c "dokku traefik:set $TEST_APP api-entry-point private"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "can only be set globally"
+}
+
+@test "(traefik) api-entry-point-address can only be set globally" {
+  run /bin/bash -c "dokku traefik:set $TEST_APP api-entry-point-address :8080"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "can only be set globally"
+}
+
+@test "(traefik) show-config with api-entry-point" {
+  run /bin/bash -c "dokku traefik:set --global api-enabled true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:set --global api-entry-point private"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:set --global api-entry-point-address :8080"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:show-config | yq -r '.services.traefik.command[] | select(. == \"--entrypoints.private.address=:8080\")'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "--entrypoints.private.address=:8080"
+
+  run /bin/bash -c "dokku traefik:show-config | yq -r '.services.traefik.labels[] | select(. == \"traefik.http.routers.api.entrypoints=private\")'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "traefik.http.routers.api.entrypoints=private"
+
+  run /bin/bash -c "dokku traefik:show-config | yq -r '.services.traefik.ports[] | select(. == \":8080:8080\")'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ":8080:8080"
+
+  # Cleanup
+  run /bin/bash -c "dokku traefik:set --global api-enabled"
+  run /bin/bash -c "dokku traefik:set --global api-entry-point"
+  run /bin/bash -c "dokku traefik:set --global api-entry-point-address"
+}
+
+@test "(traefik) show-config with api-entry-point does not set tls cert resolver" {
+  run /bin/bash -c "dokku traefik:set --global letsencrypt-email test@example.com"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:set --global api-enabled true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:set --global api-entry-point private"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku traefik:show-config | yq -r '.services.traefik.labels[] | select(contains(\"certresolver\"))'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  # Cleanup
+  run /bin/bash -c "dokku traefik:set --global letsencrypt-email"
+  run /bin/bash -c "dokku traefik:set --global api-enabled"
+  run /bin/bash -c "dokku traefik:set --global api-entry-point"
 }
 
 @test "(traefik) [dns-01] show-config with dns challenge" {


### PR DESCRIPTION
This pull request introduces support for customizing the Traefik API entry point and its address within the Dokku Traefik plugin. The changes allow users to define the API entry point and address globally, update the compose file template and command/report outputs accordingly, and add comprehensive tests to ensure correct behavior and validation.

## Example Usage

Getting this working should be relatively straightforward:

```
$ dokku traefik:set --global api-entry-point private
$ dokku traefik:set --global api-entry-point-address :8080
$ dokku traefik:stop
$ dokku traefik:start
```

closes dokku/dokku#8370.

## AI Disclaimer

I prompted Claude Code for generating this. I have two small kids, so this is pretty much the only way I have time for open source these days. 😓 All code here has been reviewed, and will be manually validated prior to moving the PR out of "draft" status.