### PR TITLE
Use SYSTEM for shfmt Darwin detection

### DIFF
--- a/tests.mk
+++ b/tests.mk
@@ -25,7 +25,7 @@ endif
 
 shfmt:
 ifneq ($(shell shfmt --version >/dev/null 2>&1; echo $$?),0)
-ifeq ($(shfmt),Darwin)
+ifeq ($(SYSTEM),Darwin)
 	brew install shfmt
 else
 	wget -qO /tmp/shfmt https://github.com/mvdan/sh/releases/download/v3.5.1/shfmt_v3.5.1_linux_${TARGETARCH}


### PR DESCRIPTION
Small fix for `make shfmt` on macOS.

Right now this target checks `$(shfmt)` instead of `$(SYSTEM)`, so Darwin drops into the Linux install path and tries to fetch a Linux binary. kinda busted for local contrib setup.

Repro:
`env PATH=/usr/bin:/bin make -n -f tests.mk shfmt SYSTEM=Darwin TARGETARCH=amd64`

Before:
`wget -qO /tmp/shfmt https://github.com/mvdan/sh/releases/download/v3.5.1/shfmt_v3.5.1_linux_amd64`

After this change:
`brew install shfmt`

Linux still keeps the existing path:
`env PATH=/usr/bin:/bin make -n -f tests.mk shfmt SYSTEM=Linux TARGETARCH=amd64`
