### PR TITLE
Add launcher entrypoint for CNB images on dokku run and cron:run

### DIFF
--- a/plugins/builder-pack/docker-args-process-deploy
+++ b/plugins/builder-pack/docker-args-process-deploy
@@ -20,7 +20,7 @@ trigger-builder-pack-docker-args-process-deploy() {
 
   if [[ "$inject_launcher" == "true" ]]; then
     # without this, the command and arguments are passed as args to the default process type
-    output="--entrypoint launcher "
+    output=" --entrypoint launcher"
   fi
 
   echo -n "$STDIN$output"

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -73,6 +73,7 @@ trigger-scheduler-docker-local-scheduler-run() {
   local DYNO_NUMBER="$RANDOM"
   local IMAGE_SOURCE_TYPE="dockerfile"
   is_image_herokuish_based "$IMAGE" "$APP" && IMAGE_SOURCE_TYPE="herokuish"
+  is_image_cnb_based "$IMAGE" && IMAGE_SOURCE_TYPE="pack"
   DOCKER_ARGS+=$(: | plugn trigger docker-args-process-run "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG")
   DOCKER_ARGS+=" -e DYNO=$PROCESS_TYPE.$DYNO_NUMBER --name $APP.$PROCESS_TYPE.$DYNO_NUMBER"
 
@@ -96,8 +97,8 @@ trigger-scheduler-docker-local-scheduler-run() {
     done
   fi
 
-  [[ "$IMAGE_SOURCE_TYPE" == "herokuish" ]] && local EXEC_CMD="/exec"
-  is_image_cnb_based "$IMAGE" && EXEC_CMD=""
+  local EXEC_CMD=""
+  [[ "$IMAGE_SOURCE_TYPE" == "herokuish" ]] && EXEC_CMD="/exec"
 
   if [[ "$1" == "--" ]]; then
     shift

--- a/tests/apps/python/app-cnb-cron-procfile.json
+++ b/tests/apps/python/app-cnb-cron-procfile.json
@@ -1,0 +1,21 @@
+{
+  "cron": [
+    {
+      "command": "task",
+      "schedule": "5 5 5 5 5"
+    }
+  ],
+  "healthchecks": {
+    "web": [
+      {
+        "attempts": 2,
+        "content": "python/http.server",
+        "name": "check-1",
+        "path": "/",
+        "timeout": 5,
+        "type": "startup",
+        "wait": 2
+      }
+    ]
+  }
+}

--- a/tests/unit/builder-pack.bats
+++ b/tests/unit/builder-pack.bats
@@ -177,6 +177,39 @@ teardown() {
   assert_output "['task.py', 'some', 'cron', 'task']"
 }
 
+@test "(builder-pack) cron:run with Procfile reference" {
+  run /bin/bash -c "dokku config:set $TEST_APP SECRET_KEY=fjdkslafjdk"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder:set $TEST_APP selected pack"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP cron_run_procfile_wrapper
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains 'from cnb stack'
+  assert_output_contains 'Building with buildpack 1' 0
+  assert_output_contains 'Installing dependencies using pip'
+
+  cron_id="$(dokku cron:list $TEST_APP --format json | jq -r '.[0].id')"
+  run /bin/bash -c "echo $cron_id"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_exists
+
+  run /bin/bash -c "dokku --quiet cron:run $TEST_APP $cron_id"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "['task.py', 'test']"
+}
+
 cron_run_wrapper() {
   local APP="$1"
   local APP_REPO_DIR="$2"
@@ -186,4 +219,15 @@ cron_run_wrapper() {
   add_requirements_txt "$APP" "$APP_REPO_DIR"
   ls -lah "$APP_REPO_DIR"
   mv -f "$APP_REPO_DIR/app-cnb-cron.json" "$APP_REPO_DIR/app.json"
+}
+
+cron_run_procfile_wrapper() {
+  local APP="$1"
+  local APP_REPO_DIR="$2"
+  [[ -z "$APP" ]] && local APP="$TEST_APP"
+  APP_REPO_DIR="$(realpath "$APP_REPO_DIR")"
+
+  add_requirements_txt "$APP" "$APP_REPO_DIR"
+  ls -lah "$APP_REPO_DIR"
+  mv -f "$APP_REPO_DIR/app-cnb-cron-procfile.json" "$APP_REPO_DIR/app.json"
 }


### PR DESCRIPTION
## Summary

The scheduler-run script classified CNB-based images as `herokuish` because `is_image_herokuish_based` returns true for them, which caused the `docker-args-process-run` trigger for builder-pack to skip injecting `--entrypoint launcher`. Without that flag the container fell back to the image entrypoint (e.g. `/cnb/process/web`) and dropped the user-supplied arguments, so commands like `npm run job <task>` were invoked as bare `npm`. Mirror the deploy-side detection so CNB images set `IMAGE_SOURCE_TYPE=pack`, allowing the launcher entrypoint to be added.

Closes #8242