### PR TITLE
Set issue type in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,8 @@
 ---
 name: Bug Report
 description: File a bug report
-labels: ["needs: investigation", "type: bug"]
+labels: ["needs: investigation"]
+type: Bug
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
You can now set the new type directly from the issue template.