### PR TITLE
Reject per-app sets for openresty global-only properties

### DIFF
--- a/plugins/openresty-vhosts/subcommands/set
+++ b/plugins/openresty-vhosts/subcommands/set
@@ -11,6 +11,7 @@ cmd-openresty-set() {
   declare APP="$1" KEY="$2" VALUE="$3"
   local VALID_KEYS=("access-log-format" "access-log-path" "allowed-letsencrypt-domains-func-base64" "bind-address-ipv4" "bind-address-ipv6" "client-body-timeout" "client-header-timeout" "client-max-body-size" "error-log-path" "hsts" "hsts-include-subdomains" "hsts-preload" "hsts-max-age" "image" "keepalive-timeout" "log-level" "letsencrypt-email" "letsencrypt-server" "lingering-timeout" "proxy-buffer-size" "proxy-buffering" "proxy-buffers" "proxy-busy-buffers-size" "proxy-connect-timeout" "proxy-read-timeout" "send-timeout" "proxy-send-timeout" "underscore-in-headers" "x-forwarded-for-value" "x-forwarded-port-value" "x-forwarded-proto-value" "x-forwarded-ssl")
   local GLOBAL_KEYS=("allowed-letsencrypt-domains-func-base64" "image" "log-level" "letsencrypt-email" "letsencrypt-server")
+  local GLOBAL_ONLY_KEYS=("allowed-letsencrypt-domains-func-base64" "image" "log-level" "letsencrypt-email" "letsencrypt-server")
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"
 
@@ -23,6 +24,10 @@ cmd-openresty-set() {
       dokku_log_fail "The key '$KEY' cannot be set globally"
     fi
     verify_app_name "$APP"
+  fi
+
+  if fn-in-array "$KEY" "${GLOBAL_ONLY_KEYS[@]}" && [[ "$APP" != "--global" ]]; then
+    dokku_log_fail "The key '$KEY' can only be set globally"
   fi
 
   if [[ -n "$VALUE" ]]; then

--- a/tests/unit/openresty.bats
+++ b/tests/unit/openresty.bats
@@ -26,6 +26,33 @@ teardown() {
   assert_output "https://acme-staging-v02.api.letsencrypt.org/directory"
 }
 
+@test "(openresty) global-only keys" {
+  for key in allowed-letsencrypt-domains-func-base64 image log-level letsencrypt-email letsencrypt-server; do
+    run /bin/bash -c "dokku openresty:set $TEST_APP $key somevalue"
+    echo "key: $key"
+    echo "output: $output"
+    echo "status: $status"
+    assert_failure
+    assert_output_contains "can only be set globally"
+  done
+
+  run /bin/bash -c "dokku openresty:set $TEST_APP bind-address-ipv4 127.0.0.1"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku openresty:report $TEST_APP --openresty-bind-address-ipv4"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "127.0.0.1"
+
+  run /bin/bash -c "dokku openresty:set $TEST_APP bind-address-ipv4"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
 @test "(openresty) openresty:help" {
   run /bin/bash -c "dokku openresty"
   echo "output: $output"


### PR DESCRIPTION
`openresty:set <app>` previously accepted per-app writes for properties whose readers only consult the global store, so `:set myapp image foo` printed a success message while `:report myapp` kept showing the global default. The per-app form is now rejected with `The key '<key>' can only be set globally`, matching the behavior introduced for `caddy`, `haproxy`, and `traefik` in #8602.

Closes #8612.