### PR TITLE
chore: label test app dependency updates as type: tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -189,140 +189,140 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: bundler
     directory: "/tests/apps/multi"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/checks-root"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/config"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/dockerfile-app-json-formations"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/dockerfile-noexpose"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/dockerfile-procfile-bad"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/dockerfile-procfile"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/dockerfile"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/gitsubmodules"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: gomod
     directory: "/tests/apps/gogrpc"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: pip
     directory: "/tests/apps/multi"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: maven
     directory: "/tests/apps/java"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/multi"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/nodejs-express"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/nodejs-worker"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/nodejs-express-noappjson"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: npm
     directory: "/tests/apps/nodejs-express-noprocfile"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: composer
     directory: "/tests/apps/php"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: pip
     directory: "/tests/apps/python-flask"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -343,91 +343,91 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/dockerfile"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/dockerfile-procfile"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/dockerfile-entrypoint"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/dockerfile-procfile-bad"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/go-fail-predeploy"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/zombies-dockerfile-no-tini"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/dockerfile-release"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: pip
     directory: "/tests/apps/dockerfile-release"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/dockerfile-app-json-formations"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/gogrpc"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/zombies-dockerfile-tini"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/tests/apps/go-fail-postdeploy"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - "type: dependencies"
+      - "type: tests"
   - package-ecosystem: "docker"
     directory: "/docs/_build"
     schedule:


### PR DESCRIPTION
## Summary

- Changes all `/tests/apps/` dependabot entries from `type: dependencies` to `type: tests` label
- Test dependency bumps will now appear under the "Tests" section in the changelog instead of "Dependencies"
- Keeps plugin, docs, CI, and infrastructure dependency entries under `type: dependencies`

Closes #8477