### PR TITLE
Rename logs:report vector key test and guard old keys

### DIFF
--- a/tests/unit/logs.bats
+++ b/tests/unit/logs.bats
@@ -530,7 +530,7 @@ teardown() {
   assert_success
 }
 
-@test "(logs:report) vector-global-image and vector-global-networks raw" {
+@test "(logs:report) global-vector-image and global-vector-networks raw" {
   run create_app
   assert_success
 
@@ -558,6 +558,15 @@ teardown() {
   run /bin/bash -c "dokku logs:report --global --format json | jq -r '.\"logs-global-vector-networks\"'"
   assert_success
   assert_output ""
+}
+
+@test "(logs:report) does not expose deprecated logs-vector-global-* keys" {
+  run /bin/bash -c "dokku logs:report --global --format json"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_contains "logs-vector-global-image"
+  assert_output_not_contains "logs-vector-global-networks"
 }
 
 @test "(logs) logs:set --global vector-networks" {


### PR DESCRIPTION
The asymmetric `--logs-vector-global-image` and `--logs-vector-global-networks` flags were renamed to `--logs-global-vector-image` and `--logs-global-vector-networks` in #8640 so they match the standard `--<plugin>-global-<property>` shape used by every other report. The bats description string at `tests/unit/logs.bats:533` was still pinned to the old asymmetric phrasing, and there was no assertion that the deprecated JSON keys had actually been removed. This updates the test description to match its assertions and adds a regression guard that fails if `logs-vector-global-image` or `logs-vector-global-networks` ever reappear in the `--global` JSON report. Closes #8632.