### PR TITLE
Expose raw deploy-branch and keep-git-dir in git:report

### DIFF
--- a/docs/deployment/methods/git.md
+++ b/docs/deployment/methods/git.md
@@ -281,14 +281,20 @@ dokku git:report
 
 ```
 =====> node-js-app git information
-       Git deploy branch:             master
+       Git computed deploy branch:    master
+       Git computed keep git dir:     false
+       Git deploy branch:
+       Git global archive max files:  10000
+       Git global archive max size:   1073741824
        Git global deploy branch:      master
-       Git keep git dir:              false
+       Git keep git dir:
        Git rev env var:               GIT_REV
        Git sha:                       a1b2c3d
        Git source image:
        Git last updated at:           1700000000
 ```
+
+The `deploy-branch` and `keep-git-dir` keys hold the raw per-app value and are empty when nothing has been set on the app. The `computed-deploy-branch` and `computed-keep-git-dir` keys hold the effective value used at deploy time, falling back to the corresponding global value (where one exists) and then to the built-in default.
 
 You can run the command for a specific app also.
 

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -376,11 +376,13 @@ cmd-git-report-single() {
   else
     verify_app_name "$APP"
     flag_map=(
-      "--git-deploy-branch: $(fn-plugin-property-get "git" "$APP" "deploy-branch" "master")"
+      "--git-computed-deploy-branch: $(fn-git-deploy-branch "$APP")"
+      "--git-computed-keep-git-dir: $(fn-git-keep-git-dir "$APP")"
+      "--git-deploy-branch: $(fn-plugin-property-get "git" "$APP" "deploy-branch" "")"
       "--git-global-archive-max-files: $(fn-plugin-property-get "git" "--global" "archive-max-files" "10000")"
       "--git-global-archive-max-size: $(fn-plugin-property-get "git" "--global" "archive-max-size" "1073741824")"
       "--git-global-deploy-branch: $(fn-plugin-property-get "git" "--global" "deploy-branch" "master")"
-      "--git-keep-git-dir: $(fn-plugin-property-get "git" "$APP" "keep-git-dir" "false")"
+      "--git-keep-git-dir: $(fn-plugin-property-get "git" "$APP" "keep-git-dir" "")"
       "--git-rev-env-var: $(fn-plugin-property-get "git" "$APP" "rev-env-var" "GIT_REV")"
       "--git-sha: $(fn-git-cmd "$APP_ROOT" rev-parse HEAD 2>/dev/null || false)"
       "--git-source-image: $(fn-git-source-image "$APP")"
@@ -607,9 +609,22 @@ fn-git-deploy-branch() {
   fi
 }
 
+fn-git-keep-git-dir() {
+  declare desc="retrieve the keep-git-dir value for a given application"
+  local APP="$1"
+  local DEFAULT_KEEP_GIT_DIR="${2-false}"
+
+  local DOKKU_KEEP_GIT_DIR="$(fn-plugin-property-get "git" "$APP" "keep-git-dir" "")"
+  if [[ -n "$DOKKU_KEEP_GIT_DIR" ]]; then
+    echo "$DOKKU_KEEP_GIT_DIR"
+  else
+    echo "$DEFAULT_KEEP_GIT_DIR"
+  fi
+}
+
 fn-git-setup-build-dir() {
   declare APP="$1" GIT_WORKDIR="$2" REV="$3"
-  local DOKKU_KEEP_GIT_DIR="$(fn-plugin-property-get "git" "$APP" "keep-git-dir" "")"
+  local DOKKU_KEEP_GIT_DIR="$(fn-git-keep-git-dir "$APP")"
 
   if [[ "$DOKKU_KEEP_GIT_DIR" == "true" ]]; then
     fn-git-setup-build-dir-new "$APP" "$GIT_WORKDIR" "$REV"
@@ -656,7 +671,7 @@ fn-git-setup-build-dir-worktree() {
 
 fn-git-setup-build-dir-submodules() {
   declare APP="$1" GIT_WORKDIR="$2"
-  local DOKKU_KEEP_GIT_DIR="$(fn-plugin-property-get "git" "$APP" "keep-git-dir" "")"
+  local DOKKU_KEEP_GIT_DIR="$(fn-git-keep-git-dir "$APP")"
 
   # unset the git quarantine path to allow us to use 2.13.0+
   # See this issue for more information: https://github.com/dokku/dokku/issues/2796

--- a/tests/unit/git_1.bats
+++ b/tests/unit/git_1.bats
@@ -17,6 +17,12 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
   assert_output "master"
 
   run /bin/bash -c "dokku git:set $TEST_APP deploy-branch main"
@@ -30,6 +36,29 @@ teardown() {
   assert_success
   assert_output "main"
 
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "main"
+
+  run /bin/bash -c "dokku git:set $TEST_APP deploy-branch"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "master"
+
   run /bin/bash -c "dokku git:report $TEST_APP --git-sha"
   echo "output: $output"
   echo "status: $status"
@@ -40,6 +69,80 @@ teardown() {
   echo "status: $status"
   assert_failure
   assert_output_contains "Invalid flag passed"
+}
+
+@test "(git:report) keep-git-dir raw vs computed" {
+  run /bin/bash -c "dokku git:report $TEST_APP --git-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku git:set $TEST_APP keep-git-dir true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku git:set $TEST_APP keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+}
+
+@test "(git:report) raw and computed keys in --format json" {
+  run /bin/bash -c "dokku git:report $TEST_APP --format json | jq -r '.\"deploy-branch\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku git:report $TEST_APP --format json | jq -r '.\"computed-deploy-branch\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "master"
+
+  run /bin/bash -c "dokku git:report $TEST_APP --format json | jq -r '.\"keep-git-dir\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku git:report $TEST_APP --format json | jq -r '.\"computed-keep-git-dir\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
 }
 
 @test "(git) git:help" {

--- a/tests/unit/git_3.bats
+++ b/tests/unit/git_3.bats
@@ -770,7 +770,7 @@ teardown() {
 }
 
 @test "(git:sync) --skip-deploy-branch" {
-  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -798,7 +798,7 @@ teardown() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -810,7 +810,7 @@ teardown() {
   assert_success
   assert_output_contains "skipping deploy-branch setting"
 
-  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -818,7 +818,7 @@ teardown() {
 }
 
 @test "(git:sync) --build --skip-deploy-branch" {
-  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -831,7 +831,7 @@ teardown() {
   assert_output_contains "skipping deploy-branch setting"
   assert_output_contains "Application deployed"
 
-  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -839,7 +839,7 @@ teardown() {
 }
 
 @test "(git:sync) --build-if-changes --skip-deploy-branch" {
-  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -852,7 +852,7 @@ teardown() {
   assert_output_contains "skipping deploy-branch setting"
   assert_output_contains "Application deployed"
 
-  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -864,7 +864,7 @@ teardown() {
   assert_success
   assert_output_contains "Skipping build as no changes were detected"
 
-  run /bin/bash -c "dokku git:report $TEST_APP --git-deploy-branch"
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-deploy-branch"
   echo "output: $output"
   echo "status: $status"
   assert_success


### PR DESCRIPTION
The bare `deploy-branch` and `keep-git-dir` keys in `git:report` returned the computed (effective) value rather than the raw per-app value, with no separate `computed-*` key to distinguish "set per-app" from "falling back to global or default". This left external tooling unable to detect a per-app unset without out-of-band state. The bare keys now hold the raw per-app value (empty when unset) and new `computed-deploy-branch` and `computed-keep-git-dir` keys hold the effective value, matching the convention used by `nginx-vhosts`, `network`, and `builder`.

Closes #8610.