### PR TITLE
Split caddy report tls-internal into raw, computed, and global

### DIFF
--- a/docs/networking/proxies/caddy.md
+++ b/docs/networking/proxies/caddy.md
@@ -6,12 +6,12 @@
 Dokku provides integration with the [Caddy](https://caddyserver.com/) proxy service by utilizing the Docker label-based integration implemented by [Caddy Docker Proxy](https://github.com/lucaslorentz/caddy-docker-proxy).
 
 ```
-caddy:report [<app>] [<flag>]            # Displays a caddy report for one or more apps
-caddy:logs [--num num] [--tail]          # Display caddy log output
-caddy:set <app> <property> (<value>)     # Set or clear an caddy property for an app
-caddy:show-config <app>                  # Display caddy compose config
-caddy:start                              # Starts the caddy server
-caddy:stop                               # Stops the caddy server
+caddy:report [<app>] [<flag>]                            # Displays a caddy report for one or more apps
+caddy:logs [--num num] [--tail]                          # Display caddy log output
+caddy:set [<app>|--global] <property> (<value>)          # Set or clear an caddy property for an app or globally
+caddy:show-config <app>                                  # Display caddy compose config
+caddy:start                                              # Starts the caddy server
+caddy:stop                                               # Stops the caddy server
 ```
 
 ## Requirements
@@ -191,10 +191,23 @@ After enabling, the Caddy container will need to be restarted and apps will need
 
 ### Using Caddy's Internal TLS server
 
-To switch to Caddy's internal TLS server for certificate provisioning, set the `tls-internal` property. This can only be set on a per-app basis.
+To switch to Caddy's internal TLS server for certificate provisioning, set the `tls-internal` property.
 
 ```shell
 dokku caddy:set node-js-app tls-internal true
+```
+
+The default value may also be configured globally with the `--global` flag. Per-app values take precedence over the global value when set.
+
+```shell
+dokku caddy:set --global tls-internal true
+```
+
+Both the per-app and the global value may be unset by setting a blank value.
+
+```shell
+dokku caddy:set node-js-app tls-internal
+dokku caddy:set --global tls-internal
 ```
 
 ## Displaying Caddy reports for an app
@@ -207,27 +220,35 @@ dokku caddy:report
 
 ```
 =====> node-js-app caddy information
+       Caddy computed tls internal:   false
+       Caddy global tls internal:     false
        Caddy image:                   lucaslorentz/caddy-docker-proxy:2.7
        Caddy letsencrypt email:
        Caddy letsencrypt server:
        Caddy log level:               ERROR
        Caddy polling interval:        5s
-       Caddy tls internal:            false
+       Caddy tls internal:
 =====> python-app caddy information
+       Caddy computed tls internal:   false
+       Caddy global tls internal:     false
        Caddy image:                   lucaslorentz/caddy-docker-proxy:2.7
        Caddy letsencrypt email:
        Caddy letsencrypt server:
        Caddy log level:               ERROR
        Caddy polling interval:        5s
-       Caddy tls internal:            false
+       Caddy tls internal:
 =====> ruby-app caddy information
+       Caddy computed tls internal:   false
+       Caddy global tls internal:     false
        Caddy image:                   lucaslorentz/caddy-docker-proxy:2.7
        Caddy letsencrypt email:
        Caddy letsencrypt server:
        Caddy log level:               ERROR
        Caddy polling interval:        5s
-       Caddy tls internal:            false
+       Caddy tls internal:
 ```
+
+The `tls-internal` key holds the raw per-app value and is empty when nothing has been set on the app. The `computed-tls-internal` key holds the effective value used at deploy time, falling back to the global value and then to the built-in default of `false`. The `global-tls-internal` key holds the global value.
 
 You can run the command for a specific app also.
 
@@ -237,12 +258,14 @@ dokku caddy:report node-js-app
 
 ```
 =====> node-js-app caddy information
+       Caddy computed tls internal:   false
+       Caddy global tls internal:     false
        Caddy image:                   lucaslorentz/caddy-docker-proxy:2.7
        Caddy letsencrypt email:
        Caddy letsencrypt server:
        Caddy log level:               ERROR
        Caddy polling interval:        5s
-       Caddy tls internal:            false
+       Caddy tls internal:
 ```
 
 You can pass flags which will output only the value of the specific information you want. For example:

--- a/plugins/caddy-vhosts/command-functions
+++ b/plugins/caddy-vhosts/command-functions
@@ -70,6 +70,7 @@ cmd-caddy-report-single() {
   local flag_map=()
   if [[ "$APP" == "--global" ]]; then
     flag_map=(
+      "--caddy-global-tls-internal: $(fn-caddy-global-tls-internal)"
       "--caddy-image: $(fn-caddy-image)"
       "--caddy-letsencrypt-email: $(fn-caddy-letsencrypt-email)"
       "--caddy-letsencrypt-server: $(fn-caddy-letsencrypt-server)"
@@ -79,6 +80,8 @@ cmd-caddy-report-single() {
   else
     verify_app_name "$APP"
     flag_map=(
+      "--caddy-computed-tls-internal: $(fn-caddy-computed-tls-internal "$APP")"
+      "--caddy-global-tls-internal: $(fn-caddy-global-tls-internal)"
       "--caddy-image: $(fn-caddy-image)"
       "--caddy-letsencrypt-email: $(fn-caddy-letsencrypt-email)"
       "--caddy-letsencrypt-server: $(fn-caddy-letsencrypt-server)"

--- a/plugins/caddy-vhosts/core-post-deploy
+++ b/plugins/caddy-vhosts/core-post-deploy
@@ -14,7 +14,7 @@ trigger-caddy-vhosts-core-post-deploy() {
     return
   fi
 
-  tls_internal="$(fn-caddy-tls-internal)"
+  tls_internal="$(fn-caddy-computed-tls-internal "$APP")"
   dokku_log_info1 "Routing app via caddy"
   if [[ "$tls_internal" == "true" ]]; then
     dokku_log_warn "Warning: using caddy's internal, locally-trusted CA to produce certificates for this site"

--- a/plugins/caddy-vhosts/docker-args-process-deploy
+++ b/plugins/caddy-vhosts/docker-args-process-deploy
@@ -88,7 +88,7 @@ trigger-caddy-vhosts-docker-args-process-deploy() {
   # prefer the https:443 mapping to http:80 mapping
   if [[ -n "$is_app_listening" ]] && [[ -n "$caddy_domains" ]]; then
     has_443_mapping=false
-    tls_internal="$(fn-caddy-tls-internal)"
+    tls_internal="$(fn-caddy-computed-tls-internal "$APP")"
     if [[ -n "$proxy_container_https_port" ]] || [[ -n "$proxy_container_https_port_candidate" ]]; then
       has_443_mapping=true
     fi

--- a/plugins/caddy-vhosts/help-functions
+++ b/plugins/caddy-vhosts/help-functions
@@ -28,7 +28,7 @@ fn-help-content() {
   declare desc="return help content"
   cat <<help_content
     caddy:report [<app>] [<flag>], Displays an caddy report for one or more apps
-    caddy:set <app> <property> (<value>), Set or clear an caddy property for an app
+    caddy:set [<app>|--global] <property> (<value>), Set or clear an caddy property for an app or globally
     caddy:show-config <app>, Display caddy compose config
     caddy:labels:add <app> <label> <value>, Add a label to an caddy app
     caddy:labels:remove <app> <label>, Remove a label from an caddy app

--- a/plugins/caddy-vhosts/internal-functions
+++ b/plugins/caddy-vhosts/internal-functions
@@ -69,5 +69,19 @@ fn-caddy-polling-interval() {
 
 fn-caddy-tls-internal() {
   declare APP="$1"
-  fn-plugin-property-get-default "caddy" "$APP" "tls-internal" "false"
+  fn-plugin-property-get-default "caddy" "$APP" "tls-internal" ""
+}
+
+fn-caddy-computed-tls-internal() {
+  declare APP="$1"
+  local value
+  value="$(fn-caddy-tls-internal "$APP")"
+  if [[ -z "$value" ]]; then
+    value="$(fn-caddy-global-tls-internal)"
+  fi
+  echo "$value"
+}
+
+fn-caddy-global-tls-internal() {
+  fn-plugin-property-get-default "caddy" "--global" "tls-internal" "false"
 }

--- a/plugins/caddy-vhosts/subcommands/set
+++ b/plugins/caddy-vhosts/subcommands/set
@@ -10,7 +10,7 @@ cmd-caddy-set() {
   [[ "$1" == "$cmd" ]] && shift 1
   declare APP="$1" KEY="$2" VALUE="$3"
   local VALID_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval" "tls-internal")
-  local GLOBAL_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval")
+  local GLOBAL_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval" "tls-internal")
   local GLOBAL_ONLY_KEYS=("image" "letsencrypt-email" "letsencrypt-server" "log-level" "polling-interval")
 
   [[ -z "$KEY" ]] && dokku_log_fail "No key specified"

--- a/tests/unit/caddy.bats
+++ b/tests/unit/caddy.bats
@@ -63,6 +63,118 @@ teardown() {
   assert_success
 }
 
+@test "(caddy:report) tls-internal raw vs computed vs global" {
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-computed-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-global-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku caddy:set $TEST_APP tls-internal true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-computed-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku caddy:set $TEST_APP tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-computed-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+}
+
+@test "(caddy:set) --global tls-internal" {
+  run /bin/bash -c "dokku caddy:set --global tls-internal true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku caddy:report --global --caddy-global-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-computed-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-global-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku caddy:set $TEST_APP tls-internal false"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku caddy:report $TEST_APP --caddy-computed-tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku caddy:set $TEST_APP tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku caddy:set --global tls-internal"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
 @test "(caddy) caddy:help" {
   run /bin/bash -c "dokku caddy"
   echo "output: $output"


### PR DESCRIPTION
The bare `tls-internal` key previously returned the computed value, so external tooling could not tell whether the property had been set on the app or was merely defaulting to `false`. The property is now also configurable with `--global`, the report exposes `computed-tls-internal` and `global-tls-internal` keys alongside the bare raw key, and the deploy path honors the per-app value with a fallback to the global value before the built-in default. Closes #8625.