### PR TITLE
Expose global keep-git-dir in git:report and honor as fallback

### DIFF
--- a/docs/deployment/methods/git.md
+++ b/docs/deployment/methods/git.md
@@ -126,6 +126,15 @@ dokku git:set node-js-app keep-git-dir ""
 
 Please keep in mind that setting `keep-git-dir` to `true` may result in unstaged changes shown within the built container due to the build process generating application changes within the built app directory.
 
+The `keep-git-dir` property may also be set globally so that newly created apps default to keeping the `.git` directory.
+
+```shell
+# on the Dokku host
+dokku git:set --global keep-git-dir true
+```
+
+When set globally, any app that has no per-app `keep-git-dir` override will use the global value at deploy time. A per-app `keep-git-dir` value always takes precedence over the global setting.
+
 ### Initializing an app repository from a remote repository
 
 > [!IMPORTANT]
@@ -287,6 +296,7 @@ dokku git:report
        Git global archive max files:  10000
        Git global archive max size:   1073741824
        Git global deploy branch:      master
+       Git global keep git dir:       false
        Git keep git dir:
        Git rev env var:               GIT_REV
        Git sha:                       a1b2c3d

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -372,6 +372,7 @@ cmd-git-report-single() {
       "--git-global-archive-max-files: $(fn-plugin-property-get "git" "--global" "archive-max-files" "10000")"
       "--git-global-archive-max-size: $(fn-plugin-property-get "git" "--global" "archive-max-size" "1073741824")"
       "--git-global-deploy-branch: $(fn-plugin-property-get "git" "--global" "deploy-branch" "master")"
+      "--git-global-keep-git-dir: $(fn-plugin-property-get "git" "--global" "keep-git-dir" "false")"
     )
   else
     verify_app_name "$APP"
@@ -382,6 +383,7 @@ cmd-git-report-single() {
       "--git-global-archive-max-files: $(fn-plugin-property-get "git" "--global" "archive-max-files" "10000")"
       "--git-global-archive-max-size: $(fn-plugin-property-get "git" "--global" "archive-max-size" "1073741824")"
       "--git-global-deploy-branch: $(fn-plugin-property-get "git" "--global" "deploy-branch" "master")"
+      "--git-global-keep-git-dir: $(fn-plugin-property-get "git" "--global" "keep-git-dir" "false")"
       "--git-keep-git-dir: $(fn-plugin-property-get "git" "$APP" "keep-git-dir" "")"
       "--git-rev-env-var: $(fn-plugin-property-get "git" "$APP" "rev-env-var" "GIT_REV")"
       "--git-sha: $(fn-git-cmd "$APP_ROOT" rev-parse HEAD 2>/dev/null || false)"
@@ -615,8 +617,11 @@ fn-git-keep-git-dir() {
   local DEFAULT_KEEP_GIT_DIR="${2-false}"
 
   local DOKKU_KEEP_GIT_DIR="$(fn-plugin-property-get "git" "$APP" "keep-git-dir" "")"
+  local DOKKU_GLOBAL_KEEP_GIT_DIR="$(fn-plugin-property-get "git" "--global" "keep-git-dir" "")"
   if [[ -n "$DOKKU_KEEP_GIT_DIR" ]]; then
     echo "$DOKKU_KEEP_GIT_DIR"
+  elif [[ -n "$DOKKU_GLOBAL_KEEP_GIT_DIR" ]]; then
+    echo "$DOKKU_GLOBAL_KEEP_GIT_DIR"
   else
     echo "$DEFAULT_KEEP_GIT_DIR"
   fi

--- a/tests/unit/git_1.bats
+++ b/tests/unit/git_1.bats
@@ -143,6 +143,70 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output "false"
+
+  run /bin/bash -c "dokku git:report $TEST_APP --format json | jq -r '.\"global-keep-git-dir\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+}
+
+@test "(git:report) keep-git-dir global fallback" {
+  run /bin/bash -c "dokku git:set --global keep-git-dir true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-global-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku git:report $TEST_APP --format json | jq -r '.\"global-keep-git-dir\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku git:report $TEST_APP --format json | jq -r '.\"computed-keep-git-dir\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku git:set $TEST_APP keep-git-dir false"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report $TEST_APP --git-computed-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku git:set $TEST_APP keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:set --global keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 }
 
 @test "(git) git:help" {

--- a/tests/unit/git_3.bats
+++ b/tests/unit/git_3.bats
@@ -913,6 +913,7 @@ teardown() {
   assert_success
   assert_output_contains "global git information"
   assert_output_contains "Git global deploy branch"
+  assert_output_contains "Git global keep git dir"
 }
 
 @test "(git:report) --global --format json" {
@@ -927,7 +928,19 @@ teardown() {
   assert_success
   assert_output "master"
 
+  run /bin/bash -c "dokku git:report --global --format json | jq -r '.\"global-keep-git-dir\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
   run /bin/bash -c "dokku git:report --global --format json | jq -r 'has(\"deploy-branch\")'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku git:report --global --format json | jq -r 'has(\"keep-git-dir\")'"
   echo "output: $output"
   echo "status: $status"
   assert_success
@@ -938,4 +951,38 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output "master"
+
+  run /bin/bash -c "dokku git:report --global --git-global-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku git:set --global keep-git-dir true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report --global --format json | jq -r '.\"global-keep-git-dir\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku git:report --global --git-global-keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku git:set --global keep-git-dir"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku git:report --global --format json | jq -r '.\"global-keep-git-dir\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
 }


### PR DESCRIPTION
The `keep-git-dir` property was settable via `git:set --global` but the value was absent from `git:report --global --format json` and the per-app report, and `fn-git-keep-git-dir` did not consult the global value when computing the effective setting. The global flag map now emits `global-keep-git-dir`, the per-app flag map matches `global-deploy-branch` by also exposing `global-keep-git-dir`, and `fn-git-keep-git-dir` cascades app then global then default in the same shape as `fn-git-deploy-branch`.

Closes #8636.