### PR TITLE
Report info-flag should not error when app undeployed

### DIFF
--- a/plugins/builder-dockerfile/internal-functions
+++ b/plugins/builder-dockerfile/internal-functions
@@ -74,14 +74,13 @@ cmd-builder-dockerfile-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/builder-dockerfile/internal-functions
+++ b/plugins/builder-dockerfile/internal-functions
@@ -88,7 +88,6 @@ cmd-builder-dockerfile-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/builder-herokuish/internal-functions
+++ b/plugins/builder-herokuish/internal-functions
@@ -74,14 +74,13 @@ cmd-builder-herokuish-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/builder-herokuish/internal-functions
+++ b/plugins/builder-herokuish/internal-functions
@@ -88,7 +88,6 @@ cmd-builder-herokuish-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/builder-lambda/internal-functions
+++ b/plugins/builder-lambda/internal-functions
@@ -74,14 +74,13 @@ cmd-builder-lambda-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/builder-lambda/internal-functions
+++ b/plugins/builder-lambda/internal-functions
@@ -88,7 +88,6 @@ cmd-builder-lambda-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/builder-nixpacks/internal-functions
+++ b/plugins/builder-nixpacks/internal-functions
@@ -88,7 +88,6 @@ cmd-builder-nixpacks-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/builder-nixpacks/internal-functions
+++ b/plugins/builder-nixpacks/internal-functions
@@ -74,14 +74,13 @@ cmd-builder-nixpacks-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/builder-pack/internal-functions
+++ b/plugins/builder-pack/internal-functions
@@ -74,14 +74,13 @@ cmd-builder-pack-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/builder-pack/internal-functions
+++ b/plugins/builder-pack/internal-functions
@@ -88,7 +88,6 @@ cmd-builder-pack-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/builder-railpack/internal-functions
+++ b/plugins/builder-railpack/internal-functions
@@ -74,14 +74,13 @@ cmd-builder-railpack-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/builder-railpack/internal-functions
+++ b/plugins/builder-railpack/internal-functions
@@ -88,7 +88,6 @@ cmd-builder-railpack-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/caddy-vhosts/command-functions
+++ b/plugins/caddy-vhosts/command-functions
@@ -107,14 +107,13 @@ cmd-caddy-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/certs/internal-functions
+++ b/plugins/certs/internal-functions
@@ -89,7 +89,6 @@ cmd-certs-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/certs/internal-functions
+++ b/plugins/certs/internal-functions
@@ -75,14 +75,13 @@ cmd-certs-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/checks/internal-functions
+++ b/plugins/checks/internal-functions
@@ -91,7 +91,6 @@ cmd-checks-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/checks/internal-functions
+++ b/plugins/checks/internal-functions
@@ -77,14 +77,13 @@ cmd-checks-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/domains/internal-functions
+++ b/plugins/domains/internal-functions
@@ -77,14 +77,13 @@ cmd-domains-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -421,7 +421,6 @@ cmd-git-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -407,14 +407,13 @@ cmd-git-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/haproxy-vhosts/command-functions
+++ b/plugins/haproxy-vhosts/command-functions
@@ -97,14 +97,13 @@ cmd-haproxy-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/nginx-vhosts/command-functions
+++ b/plugins/nginx-vhosts/command-functions
@@ -164,14 +164,13 @@ cmd-nginx-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/nginx-vhosts/command-functions
+++ b/plugins/nginx-vhosts/command-functions
@@ -178,7 +178,6 @@ cmd-nginx-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/openresty-vhosts/command-functions
+++ b/plugins/openresty-vhosts/command-functions
@@ -134,14 +134,13 @@ cmd-openresty-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -83,7 +83,6 @@ cmd-scheduler-docker-local-report-single() {
       fi
     done
     [[ "$match" == "true" ]] || dokku_log_fail "Invalid flag passed, valid flags:${valid_flags}"
-    [[ "$value_exists" == "true" ]] || dokku_log_fail "not deployed"
   fi
 }
 

--- a/plugins/scheduler-docker-local/internal-functions
+++ b/plugins/scheduler-docker-local/internal-functions
@@ -69,14 +69,13 @@ cmd-scheduler-docker-local-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/plugins/traefik-vhosts/command-functions
+++ b/plugins/traefik-vhosts/command-functions
@@ -124,14 +124,13 @@ cmd-traefik-report-single() {
     done
   else
     local match=false
-    local value_exists=false
     for flag in "${flag_map[@]}"; do
       valid_flags="${valid_flags} $(echo "$flag" | cut -d':' -f1)"
       if [[ "$flag" == "${INFO_FLAG}:"* ]]; then
         value=${flag#*: }
         size="${#value}"
         if [[ "$size" -ne 0 ]]; then
-          echo "$value" && match=true && value_exists=true
+          echo "$value" && match=true
         else
           match=true
         fi

--- a/tests/unit/builder-dockerfile.bats
+++ b/tests/unit/builder-dockerfile.bats
@@ -12,6 +12,30 @@ teardown() {
   destroy_app
 }
 
+@test "(builder-dockerfile:report) info-flag works before deploy" {
+  run /bin/bash -c "dokku builder-dockerfile:report $TEST_APP --builder-dockerfile-dockerfile-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-dockerfile:set $TEST_APP dockerfile-path second.Dockerfile"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-dockerfile:report $TEST_APP --builder-dockerfile-dockerfile-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "second.Dockerfile"
+
+  run /bin/bash -c "dokku builder-dockerfile:report $TEST_APP --builder-dockerfile-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+}
+
 @test "(builder-dockerfile:report) --global --format json" {
   run /bin/bash -c "dokku builder-dockerfile:report --global --format json | jq -e ."
   echo "output: $output"

--- a/tests/unit/builder-herokuish.bats
+++ b/tests/unit/builder-herokuish.bats
@@ -10,6 +10,30 @@ teardown() {
   destroy_app
 }
 
+@test "(builder-herokuish:report) info-flag works before deploy" {
+  run /bin/bash -c "dokku builder-herokuish:report $TEST_APP --builder-herokuish-allowed"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-herokuish:set $TEST_APP allowed false"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-herokuish:report $TEST_APP --builder-herokuish-allowed"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku builder-herokuish:report $TEST_APP --builder-herokuish-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+}
+
 @test "(builder-herokuish:report) --global --builder-herokuish-global-allowed" {
   run /bin/bash -c "dokku builder-herokuish:set --global allowed false"
   echo "output: $output"

--- a/tests/unit/builder-lambda.bats
+++ b/tests/unit/builder-lambda.bats
@@ -10,6 +10,30 @@ teardown() {
   destroy_app
 }
 
+@test "(builder-lambda:report) info-flag works before deploy" {
+  run /bin/bash -c "dokku builder-lambda:report $TEST_APP --builder-lambda-lambdayml-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-lambda:set $TEST_APP lambdayml-path lambda.alt.yml"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-lambda:report $TEST_APP --builder-lambda-lambdayml-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "lambda.alt.yml"
+
+  run /bin/bash -c "dokku builder-lambda:report $TEST_APP --builder-lambda-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+}
+
 @test "(builder-lambda:report) --global --builder-lambda-global-lambdayml-path" {
   run /bin/bash -c "dokku builder-lambda:set --global lambdayml-path lambda.alt.yml"
   echo "output: $output"

--- a/tests/unit/builder-nixpacks.bats
+++ b/tests/unit/builder-nixpacks.bats
@@ -14,6 +14,30 @@ teardown() {
   destroy_app
 }
 
+@test "(builder-nixpacks:report) info-flag works before deploy" {
+  run /bin/bash -c "dokku builder-nixpacks:report $TEST_APP --builder-nixpacks-nixpackstoml-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-nixpacks:set $TEST_APP nixpackstoml-path nixpacks.alt.toml"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-nixpacks:report $TEST_APP --builder-nixpacks-nixpackstoml-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "nixpacks.alt.toml"
+
+  run /bin/bash -c "dokku builder-nixpacks:report $TEST_APP --builder-nixpacks-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+}
+
 @test "(builder-nixpacks:report) --global --builder-nixpacks-global-nixpackstoml-path" {
   run /bin/bash -c "dokku builder-nixpacks:set --global nixpackstoml-path nixpacks.alt.toml"
   echo "output: $output"

--- a/tests/unit/builder-pack.bats
+++ b/tests/unit/builder-pack.bats
@@ -16,6 +16,30 @@ teardown() {
   global_teardown
 }
 
+@test "(builder-pack:report) info-flag works before deploy" {
+  run /bin/bash -c "dokku builder-pack:report $TEST_APP --builder-pack-projecttoml-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-pack:set $TEST_APP projecttoml-path project.alt.toml"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-pack:report $TEST_APP --builder-pack-projecttoml-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "project.alt.toml"
+
+  run /bin/bash -c "dokku builder-pack:report $TEST_APP --builder-pack-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+}
+
 @test "(builder-pack:report) --global --builder-pack-global-projecttoml-path" {
   run /bin/bash -c "dokku builder-pack:set --global projecttoml-path project.alt.toml"
   echo "output: $output"

--- a/tests/unit/builder-railpack.bats
+++ b/tests/unit/builder-railpack.bats
@@ -25,6 +25,30 @@ teardown() {
   global_teardown
 }
 
+@test "(builder-railpack:report) info-flag works before deploy" {
+  run /bin/bash -c "dokku builder-railpack:report $TEST_APP --builder-railpack-railpackjson-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-railpack:set $TEST_APP railpackjson-path railpack.alt.json"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku builder-railpack:report $TEST_APP --builder-railpack-railpackjson-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "railpack.alt.json"
+
+  run /bin/bash -c "dokku builder-railpack:report $TEST_APP --builder-railpack-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+}
+
 @test "(builder-railpack:report) --global --builder-railpack-global-railpackjson-path" {
   run /bin/bash -c "dokku builder-railpack:set --global railpackjson-path railpack.alt.json"
   echo "output: $output"

--- a/tests/unit/certs.bats
+++ b/tests/unit/certs.bats
@@ -41,6 +41,25 @@ teardown() {
   assert_output "$help_output"
 }
 
+@test "(certs:report) info-flag works before deploy" {
+  run /bin/bash -c "dokku certs:report $TEST_APP --ssl-hostnames"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku certs:report $TEST_APP --ssl-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "/$TEST_APP/tls"
+
+  run /bin/bash -c "dokku certs:report $TEST_APP --ssl-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+}
+
 @test "(certs:report) --global --format json" {
   run /bin/bash -c "dokku certs:report --global --format json | jq -e ."
   echo "output: $output"

--- a/tests/unit/checks.bats
+++ b/tests/unit/checks.bats
@@ -16,6 +16,30 @@ teardown() {
   global_teardown
 }
 
+@test "(checks:report) info-flag works before deploy" {
+  run /bin/bash -c "dokku checks:report $TEST_APP --checks-wait-to-retire"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku checks:set $TEST_APP wait-to-retire 30"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku checks:report $TEST_APP --checks-wait-to-retire"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "30"
+
+  run /bin/bash -c "dokku checks:report $TEST_APP --checks-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+}
+
 @test "(checks:report) --global --format json" {
   run /bin/bash -c "dokku checks:set --global wait-to-retire 90"
   echo "output: $output"

--- a/tests/unit/git_1.bats
+++ b/tests/unit/git_1.bats
@@ -12,6 +12,36 @@ teardown() {
   global_teardown
 }
 
+@test "(git:report) info-flag works before deploy" {
+  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "master"
+
+  run /bin/bash -c "dokku git:set $TEST_APP deploy-branch main"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "main"
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-sha"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+}
+
 @test "(git) git:help" {
   run /bin/bash -c "dokku git"
   echo "output: $output"

--- a/tests/unit/nginx-vhosts_1.bats
+++ b/tests/unit/nginx-vhosts_1.bats
@@ -28,6 +28,35 @@ teardown() {
   assert_output "$help_output"
 }
 
+@test "(nginx:report) info-flag works before deploy" {
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:report $TEST_APP --nginx-bind-address-ipv4"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:set $TEST_APP bind-address-ipv4 127.0.0.1"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku nginx:report $TEST_APP --nginx-bind-address-ipv4"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "127.0.0.1"
+
+  run /bin/bash -c "dokku nginx:report $TEST_APP --nginx-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+}
+
 @test "(nginx:report) --format json" {
   run create_app
   echo "output: $output"

--- a/tests/unit/scheduler-docker-local.bats
+++ b/tests/unit/scheduler-docker-local.bats
@@ -18,6 +18,32 @@ teardown() {
   assert_output "true"
 }
 
+@test "(scheduler-docker-local:report) info-flag works before deploy" {
+  run create_app
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-docker-local:report $TEST_APP --scheduler-docker-local-parallel-schedule-count"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-docker-local:report $TEST_APP --scheduler-docker-local-init-process"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku scheduler-docker-local:report $TEST_APP --scheduler-docker-local-invalid-flag"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+
+  destroy_app
+}
+
 @test "(scheduler-docker-local) scheduler-docker-local:help" {
   run /bin/bash -c "dokku scheduler-docker-local"
   echo "output: $output"


### PR DESCRIPTION
Several plugin `:report` subcommands erroneously failed with `not deployed` when an info-flag matched a property whose value was empty. Empty values are legitimate for configuration properties pre-deploy, and the `--format json` path already returns them without error - so the info-flag form was inconsistent with the JSON form.

The fix removes the `value_exists` check across nginx, checks, git, certs, scheduler-docker-local, and the builder-* plugins so the info-flag form behaves the same as JSON.

Closes #8596.