### PR TITLE
Use type prefix for dokku-bot dependency label

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -107,4 +107,4 @@ jobs:
             Bumps `${{ matrix.name }}` from `${{ matrix.version }}` to `${{ steps.latest.outputs.latest }}`.
 
             Release notes: https://github.com/${{ matrix.repo }}/releases/tag/v${{ steps.latest.outputs.latest }}
-          labels: dependencies
+          labels: 'type: dependencies'


### PR DESCRIPTION
Aligns the auto-generated dokku-bot dependency-bump PRs with the rest of the repository's labeling convention. The dependency-updates workflow currently tags its PRs with the bare `dependencies` label, while Dependabot and the issue templates all use namespaced labels such as `type: dependencies`, `type: bug`, and `needs: investigation`. Using `type: dependencies` gives every dependency-bump PR the same label regardless of which bot opened it.