### PR TITLE
chore: bump dokku/netrc to v0.11.0

### DIFF
--- a/contrib/dependencies.json
+++ b/contrib/dependencies.json
@@ -26,10 +26,10 @@
     },
     {
       "name": "netrc",
-      "version": "0.10.3",
+      "version": "0.11.0",
       "urls": {
-        "amd64": "https://github.com/dokku/netrc/releases/download/v0.10.3/netrc-linux-amd64",
-        "arm64": "https://github.com/dokku/netrc/releases/download/v0.10.3/netrc-linux-arm64"
+        "amd64": "https://github.com/dokku/netrc/releases/download/v0.11.0/netrc-linux-amd64",
+        "arm64": "https://github.com/dokku/netrc/releases/download/v0.11.0/netrc-linux-arm64"
       }
     },
     {


### PR DESCRIPTION
The `git:auth` test in `tests/unit/git_3.bats` verifies the written entry with `netrc get --netrc-file ${DOKKU_ROOT}/.netrc github.com`, but the `--netrc-file` flag was added in netrc v0.11.0 and CI was still pinned to v0.10.3, so the assertion ran against root's `~/.netrc` and exited 1.