### PR TITLE
Use explicit type property in proxy:set examples

### DIFF
--- a/docs/networking/port-management.md
+++ b/docs/networking/port-management.md
@@ -40,7 +40,7 @@ To change the proxy implementation in use for an application, use the `proxy:set
 ```shell
 # no validation will be performed against
 # the specified proxy implementation
-dokku proxy:set node-js-app nginx
+dokku proxy:set node-js-app type nginx
 ```
 
 ### Listing port mappings

--- a/docs/networking/proxies/caddy.md
+++ b/docs/networking/proxies/caddy.md
@@ -39,7 +39,7 @@ The Caddy plugin has specific rules for routing requests:
 To use the Caddy plugin, use the `proxy:set` command for the app in question:
 
 ```shell
-dokku proxy:set node-js-app caddy
+dokku proxy:set node-js-app type caddy
 ```
 
 This will enable the docker label-based Caddy integration. All future deploys will inject the correct labels for Caddy to read and route requests to containers. Due to the docker label-based integration used by Caddy, a single deploy or rebuild will be required before requests will route successfully.

--- a/docs/networking/proxies/haproxy.md
+++ b/docs/networking/proxies/haproxy.md
@@ -35,7 +35,7 @@ The Haproxy plugin has specific rules for routing requests:
 To use the Haproxy plugin, use the `proxy:set` command for the app in question:
 
 ```shell
-dokku proxy:set node-js-app haproxy
+dokku proxy:set node-js-app type haproxy
 ```
 
 This will enable the docker label-based Haproxy integration. All future deploys will inject the correct labels for Haproxy to read and route requests to containers. Due to the docker label-based integration used by Haproxy, a single deploy or rebuild will be required before requests will route successfully.

--- a/docs/networking/proxies/openresty.md
+++ b/docs/networking/proxies/openresty.md
@@ -35,7 +35,7 @@ The OpenResty plugin has specific rules for routing requests:
 To use the OpenResty plugin, use the `proxy:set` command for the app in question:
 
 ```shell
-dokku proxy:set node-js-app openresty
+dokku proxy:set node-js-app type openresty
 ```
 
 This will enable the docker label-based OpenResty integration. All future deploys will inject the correct labels for OpenResty to read and route requests to containers. Due to the docker label-based integration used by OpenResty, a single deploy or rebuild will be required before requests will route successfully.

--- a/docs/networking/proxies/traefik.md
+++ b/docs/networking/proxies/traefik.md
@@ -74,7 +74,7 @@ Example `app.json` configuration:
 To use the Traefik plugin, use the `proxy:set` command for the app in question:
 
 ```shell
-dokku proxy:set node-js-app traefik
+dokku proxy:set node-js-app type traefik
 ```
 
 This will enable the docker label-based Traefik integration. All future deploys will inject the correct labels for Traefik to read and route requests to containers. Due to the docker label-based integration used by Traefik, a single deploy or rebuild will be required before requests will route successfully.

--- a/docs/networking/proxy-management.md
+++ b/docs/networking/proxy-management.md
@@ -21,7 +21,7 @@ In Dokku 0.5.0, port proxying was decoupled from the `nginx-vhosts` plugin into 
 The default proxy shipped with Dokku is `nginx`. It can be changed via the `proxy:set` command.
 
 ```shell
-dokku proxy:set node-js-app caddy
+dokku proxy:set node-js-app type caddy
 ```
 
 ```
@@ -31,7 +31,7 @@ dokku proxy:set node-js-app caddy
 The proxy may also be set on a global basis. This is usually preferred as running multiple proxy implementations may cause port collision issues.
 
 ```shell
-dokku proxy:set --global caddy
+dokku proxy:set --global type caddy
 ```
 
 ```


### PR DESCRIPTION
The 0.38.0 migration documents `proxy:set <app> type <value>` as the canonical way to set the proxy implementation, but several user-facing examples still taught the legacy implicit form. Switch every example over to the explicit property syntax so the docs match the migration guide and other property-based plugin commands.