### PR TITLE
Reference SOURCECODE_WORK_DIR in builder core-post-extract

### DIFF
--- a/plugins/builder-dockerfile/core-post-extract
+++ b/plugins/builder-dockerfile/core-post-extract
@@ -10,7 +10,7 @@ trigger-builder-dockerfile-core-post-extract() {
   declare APP="$1" SOURCECODE_WORK_DIR="$2"
   local NEW_DOCKERFILE="$(fn-builder-dockerfile-computed-dockerfile-path "$APP")"
 
-  pushd "$TMP_WORK_DIR" >/dev/null
+  pushd "$SOURCECODE_WORK_DIR" >/dev/null
 
   if [[ -z "$NEW_DOCKERFILE" ]]; then
     return

--- a/plugins/builder-lambda/core-post-extract
+++ b/plugins/builder-lambda/core-post-extract
@@ -10,7 +10,7 @@ trigger-builder-lambda-core-post-extract() {
   declare APP="$1" SOURCECODE_WORK_DIR="$2"
   local NEW_LAMBDA_YML="$(fn-builder-lambda-computed-lambdayml-path "$APP")"
 
-  pushd "$TMP_WORK_DIR" >/dev/null
+  pushd "$SOURCECODE_WORK_DIR" >/dev/null
 
   if [[ -z "$NEW_LAMBDA_YML" ]]; then
     return

--- a/plugins/builder-nixpacks/core-post-extract
+++ b/plugins/builder-nixpacks/core-post-extract
@@ -10,7 +10,7 @@ trigger-builder-nixpacks-core-post-extract() {
   declare APP="$1" SOURCECODE_WORK_DIR="$2"
   local NEW_NIXPACKS_YML="$(fn-builder-nixpacks-computed-nixpackstoml-path "$APP")"
 
-  pushd "$TMP_WORK_DIR" >/dev/null
+  pushd "$SOURCECODE_WORK_DIR" >/dev/null
 
   if [[ -z "$NEW_NIXPACKS_YML" ]]; then
     return

--- a/plugins/builder-pack/core-post-extract
+++ b/plugins/builder-pack/core-post-extract
@@ -10,7 +10,7 @@ trigger-builder-pack-core-post-extract() {
   declare APP="$1" SOURCECODE_WORK_DIR="$2"
   local NEW_PROJECT_TOML="$(fn-builder-pack-computed-projecttoml-path "$APP")"
 
-  pushd "$TMP_WORK_DIR" >/dev/null
+  pushd "$SOURCECODE_WORK_DIR" >/dev/null
 
   if [[ -z "$NEW_PROJECT_TOML" ]]; then
     return

--- a/plugins/builder-railpack/core-post-extract
+++ b/plugins/builder-railpack/core-post-extract
@@ -10,7 +10,7 @@ trigger-builder-railpack-core-post-extract() {
   declare APP="$1" SOURCECODE_WORK_DIR="$2"
   local NEW_RAILPACK_JSON="$(fn-builder-railpack-computed-railpackjson-path "$APP")"
 
-  pushd "$TMP_WORK_DIR" >/dev/null
+  pushd "$SOURCECODE_WORK_DIR" >/dev/null
 
   if [[ -z "$NEW_RAILPACK_JSON" ]]; then
     return

--- a/tests/unit/builder-dockerfile.bats
+++ b/tests/unit/builder-dockerfile.bats
@@ -166,7 +166,7 @@ EOF
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/builder-dockerfile/core-post-extract $TEST_APP $TMP_DIR HEAD"
+  run_plugin_script builder-dockerfile core-post-extract "$TEST_APP" "$TMP_DIR" HEAD
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/builder-dockerfile.bats
+++ b/tests/unit/builder-dockerfile.bats
@@ -155,6 +155,29 @@ EOF
   assert_output "3001/udp 3000/tcp 3003"
 }
 
+@test "(builder-dockerfile) core-post-extract renames the configured dockerfile" {
+  local TMP_DIR
+  TMP_DIR="$(mktemp -d "/tmp/dokku-test-builder-dockerfile.XXXXXX")"
+  trap "rm -rf '$TMP_DIR'" RETURN
+  echo "FROM scratch" >"$TMP_DIR/second.Dockerfile"
+
+  run /bin/bash -c "dokku builder-dockerfile:set $TEST_APP dockerfile-path second.Dockerfile"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/builder-dockerfile/core-post-extract $TEST_APP $TMP_DIR HEAD"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "test -f $TMP_DIR/Dockerfile"
+  assert_success
+
+  run /bin/bash -c "test ! -e $TMP_DIR/second.Dockerfile"
+  assert_success
+}
+
 @test "(builder-dockerfile) ps:rebuild fetches files from image" {
   run /bin/bash -c "dokku --trace git:from-image $TEST_APP dokku/smoke-test-app:dockerfile"
   echo "output: $output"

--- a/tests/unit/builder-dockerfile.bats
+++ b/tests/unit/builder-dockerfile.bats
@@ -156,25 +156,22 @@ EOF
 }
 
 @test "(builder-dockerfile) core-post-extract renames the configured dockerfile" {
-  local TMP_DIR
-  TMP_DIR="$(mktemp -d "/tmp/dokku-test-builder-dockerfile.XXXXXX")"
-  trap "rm -rf '$TMP_DIR'" RETURN
-  echo "FROM scratch" >"$TMP_DIR/second.Dockerfile"
+  echo "FROM scratch" >"$BATS_TEST_TMPDIR/second.Dockerfile"
 
   run /bin/bash -c "dokku builder-dockerfile:set $TEST_APP dockerfile-path second.Dockerfile"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run_plugin_script builder-dockerfile core-post-extract "$TEST_APP" "$TMP_DIR" HEAD
+  run_plugin_script builder-dockerfile core-post-extract "$TEST_APP" "$BATS_TEST_TMPDIR" HEAD
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "test -f $TMP_DIR/Dockerfile"
+  run /bin/bash -c "test -f $BATS_TEST_TMPDIR/Dockerfile"
   assert_success
 
-  run /bin/bash -c "test ! -e $TMP_DIR/second.Dockerfile"
+  run /bin/bash -c "test ! -e $BATS_TEST_TMPDIR/second.Dockerfile"
   assert_success
 }
 

--- a/tests/unit/builder-lambda.bats
+++ b/tests/unit/builder-lambda.bats
@@ -163,7 +163,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/builder-lambda/core-post-extract $TEST_APP $TMP_DIR HEAD"
+  run_plugin_script builder-lambda core-post-extract "$TEST_APP" "$TMP_DIR" HEAD
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/builder-lambda.bats
+++ b/tests/unit/builder-lambda.bats
@@ -153,25 +153,22 @@ teardown() {
 }
 
 @test "(builder-lambda) core-post-extract renames the configured lambda.yml" {
-  local TMP_DIR
-  TMP_DIR="$(mktemp -d "/tmp/dokku-test-builder-lambda.XXXXXX")"
-  trap "rm -rf '$TMP_DIR'" RETURN
-  echo "---" >"$TMP_DIR/lambda2.yml"
+  echo "---" >"$BATS_TEST_TMPDIR/lambda2.yml"
 
   run /bin/bash -c "dokku builder-lambda:set $TEST_APP lambdayml-path lambda2.yml"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run_plugin_script builder-lambda core-post-extract "$TEST_APP" "$TMP_DIR" HEAD
+  run_plugin_script builder-lambda core-post-extract "$TEST_APP" "$BATS_TEST_TMPDIR" HEAD
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "test -f $TMP_DIR/lambda.yml"
+  run /bin/bash -c "test -f $BATS_TEST_TMPDIR/lambda.yml"
   assert_success
 
-  run /bin/bash -c "test ! -e $TMP_DIR/lambda2.yml"
+  run /bin/bash -c "test ! -e $BATS_TEST_TMPDIR/lambda2.yml"
   assert_success
 }
 

--- a/tests/unit/builder-lambda.bats
+++ b/tests/unit/builder-lambda.bats
@@ -152,6 +152,29 @@ teardown() {
   assert_success
 }
 
+@test "(builder-lambda) core-post-extract renames the configured lambda.yml" {
+  local TMP_DIR
+  TMP_DIR="$(mktemp -d "/tmp/dokku-test-builder-lambda.XXXXXX")"
+  trap "rm -rf '$TMP_DIR'" RETURN
+  echo "---" >"$TMP_DIR/lambda2.yml"
+
+  run /bin/bash -c "dokku builder-lambda:set $TEST_APP lambdayml-path lambda2.yml"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/builder-lambda/core-post-extract $TEST_APP $TMP_DIR HEAD"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "test -f $TMP_DIR/lambda.yml"
+  assert_success
+
+  run /bin/bash -c "test ! -e $TMP_DIR/lambda2.yml"
+  assert_success
+}
+
 inject_lambda_yml() {
   local APP="$1"
   local APP_REPO_DIR="$2"

--- a/tests/unit/builder-nixpacks.bats
+++ b/tests/unit/builder-nixpacks.bats
@@ -131,6 +131,29 @@ teardown() {
   assert_output "['task.py', 'some', 'cron', 'task']"
 }
 
+@test "(builder-nixpacks) core-post-extract renames the configured nixpacks.toml" {
+  local TMP_DIR
+  TMP_DIR="$(mktemp -d "/tmp/dokku-test-builder-nixpacks.XXXXXX")"
+  trap "rm -rf '$TMP_DIR'" RETURN
+  echo "" >"$TMP_DIR/nixpacks.alt.toml"
+
+  run /bin/bash -c "dokku builder-nixpacks:set $TEST_APP nixpackstoml-path nixpacks.alt.toml"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/builder-nixpacks/core-post-extract $TEST_APP $TMP_DIR HEAD"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "test -f $TMP_DIR/nixpacks.toml"
+  assert_success
+
+  run /bin/bash -c "test ! -e $TMP_DIR/nixpacks.alt.toml"
+  assert_success
+}
+
 cron_run_wrapper() {
   local APP="$1"
   local APP_REPO_DIR="$2"

--- a/tests/unit/builder-nixpacks.bats
+++ b/tests/unit/builder-nixpacks.bats
@@ -132,25 +132,22 @@ teardown() {
 }
 
 @test "(builder-nixpacks) core-post-extract renames the configured nixpacks.toml" {
-  local TMP_DIR
-  TMP_DIR="$(mktemp -d "/tmp/dokku-test-builder-nixpacks.XXXXXX")"
-  trap "rm -rf '$TMP_DIR'" RETURN
-  echo "" >"$TMP_DIR/nixpacks.alt.toml"
+  echo "" >"$BATS_TEST_TMPDIR/nixpacks.alt.toml"
 
   run /bin/bash -c "dokku builder-nixpacks:set $TEST_APP nixpackstoml-path nixpacks.alt.toml"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run_plugin_script builder-nixpacks core-post-extract "$TEST_APP" "$TMP_DIR" HEAD
+  run_plugin_script builder-nixpacks core-post-extract "$TEST_APP" "$BATS_TEST_TMPDIR" HEAD
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "test -f $TMP_DIR/nixpacks.toml"
+  run /bin/bash -c "test -f $BATS_TEST_TMPDIR/nixpacks.toml"
   assert_success
 
-  run /bin/bash -c "test ! -e $TMP_DIR/nixpacks.alt.toml"
+  run /bin/bash -c "test ! -e $BATS_TEST_TMPDIR/nixpacks.alt.toml"
   assert_success
 }
 

--- a/tests/unit/builder-nixpacks.bats
+++ b/tests/unit/builder-nixpacks.bats
@@ -142,7 +142,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/builder-nixpacks/core-post-extract $TEST_APP $TMP_DIR HEAD"
+  run_plugin_script builder-nixpacks core-post-extract "$TEST_APP" "$TMP_DIR" HEAD
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/builder-pack.bats
+++ b/tests/unit/builder-pack.bats
@@ -239,7 +239,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/builder-pack/core-post-extract $TEST_APP $TMP_DIR HEAD"
+  run_plugin_script builder-pack core-post-extract "$TEST_APP" "$TMP_DIR" HEAD
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/builder-pack.bats
+++ b/tests/unit/builder-pack.bats
@@ -228,6 +228,29 @@ teardown() {
   assert_output "['task.py', 'test']"
 }
 
+@test "(builder-pack) core-post-extract renames the configured project.toml" {
+  local TMP_DIR
+  TMP_DIR="$(mktemp -d "/tmp/dokku-test-builder-pack.XXXXXX")"
+  trap "rm -rf '$TMP_DIR'" RETURN
+  echo "" >"$TMP_DIR/project2.toml"
+
+  run /bin/bash -c "dokku builder-pack:set $TEST_APP projecttoml-path project2.toml"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/builder-pack/core-post-extract $TEST_APP $TMP_DIR HEAD"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "test -f $TMP_DIR/project.toml"
+  assert_success
+
+  run /bin/bash -c "test ! -e $TMP_DIR/project2.toml"
+  assert_success
+}
+
 cron_run_wrapper() {
   local APP="$1"
   local APP_REPO_DIR="$2"

--- a/tests/unit/builder-pack.bats
+++ b/tests/unit/builder-pack.bats
@@ -229,25 +229,22 @@ teardown() {
 }
 
 @test "(builder-pack) core-post-extract renames the configured project.toml" {
-  local TMP_DIR
-  TMP_DIR="$(mktemp -d "/tmp/dokku-test-builder-pack.XXXXXX")"
-  trap "rm -rf '$TMP_DIR'" RETURN
-  echo "" >"$TMP_DIR/project2.toml"
+  echo "" >"$BATS_TEST_TMPDIR/project2.toml"
 
   run /bin/bash -c "dokku builder-pack:set $TEST_APP projecttoml-path project2.toml"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run_plugin_script builder-pack core-post-extract "$TEST_APP" "$TMP_DIR" HEAD
+  run_plugin_script builder-pack core-post-extract "$TEST_APP" "$BATS_TEST_TMPDIR" HEAD
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "test -f $TMP_DIR/project.toml"
+  run /bin/bash -c "test -f $BATS_TEST_TMPDIR/project.toml"
   assert_success
 
-  run /bin/bash -c "test ! -e $TMP_DIR/project2.toml"
+  run /bin/bash -c "test ! -e $BATS_TEST_TMPDIR/project2.toml"
   assert_success
 }
 

--- a/tests/unit/builder-railpack.bats
+++ b/tests/unit/builder-railpack.bats
@@ -143,25 +143,22 @@ teardown() {
 }
 
 @test "(builder-railpack) core-post-extract renames the configured railpack.json" {
-  local TMP_DIR
-  TMP_DIR="$(mktemp -d "/tmp/dokku-test-builder-railpack.XXXXXX")"
-  trap "rm -rf '$TMP_DIR'" RETURN
-  echo "{}" >"$TMP_DIR/railpack.alt.json"
+  echo "{}" >"$BATS_TEST_TMPDIR/railpack.alt.json"
 
   run /bin/bash -c "dokku builder-railpack:set $TEST_APP railpackjson-path railpack.alt.json"
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run_plugin_script builder-railpack core-post-extract "$TEST_APP" "$TMP_DIR" HEAD
+  run_plugin_script builder-railpack core-post-extract "$TEST_APP" "$BATS_TEST_TMPDIR" HEAD
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "test -f $TMP_DIR/railpack.json"
+  run /bin/bash -c "test -f $BATS_TEST_TMPDIR/railpack.json"
   assert_success
 
-  run /bin/bash -c "test ! -e $TMP_DIR/railpack.alt.json"
+  run /bin/bash -c "test ! -e $BATS_TEST_TMPDIR/railpack.alt.json"
   assert_success
 }
 

--- a/tests/unit/builder-railpack.bats
+++ b/tests/unit/builder-railpack.bats
@@ -153,7 +153,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/builder-railpack/core-post-extract $TEST_APP $TMP_DIR HEAD"
+  run_plugin_script builder-railpack core-post-extract "$TEST_APP" "$TMP_DIR" HEAD
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/builder-railpack.bats
+++ b/tests/unit/builder-railpack.bats
@@ -142,6 +142,29 @@ teardown() {
   assert_output "['task.py', 'some', 'cron', 'task']"
 }
 
+@test "(builder-railpack) core-post-extract renames the configured railpack.json" {
+  local TMP_DIR
+  TMP_DIR="$(mktemp -d "/tmp/dokku-test-builder-railpack.XXXXXX")"
+  trap "rm -rf '$TMP_DIR'" RETURN
+  echo "{}" >"$TMP_DIR/railpack.alt.json"
+
+  run /bin/bash -c "dokku builder-railpack:set $TEST_APP railpackjson-path railpack.alt.json"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/builder-railpack/core-post-extract $TEST_APP $TMP_DIR HEAD"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "test -f $TMP_DIR/railpack.json"
+  assert_success
+
+  run /bin/bash -c "test ! -e $TMP_DIR/railpack.alt.json"
+  assert_success
+}
+
 cron_run_wrapper() {
   local APP="$1"
   local APP_REPO_DIR="$2"

--- a/tests/unit/resource_3.bats
+++ b/tests/unit/resource_3.bats
@@ -23,7 +23,7 @@ teardown() {
   echo "status: $status"
   assert_output "256m"
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT plugn trigger docker-args-process-build $TEST_APP herokuish < /dev/null"
+  run_plugn_trigger docker-args-process-build "$TEST_APP" herokuish
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -39,7 +39,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT plugn trigger docker-args-process-build $TEST_APP dockerfile < /dev/null"
+  run_plugn_trigger docker-args-process-build "$TEST_APP" dockerfile
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -55,13 +55,13 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT plugn trigger docker-args-process-build $TEST_APP pack < /dev/null"
+  run_plugn_trigger docker-args-process-build "$TEST_APP" pack
   echo "output: $output"
   echo "status: $status"
   assert_success
   assert_output_not_contains "--memory"
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT plugn trigger docker-args-process-build $TEST_APP lambda < /dev/null"
+  run_plugn_trigger docker-args-process-build "$TEST_APP" lambda
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -74,7 +74,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT plugn trigger docker-args-process-build $TEST_APP herokuish < /dev/null"
+  run_plugn_trigger docker-args-process-build "$TEST_APP" herokuish
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -87,7 +87,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT plugn trigger docker-args-process-build $TEST_APP herokuish < /dev/null"
+  run_plugn_trigger docker-args-process-build "$TEST_APP" herokuish
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -101,7 +101,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT DOKKU_OMIT_RESOURCE_ARGS=1 plugn trigger docker-args-process-build $TEST_APP herokuish < /dev/null"
+  run_plugn_trigger DOKKU_OMIT_RESOURCE_ARGS=1 docker-args-process-build "$TEST_APP" herokuish
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -231,6 +231,29 @@ destroy_key() {
   rm -f /tmp/testkey* &>/dev/null || true
 }
 
+# Run a plugn trigger with the env vars plugn needs, capturing $output/$status via bats `run`.
+# Optional VAR=VAL pairs before <trigger> are forwarded as extra env vars on the bash command line.
+# Usage: run_plugn_trigger [VAR=VAL ...] <trigger> <args...>
+run_plugn_trigger() {
+  local extra_env=""
+  while [[ "$1" == *=* ]]; do
+    extra_env+=" $1"
+    shift
+  done
+  local TRIGGER="$1"
+  shift
+  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT${extra_env} plugn trigger $TRIGGER $* < /dev/null"
+}
+
+# Run a single plugin's trigger script directly so other plugins' handlers do not fire.
+# Captures $output/$status via bats `run`.
+# Usage: run_plugin_script <plugin_name> <script_name> <args...>
+run_plugin_script() {
+  local PLUGIN_NAME="$1" SCRIPT_NAME="$2"
+  shift 2
+  run /bin/bash -c "PLUGIN_PATH=$PLUGIN_PATH PLUGIN_AVAILABLE_PATH=$PLUGIN_AVAILABLE_PATH PLUGIN_ENABLED_PATH=$PLUGIN_ENABLED_PATH PLUGIN_CORE_AVAILABLE_PATH=$PLUGIN_CORE_AVAILABLE_PATH DOKKU_LIB_ROOT=$DOKKU_LIB_ROOT $PLUGIN_ENABLED_PATH/$PLUGIN_NAME/$SCRIPT_NAME $*"
+}
+
 check_urls() {
   local PATTERN="$1"
   run /bin/bash -c "dokku urls $TEST_APP | grep -E \"${PATTERN}\""


### PR DESCRIPTION
The builder-dockerfile, builder-lambda, builder-nixpacks, builder-pack and builder-railpack `core-post-extract` triggers assigned `$2` to a local `SOURCECODE_WORK_DIR` but called `pushd "$TMP_WORK_DIR"`, which was unset. Bash 5.2 silently accepted `pushd ""`, so the bug stayed dormant. Bash 5.3 (shipped with Ubuntu 26.04) makes it a hard error and `set -e` aborts the trigger, causing every `git push` to fail with `pushd: null directory`.

Closes #8566.