### PR TITLE
Source property-functions where fn-plugin-property-* helpers are used

### DIFF
--- a/plugins/caddy-vhosts/command-functions
+++ b/plugins/caddy-vhosts/command-functions
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/proxy/command-functions"
 source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/internal-functions"
 set -eo pipefail

--- a/plugins/caddy-vhosts/pre-restore
+++ b/plugins/caddy-vhosts/pre-restore
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/caddy-vhosts/command-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 
 has_tty() {
   declare desc="return 0 if we have a tty"
@@ -973,10 +974,6 @@ fn-migrate-config-to-property() {
   # todo: refactor to remove config_unset usage
   if ! declare -f -F config_unset >/dev/null; then
     source "$PLUGIN_AVAILABLE_PATH/config/functions"
-  fi
-
-  if ! declare -f -F fn-plugin-property-write >/dev/null; then
-    source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
   fi
 
   if [[ -n "$GLOBAL_CONFIG_VAR" ]]; then

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -637,7 +637,7 @@ release_and_deploy() {
 
   if verify_image "$IMAGE"; then
     if ! declare -f -F fn-plugin-property-get-default >/dev/null; then
-      source "$PLUGIN_AVAILABLE_PATH/common/property-functions"
+      source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
     fi
 
     IMAGE_SOURCE_TYPE="$(get_image_builder_type "$IMAGE" "$APP")"
@@ -980,7 +980,7 @@ fn-migrate-config-to-property() {
   fi
 
   if ! declare -f -F fn-plugin-property-write >/dev/null; then
-    source "$PLUGIN_AVAILABLE_PATH/common/property-functions"
+    source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
   fi
 
   if [[ -n "$GLOBAL_CONFIG_VAR" ]]; then

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
-source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 
 has_tty() {
   declare desc="return 0 if we have a tty"
@@ -637,6 +636,10 @@ release_and_deploy() {
   local exit_code=0
 
   if verify_image "$IMAGE"; then
+    if ! declare -f -F fn-plugin-property-get-default >/dev/null; then
+      source "$PLUGIN_AVAILABLE_PATH/common/property-functions"
+    fi
+
     IMAGE_SOURCE_TYPE="$(get_image_builder_type "$IMAGE" "$APP")"
     local DOKKU_APP_SKIP_DEPLOY="$(fn-plugin-property-get-default "ps" "$APP" "skip-deploy" "")"
     local DOKKU_GLOBAL_SKIP_DEPLOY="$(fn-plugin-property-get-default "ps" "--global" "skip-deploy" "")"
@@ -974,6 +977,10 @@ fn-migrate-config-to-property() {
   # todo: refactor to remove config_unset usage
   if ! declare -f -F config_unset >/dev/null; then
     source "$PLUGIN_AVAILABLE_PATH/config/functions"
+  fi
+
+  if ! declare -f -F fn-plugin-property-write >/dev/null; then
+    source "$PLUGIN_AVAILABLE_PATH/common/property-functions"
   fi
 
   if [[ -n "$GLOBAL_CONFIG_VAR" ]]; then

--- a/plugins/haproxy-vhosts/command-functions
+++ b/plugins/haproxy-vhosts/command-functions
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/proxy/command-functions"
 source "$PLUGIN_AVAILABLE_PATH/haproxy-vhosts/internal-functions"
 set -eo pipefail

--- a/plugins/haproxy-vhosts/pre-restore
+++ b/plugins/haproxy-vhosts/pre-restore
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/haproxy-vhosts/command-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x

--- a/plugins/nginx-vhosts/pre-restore
+++ b/plugins/nginx-vhosts/pre-restore
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/nginx-vhosts/command-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x

--- a/plugins/openresty-vhosts/command-functions
+++ b/plugins/openresty-vhosts/command-functions
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/proxy/command-functions"
 source "$PLUGIN_AVAILABLE_PATH/openresty-vhosts/internal-functions"
 set -eo pipefail

--- a/plugins/openresty-vhosts/pre-restore
+++ b/plugins/openresty-vhosts/pre-restore
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/openresty-vhosts/command-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x

--- a/plugins/traefik-vhosts/command-functions
+++ b/plugins/traefik-vhosts/command-functions
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/proxy/command-functions"
 source "$PLUGIN_AVAILABLE_PATH/traefik-vhosts/internal-functions"
 set -eo pipefail

--- a/plugins/traefik-vhosts/pre-restore
+++ b/plugins/traefik-vhosts/pre-restore
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
 source "$PLUGIN_AVAILABLE_PATH/traefik-vhosts/command-functions"
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x

--- a/tests/unit/core_2.bats
+++ b/tests/unit/core_2.bats
@@ -112,18 +112,6 @@ teardown() {
   assert_urls "http://dokku.example.com" "http://${TEST_APP}.${DOKKU_DOMAIN}" "https://dokku.example.com" "https://${TEST_APP}.${DOKKU_DOMAIN}" "https://test.${DOKKU_DOMAIN}" "http://test.${DOKKU_DOMAIN}"
 }
 
-@test "(core) sourcing common/functions exposes fn-plugin-property-* helpers" {
-  run /bin/bash -c "source $PLUGIN_CORE_AVAILABLE_PATH/common/functions && declare -f -F fn-plugin-property-get-default"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-
-  run /bin/bash -c "source $PLUGIN_CORE_AVAILABLE_PATH/common/functions && declare -f -F fn-plugin-property-write"
-  echo "output: $output"
-  echo "status: $status"
-  assert_success
-}
-
 @test "(core) release_and_deploy does not emit command not found errors" {
   run deploy_app
   echo "output: $output"

--- a/tests/unit/core_2.bats
+++ b/tests/unit/core_2.bats
@@ -112,6 +112,27 @@ teardown() {
   assert_urls "http://dokku.example.com" "http://${TEST_APP}.${DOKKU_DOMAIN}" "https://dokku.example.com" "https://${TEST_APP}.${DOKKU_DOMAIN}" "https://test.${DOKKU_DOMAIN}" "http://test.${DOKKU_DOMAIN}"
 }
 
+@test "(core) sourcing common/functions exposes fn-plugin-property-* helpers" {
+  run /bin/bash -c "source $PLUGIN_CORE_AVAILABLE_PATH/common/functions && declare -f -F fn-plugin-property-get-default"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "source $PLUGIN_CORE_AVAILABLE_PATH/common/functions && declare -f -F fn-plugin-property-write"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
+@test "(core) release_and_deploy does not emit command not found errors" {
+  run deploy_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_contains "fn-plugin-property-get-default: command not found"
+  assert_output_not_contains "fn-plugin-property-get: command not found"
+}
+
 @test "(core) git-remote (off-port)" {
   run deploy_app nodejs-express ssh://dokku@127.0.0.1:22333/$TEST_APP
   echo "output: $output"

--- a/tests/unit/core_2.bats
+++ b/tests/unit/core_2.bats
@@ -131,6 +131,7 @@ teardown() {
   assert_success
   assert_output_not_contains "fn-plugin-property-get-default: command not found"
   assert_output_not_contains "fn-plugin-property-get: command not found"
+  assert_output_not_contains "/common/property-functions: No such file or directory"
 }
 
 @test "(core) git-remote (off-port)" {


### PR DESCRIPTION
## Summary

The `release_and_deploy` function and several proxy plugin scripts call `fn-plugin-property-*` helpers without sourcing `plugins/common/property-functions`, producing `command not found` errors during deploys. Sourcing the helpers from `plugins/common/functions` and from each proxy plugin entry point that consumes them resolves issue #8560.

closes #8560