### PR TITLE
Rename app-json:report flags to match property

### DIFF
--- a/plugins/app-json/report.go
+++ b/plugins/app-json/report.go
@@ -15,13 +15,13 @@ func ReportSingleApp(appName string, format string, infoFlag string) error {
 	var flags map[string]common.ReportFunc
 	if appName == "--global" {
 		flags = map[string]common.ReportFunc{
-			"--app-json-global-selected": reportGlobalAppjsonpath,
+			"--app-json-global-appjson-path": reportGlobalAppjsonpath,
 		}
 	} else {
 		flags = map[string]common.ReportFunc{
-			"--app-json-computed-selected": reportComputedAppjsonpath,
-			"--app-json-global-selected":   reportGlobalAppjsonpath,
-			"--app-json-selected":          reportAppjsonpath,
+			"--app-json-computed-appjson-path": reportComputedAppjsonpath,
+			"--app-json-global-appjson-path":   reportGlobalAppjsonpath,
+			"--app-json-appjson-path":          reportAppjsonpath,
 		}
 	}
 

--- a/tests/unit/app-json.bats
+++ b/tests/unit/app-json.bats
@@ -256,6 +256,63 @@ teardown() {
   assert_output_contains "touch /app/predeploy3.test"
 }
 
+@test "(app-json:report) appjson-path round-trip" {
+  run /bin/bash -c "dokku app-json:set $TEST_APP appjson-path app2.json"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku app-json:report $TEST_APP --app-json-appjson-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "app2.json"
+
+  run /bin/bash -c "dokku app-json:report $TEST_APP --app-json-computed-appjson-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "app2.json"
+
+  run /bin/bash -c "dokku app-json:report $TEST_APP --app-json-global-appjson-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "app.json"
+
+  run /bin/bash -c "dokku app-json:report $TEST_APP --format json"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains '"app-json-appjson-path":"app2.json"'
+  assert_output_contains '"app-json-computed-appjson-path":"app2.json"'
+  assert_output_contains '"app-json-global-appjson-path":"app.json"'
+  assert_output_contains "app-json-selected" 0
+
+  run /bin/bash -c "dokku app-json:report $TEST_APP --app-json-selected"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid flag passed"
+
+  run /bin/bash -c "dokku app-json:set $TEST_APP appjson-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku app-json:report $TEST_APP --app-json-appjson-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku app-json:report $TEST_APP --app-json-computed-appjson-path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "app.json"
+}
+
 copy_app_json_to_sub_app() {
   local APP="$1"
   local APP_REPO_DIR="$2"


### PR DESCRIPTION
The property name set via `app-json:set` is `appjson-path`, but the matching read-back flags on `app-json:report` were named `--app-json-selected`, `--app-json-global-selected`, and `--app-json-computed-selected`. The mismatch meant `dokku app-json:report <app> --app-json-appjson-path` (the form already documented in deployment-tasks.md) was rejected as an invalid flag, and the `--format json` output advertised keys that did not correspond to any settable property. The flags and JSON keys are renamed to `--app-json-appjson-path`, `--app-json-global-appjson-path`, and `--app-json-computed-appjson-path` so that the property name round-trips through set and report.

Fixes #8598.