### PR TITLE
Isolate scheduler-k3s registry tags per bats file

### DIFF
--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -706,7 +706,10 @@ install_k3s() {
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "dokku registry:set --global image-repo-template '$DOCKERHUB_USERNAME/{{ .AppName }}'"
+  local test_basename
+  test_basename="$(basename "$BATS_TEST_FILENAME" .bats)"
+
+  run /bin/bash -c "dokku registry:set --global image-repo-template '$DOCKERHUB_USERNAME/$test_basename-{{ .AppName }}'"
   echo "output: $output"
   echo "status: $status"
   assert_success


### PR DESCRIPTION
Parallel `unit.scheduler-k3s-*` matrix jobs all pushed to the same `savant/rdmtestapp:1` tag on Docker Hub, so a herokuish run pod could pull a CNB or dockerfile image that another job had just overwritten and fail with `exec: "/exec": stat /exec: no such file or directory`. The image-repo-template now embeds the bats file basename so each job owns its own tag namespace.