### PR TITLE
Count assert_output_contains matches as fixed strings

### DIFF
--- a/tests/unit/init.bats
+++ b/tests/unit/init.bats
@@ -22,7 +22,7 @@ teardown() {
 
   local CIDS=$(get_app_container_ids "$APP")
 
-  run "$DOCKER_BIN" container top "$CIDS"
+  run /bin/bash -c "$DOCKER_BIN container top $CIDS"
   echo "output: $output"
   echo "status: $status"
   assert_output_not_contains "<defunct>"
@@ -38,7 +38,7 @@ teardown() {
 
   local CIDS=$(get_app_container_ids "$APP")
 
-  run "$DOCKER_BIN" container top "$CIDS"
+  run /bin/bash -c "$DOCKER_BIN container top $CIDS"
   echo "output: $output"
   echo "status: $status"
   assert_output_not_contains "<defunct>"
@@ -54,7 +54,7 @@ teardown() {
 
   local CIDS=$(get_app_container_ids "$APP")
 
-  run "$DOCKER_BIN" container top "$CIDS"
+  run /bin/bash -c "$DOCKER_BIN container top $CIDS"
   echo "output: $output"
   echo "status: $status"
   assert_output_not_contains "<defunct>"

--- a/tests/unit/init.bats
+++ b/tests/unit/init.bats
@@ -24,7 +24,8 @@ teardown() {
 
   run "$DOCKER_BIN" container top "$CIDS"
   echo "output: $output"
-  assert_output_contains "<defunct>" "0"
+  echo "status: $status"
+  assert_output_not_contains "<defunct>"
 }
 
 @test "(init) dockerfile no tini" {
@@ -39,7 +40,8 @@ teardown() {
 
   run "$DOCKER_BIN" container top "$CIDS"
   echo "output: $output"
-  assert_output_contains "<defunct>" "0"
+  echo "status: $status"
+  assert_output_not_contains "<defunct>"
 }
 
 @test "(init) dockerfile with tini" {
@@ -54,5 +56,6 @@ teardown() {
 
   run "$DOCKER_BIN" container top "$CIDS"
   echo "output: $output"
-  assert_output_contains "<defunct>" "0"
+  echo "status: $status"
+  assert_output_not_contains "<defunct>"
 }

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -143,11 +143,8 @@ assert_output_contains() {
   local input="$output"
   local expected="$1"
   local count="${2:-1}"
-  local found=0
-  until [ "${input/$expected/}" = "$input" ]; do
-    input="${input/$expected/}"
-    found=$((found + 1))
-  done
+  local found
+  found=$(printf '%s' "$input" | grep -F -o -- "$expected" | wc -l | tr -d ' ')
 
   if [[ "$count" -eq -1 ]]; then
     if [[ "$found" -gt 0 ]]; then

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -144,7 +144,7 @@ assert_output_contains() {
   local expected="$1"
   local count="${2:-1}"
   local found
-  found=$(printf '%s' "$input" | grep -F -o -- "$expected" | wc -l | tr -d ' ')
+  found=$(printf '%s' "$input" | { grep -F -o -- "$expected" || true; } | wc -l | tr -d ' ')
 
   if [[ "$count" -eq -1 ]]; then
     if [[ "$found" -gt 0 ]]; then

--- a/tests/unit/traefik.bats
+++ b/tests/unit/traefik.bats
@@ -468,7 +468,7 @@ teardown() {
   assert_success
   assert_output_contains "dns provider cf_api_email"
   assert_output_contains "dns provider cf_api_key"
-  assert_output_contains "*******"
+  assert_output_contains "*******" 2
   assert_output_not_contains "test@example.com"
   assert_output_not_contains "secret-key"
 

--- a/tests/unit/traefik.bats
+++ b/tests/unit/traefik.bats
@@ -548,7 +548,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains "*******"
+  assert_output_contains "*******" 2
   assert_output_not_contains "test@example.com"
   assert_output_not_contains "secret-key"
 


### PR DESCRIPTION
Replace the bash pattern-substitution loop with grep -F -o piped to wc -l so the helper counts literal substring occurrences instead of treating the expected value as a glob pattern. The old implementation interpreted `[`, `]`, `*`, `?`, and `\` as pattern syntax, which made `assert_output_contains "['task.py', 'test']"` report 17 matches against an output that contained the string exactly once - the inner characters were being matched as a character class. assert_output_not_contains delegates to assert_output_contains and is fixed transitively.