### PR TITLE
Reject per-app sets for global-only proxy properties

### DIFF
--- a/plugins/caddy-vhosts/subcommands/set
+++ b/plugins/caddy-vhosts/subcommands/set
@@ -11,6 +11,7 @@ cmd-caddy-set() {
   declare APP="$1" KEY="$2" VALUE="$3"
   local VALID_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval" "tls-internal")
   local GLOBAL_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval")
+  local GLOBAL_ONLY_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval")
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
@@ -23,6 +24,10 @@ cmd-caddy-set() {
       dokku_log_fail "The key '$KEY' cannot be set globally"
     fi
     verify_app_name "$APP"
+  fi
+
+  if fn-in-array "$KEY" "${GLOBAL_ONLY_KEYS[@]}" && [[ "$APP" != "--global" ]]; then
+    dokku_log_fail "The key '$KEY' can only be set globally"
   fi
 
   if [[ -n "$VALUE" ]]; then

--- a/plugins/haproxy-vhosts/subcommands/set
+++ b/plugins/haproxy-vhosts/subcommands/set
@@ -11,7 +11,7 @@ cmd-haproxy-set() {
   declare APP="$1" KEY="$2" VALUE="$3"
   local VALID_KEYS=("image" "log-level" "letsencrypt-email" "letsencrypt-server" "refresh-conf")
   local GLOBAL_KEYS=("image" "log-level" "letsencrypt-email" "letsencrypt-server" "refresh-conf")
-  local GLOBAL_ONLY_KEYS=("refresh-conf")
+  local GLOBAL_ONLY_KEYS=("image" "log-level" "letsencrypt-email" "letsencrypt-server" "refresh-conf")
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 

--- a/plugins/traefik-vhosts/subcommands/set
+++ b/plugins/traefik-vhosts/subcommands/set
@@ -11,7 +11,7 @@ cmd-traefik-set() {
   declare APP="$1" KEY="$2" VALUE="$3"
   local VALID_KEYS=("api-enabled" "api-entry-point" "api-entry-point-address" "api-vhost" "challenge-mode" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "dns-provider" "image" "letsencrypt-email" "letsencrypt-server" "log-level" "http-entry-point" "https-entry-point")
   local GLOBAL_KEYS=("api-enabled" "api-entry-point" "api-entry-point-address" "api-vhost" "challenge-mode" "dashboard-enabled" "basic-auth-username" "basic-auth-password" "dns-provider" "image" "letsencrypt-email" "letsencrypt-server" "log-level" "http-entry-point" "https-entry-point")
-  local GLOBAL_ONLY_KEYS=("api-entry-point" "api-entry-point-address" "challenge-mode" "dns-provider")
+  local GLOBAL_ONLY_KEYS=("api-enabled" "api-entry-point" "api-entry-point-address" "api-vhost" "basic-auth-username" "basic-auth-password" "challenge-mode" "dashboard-enabled" "dns-provider" "image" "letsencrypt-email" "letsencrypt-server" "log-level" "http-entry-point" "https-entry-point")
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 

--- a/tests/unit/caddy.bats
+++ b/tests/unit/caddy.bats
@@ -36,6 +36,33 @@ teardown() {
   assert_success
 }
 
+@test "(caddy) global-only keys" {
+  for key in image letsencrypt-email letsencrypt-server log-level polling-interval; do
+    run /bin/bash -c "dokku caddy:set $TEST_APP $key somevalue"
+    echo "key: $key"
+    echo "output: $output"
+    echo "status: $status"
+    assert_failure
+    assert_output_contains "can only be set globally"
+  done
+
+  run /bin/bash -c "dokku caddy:set $TEST_APP tls-internal true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku caddy:set $TEST_APP tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
 @test "(caddy) caddy:help" {
   run /bin/bash -c "dokku caddy"
   echo "output: $output"

--- a/tests/unit/haproxy.bats
+++ b/tests/unit/haproxy.bats
@@ -34,6 +34,17 @@ teardown() {
   assert_output "$help_output"
 }
 
+@test "(haproxy) global-only keys" {
+  for key in image log-level letsencrypt-email letsencrypt-server refresh-conf; do
+    run /bin/bash -c "dokku haproxy:set $TEST_APP $key somevalue"
+    echo "key: $key"
+    echo "output: $output"
+    echo "status: $status"
+    assert_failure
+    assert_output_contains "can only be set globally"
+  done
+}
+
 @test "(haproxy) refresh-conf" {
   run /bin/bash -c "dokku haproxy:set $TEST_APP refresh-conf 2"
   echo "output: $output"

--- a/tests/unit/traefik.bats
+++ b/tests/unit/traefik.bats
@@ -41,6 +41,23 @@ teardown() {
   assert_success
 }
 
+@test "(traefik) global-only keys" {
+  for key in api-enabled api-entry-point api-entry-point-address api-vhost basic-auth-username basic-auth-password challenge-mode dashboard-enabled dns-provider image letsencrypt-email letsencrypt-server log-level http-entry-point https-entry-point; do
+    run /bin/bash -c "dokku traefik:set $TEST_APP $key somevalue"
+    echo "key: $key"
+    echo "output: $output"
+    echo "status: $status"
+    assert_failure
+    assert_output_contains "can only be set globally"
+  done
+
+  run /bin/bash -c "dokku traefik:set $TEST_APP dns-provider-CF_API_TOKEN somevalue"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "can only be set globally"
+}
+
 @test "(traefik) traefik:help" {
   run /bin/bash -c "dokku traefik"
   echo "output: $output"


### PR DESCRIPTION
`caddy:set`, `haproxy:set`, and `traefik:set` previously accepted per-app writes for properties that only have a single host-wide reader, so `:set myapp image foo:bar` printed a success message while `:report myapp` kept showing the global default. The per-app form is now rejected with `The key '<key>' can only be set globally`, matching the existing rejection used for haproxy `refresh-conf` and traefik `challenge-mode`. Caddy `tls-internal` remains the only legitimate per-app property in this family.

Closes #8597.