### PR TITLE
Install cnb pack from github releases instead of ppa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN addgroup --gid $DOKKU_GID dokku \
 
 COPY ./tests/dhparam.pem /tmp/dhparam.pem
 COPY ./build/package/ /tmp
+COPY ./contrib/dependencies.json /tmp/dependencies.json
 
 ENV DOKKU_INIT_SYSTEM=sv
 
@@ -22,12 +23,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3005,DL3008
 RUN mkdir -p /etc/apt/keyrings \
   && mkdir -p /etc/apt/keyrings \
-  && apt-get remove -y systemd && apt-get autoremove -y && apt-get update && apt-get -y --no-install-recommends install gpg lsb-release openssl openssh-server rsync software-properties-common \
+  && apt-get remove -y systemd && apt-get autoremove -y && apt-get update && apt-get -y --no-install-recommends install gpg jq lsb-release openssl openssh-server rsync software-properties-common \
   && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
-  && add-apt-repository ppa:cncf-buildpacks/pack-cli \
   && apt-get update \
-  && apt-get -y --no-install-recommends install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin pack-cli \
+  && apt-get -y --no-install-recommends install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
+  && PACK_URL="$(jq -r --arg arch "$(dpkg --print-architecture)" '.dependencies[] | select(.name == "pack") | .urls[$arch]' /tmp/dependencies.json)" \
+  && curl -fsSL "$PACK_URL" | tar -C /usr/bin/ --no-same-owner -xzf - pack \
+  && chmod +x /usr/bin/pack \
+  && test -x /usr/bin/pack \
   && curl -o /tmp/nixpacks.bash -sSL https://nixpacks.com/install.sh \
   && chmod +x /tmp/nixpacks.bash \
   && NIXPACKS_BIN_DIR=/usr/bin BIN_DIR=/usr/bin /tmp/nixpacks.bash \

--- a/contrib/dependencies.json
+++ b/contrib/dependencies.json
@@ -33,6 +33,14 @@
       }
     },
     {
+      "name": "pack",
+      "version": "0.40.3",
+      "urls": {
+        "amd64": "https://github.com/buildpacks/pack/releases/download/v0.40.3/pack-v0.40.3-linux.tgz",
+        "arm64": "https://github.com/buildpacks/pack/releases/download/v0.40.3/pack-v0.40.3-linux-arm64.tgz"
+      }
+    },
+    {
       "name": "procfile-util",
       "version": "0.20.7",
       "urls": {

--- a/contrib/update-deb-dependencies
+++ b/contrib/update-deb-dependencies
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import re
 
 
 def main():
@@ -18,11 +19,9 @@ def main():
         for dependency in deps[key]:
             name = dependency["name"]
             version = dependency["version"]
+            pattern = re.compile(rf"(?<![\w-]){re.escape(name)}(?![\w-])")
             for i, line in enumerate(control_lines):
-                if name in line:
-                    control_lines[i] = control_lines[i].replace(
-                        name, f"{name} (>= {version})"
-                    )
+                control_lines[i] = pattern.sub(f"{name} (>= {version})", line)
 
     with open("debian/control", mode="w", encoding="utf-8") as handle:
         handle.writelines(control_lines)

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -655,9 +655,11 @@ convert_to_dockerfile() {
 
 install_pack() {
   if [[ ! -x /usr/bin/pack ]]; then
-    add-apt-repository --yes ppa:cncf-buildpacks/pack-cli
-    apt-get update
-    apt-get --yes install pack-cli
+    local DEPS_FILE="${BATS_TEST_DIRNAME}/../../contrib/dependencies.json"
+    local PACK_URL
+    PACK_URL="$(jq -r --arg arch "$(dpkg --print-architecture)" '.dependencies[] | select(.name == "pack") | .urls[$arch]' "$DEPS_FILE")"
+    curl -fsSL "$PACK_URL" | tar -C /usr/bin --no-same-owner -xzf - pack
+    chmod +x /usr/bin/pack
   fi
 }
 


### PR DESCRIPTION
The ppa:cncf-buildpacks/pack-cli launchpad source is currently down, breaking the runtime image build and any bats run that calls install_pack. Pack is now tracked in contrib/dependencies.json and pulled from the buildpacks/pack GitHub release tarball, matching how other binary deps are managed. update-deb-dependencies gains hyphen-aware word-boundary matching so single-word names like pack cannot accidentally rewrite unrelated debian/control lines, keeping pack out of the package's hard requirements.