### PR TITLE
Add --format json to git:report and nginx:report

### DIFF
--- a/docs/deployment/methods/git.md
+++ b/docs/deployment/methods/git.md
@@ -13,7 +13,7 @@ git:load-image [--build-dir DIRECTORY] <app> <docker-image> [<git-username> <git
 git:sync [--build|--build-if-changes] [--skip-deploy-branch] <app> <repository> [<git-ref>] # Clone or fetch an app from remote git repo
 git:initialize <app>                              # Initialize a git repository for an app
 git:public-key                                    # Outputs the dokku public deploy key
-git:report [<app>] [<flag>]                       # Displays a git report for one or more apps
+git:report [<app>] [<flag>|--format json]         # Displays a git report for one or more apps
 git:set <app> <key> (<value>)                     # Set or clear a git property for an app
 git:status <app>                                  # Show the working tree status for an app
 ```
@@ -241,3 +241,42 @@ dokku git:public-key
 ```
 
 If there is no key, an error message is shown that displays the command that can be run on the Dokku server to generate a new public/private ssh key pair.
+
+### Displaying git reports for an app
+
+You can get a report about the app's git configuration using the `git:report` command:
+
+```shell
+dokku git:report
+```
+
+```
+=====> node-js-app git information
+       Git deploy branch:             master
+       Git global deploy branch:      master
+       Git keep git dir:              false
+       Git rev env var:               GIT_REV
+       Git sha:                       a1b2c3d
+       Git source image:
+       Git last updated at:           1700000000
+```
+
+You can run the command for a specific app also.
+
+```shell
+dokku git:report node-js-app
+```
+
+You can pass flags which will output only the value of the specific information you want. For example:
+
+```shell
+dokku git:report node-js-app --git-deploy-branch
+```
+
+The `git:report` command also takes a `--format` flag, with the valid options including `stdout` (default) and `json`. The `json` output format can be used for automation purposes:
+
+```shell
+dokku git:report node-js-app --format json
+```
+
+The `--format` flag cannot be combined with an info flag.

--- a/docs/networking/proxies/nginx.md
+++ b/docs/networking/proxies/nginx.md
@@ -5,7 +5,7 @@ Dokku uses nginx as its server for routing requests to specific applications. By
 ```
 nginx:access-logs <app> [-t]             # Show the nginx access logs for an application (-t follows)
 nginx:error-logs <app> [-t]              # Show the nginx error logs for an application (-t follows)
-nginx:report [<app>] [<flag>]            # Displays a nginx report for one or more apps
+nginx:report [<app>] [<flag>|--format json] # Displays a nginx report for one or more apps
 nginx:set <app> <property> (<value>)     # Set or clear an nginx property for an app
 nginx:show-config <app>                  # Display app nginx config
 nginx:start                              # Starts the nginx server
@@ -127,6 +127,34 @@ The `--clean` flag may also be specified for a given app:
 ```shell
 dokku nginx:validate-config node-js-app --clean
 ```
+
+### Displaying nginx reports for an app
+
+You can get a report about the app's nginx configuration using the `nginx:report` command:
+
+```shell
+dokku nginx:report
+```
+
+You can run the command for a specific app also.
+
+```shell
+dokku nginx:report node-js-app
+```
+
+You can pass flags which will output only the value of the specific information you want. For example:
+
+```shell
+dokku nginx:report node-js-app --nginx-bind-address-ipv4
+```
+
+The `nginx:report` command also takes a `--format` flag, with the valid options including `stdout` (default) and `json`. The `json` output format can be used for automation purposes:
+
+```shell
+dokku nginx:report node-js-app --format json
+```
+
+The `--format` flag cannot be combined with an info flag.
 
 ### Custom Error Pages
 

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -278,7 +278,23 @@ cmd-git-report() {
   declare desc="displays a git report for one or more apps"
   declare cmd="git:report"
   [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1" INFO_FLAG="$2"
+  local FORMAT="stdout"
+  local args=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --format)
+        FORMAT="$2"
+        shift 2
+        ;;
+      *)
+        args+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  declare APP="${args[0]:-}" INFO_FLAG="${args[1]:-}"
 
   if [[ -n "$APP" ]] && [[ "$APP" == --* ]]; then
     INFO_FLAG="$APP"
@@ -291,15 +307,15 @@ cmd-git-report() {
 
   if [[ -z "$APP" ]]; then
     for app in $(dokku_apps); do
-      cmd-git-report-single "$app" "$INFO_FLAG" | tee || true
+      cmd-git-report-single "$app" "$INFO_FLAG" "$FORMAT" | tee || true
     done
   else
-    cmd-git-report-single "$APP" "$INFO_FLAG"
+    cmd-git-report-single "$APP" "$INFO_FLAG" "$FORMAT"
   fi
 }
 
 cmd-git-report-single() {
-  declare APP="$1" INFO_FLAG="$2"
+  declare APP="$1" INFO_FLAG="$2" FORMAT="${3:-stdout}"
   local APP_ROOT="$DOKKU_ROOT/$APP"
   if [[ "$INFO_FLAG" == "true" ]]; then
     INFO_FLAG=""
@@ -314,6 +330,22 @@ cmd-git-report-single() {
     "--git-source-image: $(fn-git-source-image "$APP")"
     "--git-last-updated-at: $(fn-git-last-updated-at "$APP")"
   )
+
+  if [[ "$FORMAT" != "stdout" ]] && [[ -n "$INFO_FLAG" ]]; then
+    dokku_log_fail "--format flag cannot be specified when specifying an info flag"
+  fi
+
+  if [[ "$FORMAT" == "json" ]]; then
+    local json_output="{}"
+    for flag in "${flag_map[@]}"; do
+      local key value
+      key="$(echo "$flag" | cut -d':' -f1 | sed 's/^--git-//')"
+      value="$(echo "$flag" | cut -d':' -f2- | sed 's/^ //')"
+      json_output="$(echo "$json_output" | jq -c --arg key "$key" --arg value "$value" '. + {($key): $value}')"
+    done
+    echo "$json_output"
+    return
+  fi
 
   if [[ -z "$INFO_FLAG" ]]; then
     dokku_log_info2_quiet "${APP} git information"

--- a/plugins/nginx-vhosts/command-functions
+++ b/plugins/nginx-vhosts/command-functions
@@ -10,7 +10,23 @@ cmd-nginx-report() {
   declare desc="displays a nginx report for one or more apps"
   declare cmd="nginx:report"
   [[ "$1" == "$cmd" ]] && shift 1
-  declare APP="$1" INFO_FLAG="$2"
+  local FORMAT="stdout"
+  local args=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --format)
+        FORMAT="$2"
+        shift 2
+        ;;
+      *)
+        args+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  declare APP="${args[0]:-}" INFO_FLAG="${args[1]:-}"
 
   if [[ -n "$APP" ]] && [[ "$APP" == --* ]]; then
     INFO_FLAG="$APP"
@@ -23,15 +39,15 @@ cmd-nginx-report() {
 
   if [[ -z "$APP" ]]; then
     for app in $(dokku_apps); do
-      cmd-nginx-report-single "$app" "$INFO_FLAG" | tee || true
+      cmd-nginx-report-single "$app" "$INFO_FLAG" "$FORMAT" | tee || true
     done
   else
-    cmd-nginx-report-single "$APP" "$INFO_FLAG"
+    cmd-nginx-report-single "$APP" "$INFO_FLAG" "$FORMAT"
   fi
 }
 
 cmd-nginx-report-single() {
-  declare APP="$1" INFO_FLAG="$2"
+  declare APP="$1" INFO_FLAG="$2" FORMAT="${3:-stdout}"
   if [[ "$INFO_FLAG" == "true" ]]; then
     INFO_FLAG=""
   fi
@@ -129,6 +145,22 @@ cmd-nginx-report-single() {
     "--nginx-computed-x-forwarded-ssl: $(fn-nginx-computed-x-forwarded-ssl "$APP")"
     "--nginx-global-x-forwarded-ssl: $(fn-nginx-global-x-forwarded-ssl "$APP")"
   )
+
+  if [[ "$FORMAT" != "stdout" ]] && [[ -n "$INFO_FLAG" ]]; then
+    dokku_log_fail "--format flag cannot be specified when specifying an info flag"
+  fi
+
+  if [[ "$FORMAT" == "json" ]]; then
+    local json_output="{}"
+    for flag in "${flag_map[@]}"; do
+      local key value
+      key="$(echo "$flag" | cut -d':' -f1 | sed 's/^--nginx-//')"
+      value="$(echo "$flag" | cut -d':' -f2- | sed 's/^ //')"
+      json_output="$(echo "$json_output" | jq -c --arg key "$key" --arg value "$value" '. + {($key): $value}')"
+    done
+    echo "$json_output"
+    return
+  fi
 
   if [[ -z "$INFO_FLAG" ]]; then
     dokku_log_info2_quiet "${APP} nginx information"

--- a/tests/unit/git_3.bats
+++ b/tests/unit/git_3.bats
@@ -731,3 +731,38 @@ teardown() {
   assert_success
   assert_output "master"
 }
+
+@test "(git:report) --format json" {
+  run /bin/bash -c "dokku git:set $TEST_APP deploy-branch main"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report $TEST_APP --format json | jq -r '.\"deploy-branch\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "main"
+
+  run /bin/bash -c "dokku git:report $TEST_APP --format json | jq -r '.\"global-deploy-branch\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "master"
+
+  run /bin/bash -c "dokku git:report $TEST_APP --format json | jq -e ."
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report --format json | jq -e ."
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report $TEST_APP --format json --git-deploy-branch"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "--format flag cannot be specified when specifying an info flag"
+}

--- a/tests/unit/nginx-vhosts_1.bats
+++ b/tests/unit/nginx-vhosts_1.bats
@@ -28,6 +28,40 @@ teardown() {
   assert_output "$help_output"
 }
 
+@test "(nginx:report) --format json" {
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP bind-address-ipv4 127.0.0.1"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:report $TEST_APP --format json | jq -r '.\"bind-address-ipv4\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "127.0.0.1"
+
+  run /bin/bash -c "dokku nginx:report $TEST_APP --format json | jq -e ."
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:report --format json | jq -e ."
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:report $TEST_APP --format json --nginx-bind-address-ipv4"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "--format flag cannot be specified when specifying an info flag"
+}
+
 @test "(nginx-vhosts) proxy:build-config (domains:disable/enable)" {
   run deploy_app
   echo "output: $output"


### PR DESCRIPTION
## Summary

Mirrors the JSON output convention already used by `scheduler:report`, `builder:report`, `network:report`, and `traefik:report`. Both `git:report` and `nginx:report` now accept `--format json` to emit a single-line JSON object whose keys are the property names with the plugin prefix stripped. Combining `--format` with an info flag is rejected with an error message that matches the Go-based report helper.

Closes #8499