### PR TITLE
Fix client prepending `--app` for non-app commands

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -183,7 +183,7 @@ main() {
             ssh -p "$DOKKU_PORT" "dokku@$DOKKU_REMOTE_HOST" apps
             exit 1
           else
-            APP=$(random_name)
+            APP=$(fn-random-name)
             counter=$((counter + 1))
           fi
         done


### PR DESCRIPTION
## What?
- [x] Prevent `dokku_client.sh` from prepending `--app` for `network:create`, `network:destroy`, `network:exists`, `network:info`, `network:list`, `network:rebuildall` (42af3c4a6)
- [x] Add missing global commands to the exclusion whitelist: `domains:clear-global`, `logs:vector-*`, `scheduler-k3s:cluster:*`, `scheduler-k3s:profiles:*`, and other global `scheduler-k3s` commands (b548eb00c)
- [x] Fix `random_name` → `fn-random-name` typo in `apps:create` retry loop (50e383f06)

## Why?
When running commands like `dokku network:create my-net` from a git repo with a `dokku` remote, the client prepends `--app <app-name>` to the SSH command. The server then injects the app name as the first positional argument, and `network:create` picks it up as the network name instead of `my-net`.

The client maintains a whitelist of commands that should NOT get `--app` prepended. This whitelist was missing `network:*` global commands and several others (`logs:vector-*`, `scheduler-k3s` cluster/profile/system commands, `domains:clear-global`).

The `random_name` typo (50e383f06) would cause `apps:create` to fail with "command not found" when retrying name generation after a collision.

## How to test?
1. From a git repo with a `dokku` remote, run `dokku network:create test-net` — it should create network `test-net`, not the app name from the remote.
2. Verify app-specific network commands still work: `dokku network:set <app> ...` should still receive the app context.
3. Run `bats tests/unit/client.bats` if available.

## Anything else?
It might be worth noting that this whitelist approach requires updates whenever new global commands are added to plugins. A potential alternative could be handling this server-side, but that's outside the scope of this PR.