### PR TITLE
Depend on cron | cron-daemon to allow alternatives

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.38.5
 Section: web
 Priority: optional
 Architecture: amd64
-Depends: apache2-utils, locales, git, cpio, cron, curl, logrotate, man-db, netcat, sshcommand, docker-engine-cs (>= 19.03.0) | docker-engine (>= 19.03.0) | docker-io (>= 19.03.0) | docker.io (>= 19.03.0) | docker-ce (>= 19.03.0) | docker-ee (>= 19.03.0) | moby-engine, docker-compose-plugin | moby-compose | docker-compose, docker-buildx-plugin | moby-buildx | docker-buildx, docker-container-healthchecker, docker-image-labeler, lambda-builder, net-tools, netrc, parallel, procfile-util, rsync, dos2unix, unzip, util-linux
+Depends: apache2-utils, locales, git, cpio, cron | cron-daemon, curl, logrotate, man-db, netcat, sshcommand, docker-engine-cs (>= 19.03.0) | docker-engine (>= 19.03.0) | docker-io (>= 19.03.0) | docker.io (>= 19.03.0) | docker-ce (>= 19.03.0) | docker-ee (>= 19.03.0) | moby-engine, docker-compose-plugin | moby-compose | docker-compose, docker-buildx-plugin | moby-buildx | docker-buildx, docker-container-healthchecker, docker-image-labeler, lambda-builder, net-tools, netrc, parallel, procfile-util, rsync, dos2unix, unzip, util-linux
 Recommends: herokuish, bash-completion, dokku-update, dokku-event-listener
 Pre-Depends: gliderlabs-sigil, jq, nginx (>= 1.8.0) | openresty, bind9-dnsutils, debconf, plugn, sudo, python3, rsyslog
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>


### PR DESCRIPTION
The bare `cron` dependency caused `apt` to remove `dokku` whenever a user installed an alternative cron daemon such as `systemd-cron`. Listing the virtual `cron-daemon` package as an alternative keeps the default install behaviour (fresh installs still pull in `cron`) while letting any provider of `cron-daemon` satisfy the dependency, so swapping cron daemons no longer takes `dokku` with it.

Fixes #8643.