### PR TITLE
Unset bind-all-interfaces on empty value

### DIFF
--- a/plugins/network/Makefile
+++ b/plugins/network/Makefile
@@ -1,5 +1,5 @@
 SUBCOMMANDS = subcommands/create subcommands/destroy subcommands/exists subcommands/info subcommands/list subcommands/rebuild subcommands/rebuildall subcommands/report subcommands/set
-TRIGGERS = triggers/core-post-deploy triggers/docker-args-process-build triggers/docker-args-process-deploy triggers/docker-args-process-run triggers/install triggers/network-build-config triggers/network-config-exists triggers/network-get-ipaddr triggers/network-get-listeners triggers/network-get-property triggers/network-get-static-listeners triggers/network-write-ipaddr triggers/network-write-port triggers/post-app-clone-setup triggers/post-app-rename-setup triggers/post-container-create triggers/post-create triggers/post-delete triggers/report
+TRIGGERS = triggers/core-post-deploy triggers/docker-args-process-build triggers/docker-args-process-deploy triggers/docker-args-process-run triggers/install triggers/network-build-config triggers/network-config-exists triggers/network-get-ipaddr triggers/network-get-listeners triggers/network-get-property triggers/network-get-static-listeners triggers/network-write-ipaddr triggers/network-write-port triggers/post-app-clone-setup triggers/post-app-rename-setup triggers/post-container-create triggers/post-delete triggers/report
 BUILD = commands subcommands triggers
 PLUGIN_NAME = network
 

--- a/plugins/network/src/triggers/triggers.go
+++ b/plugins/network/src/triggers/triggers.go
@@ -82,9 +82,6 @@ func main() {
 		phase := flag.Arg(3)
 		processType := flag.Arg(4)
 		err = network.TriggerPostContainerCreate(containerType, containerID, appName, phase, processType)
-	case "post-create":
-		appName := flag.Arg(0)
-		err = network.TriggerPostCreate(appName)
 	case "post-delete":
 		appName := flag.Arg(0)
 		err = network.TriggerPostDelete(appName)

--- a/plugins/network/subcommands.go
+++ b/plugins/network/subcommands.go
@@ -192,10 +192,6 @@ func CommandSet(appName string, property string, value string, values []string) 
 		}
 	}
 
-	if property == "bind-all-interfaces" && value == "" {
-		value = "false"
-	}
-
 	attachProperties := map[string]bool{
 		"attach-post-create": true,
 		"attach-post-deploy": true,

--- a/plugins/network/triggers.go
+++ b/plugins/network/triggers.go
@@ -222,16 +222,6 @@ func TriggerPostContainerCreate(containerType string, containerID string, appNam
 	return nil
 }
 
-// TriggerPostCreate sets bind-all-interfaces to false by default
-func TriggerPostCreate(appName string) error {
-	err := common.PropertyWrite("network", appName, "bind-all-interfaces", "false")
-	if err != nil {
-		common.LogWarn(err.Error())
-	}
-
-	return nil
-}
-
 // TriggerPostDelete destroys the network property for a given app container
 func TriggerPostDelete(appName string) error {
 	return common.PropertyDestroy("network", appName)

--- a/tests/unit/network.bats
+++ b/tests/unit/network.bats
@@ -201,6 +201,99 @@ teardown() {
   docker network rm initial-network-x >/dev/null
 }
 
+@test "(network:report) bind-all-interfaces raw vs computed vs global" {
+  run /bin/bash -c "dokku network:set --global bind-all-interfaces"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku network:report --global --format json | jq -r '.\"network-global-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku network:report --global --format json | jq -r '.\"network-computed-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku network:set --global bind-all-interfaces true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku network:report --global --format json | jq -r '.\"network-global-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku network:report --global --format json | jq -r '.\"network-computed-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku network:report $TEST_APP --format json | jq -r '.\"network-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku network:report $TEST_APP --format json | jq -r '.\"network-computed-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku network:set --global bind-all-interfaces"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku network:report --global --format json | jq -r '.\"network-global-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku network:report --global --format json | jq -r '.\"network-computed-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+
+  run /bin/bash -c "dokku network:set $TEST_APP bind-all-interfaces true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku network:report $TEST_APP --format json | jq -r '.\"network-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku network:set $TEST_APP bind-all-interfaces"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku network:report $TEST_APP --format json | jq -r '.\"network-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku network:report $TEST_APP --format json | jq -r '.\"network-computed-bind-all-interfaces\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "false"
+}
+
 @test "(network) network:set bind-all-interfaces" {
   run deploy_app
   echo "output: $output"


### PR DESCRIPTION
`dokku network:set --global bind-all-interfaces` (no value) wrote the literal string `false` to the property file instead of unsetting it, so external tooling could not distinguish "explicitly set to default" from "not set". Drop the empty-to-`false` coercion in `CommandSet` so the empty-value path reaches `PropertyDelete` like every other property, and remove the unconditional `TriggerPostCreate` write so new apps consult the global value before falling back to the `"false"` computed default. The `reportComputedBindAllInterfaces` fallback chain (app then global then `false`) already provides the correct computed default and is unchanged.

Closes #8684.