### PR TITLE
Treat empty ps restart-policy as an unset

### DIFF
--- a/docs/processes/process-management.md
+++ b/docs/processes/process-management.md
@@ -367,6 +367,20 @@ dokku ps:set node-js-app restart-policy on-failure
 dokku ps:set node-js-app restart-policy on-failure:20
 ```
 
+The default policy (`on-failure:10`) may be restored by passing an empty value:
+
+```shell
+dokku ps:set node-js-app restart-policy
+```
+
+A global default may also be set, and is used by any app that does not have an app-specific restart policy:
+
+```shell
+dokku ps:set --global restart-policy always
+```
+
+The effective policy applied to an app's containers is resolved as the app-specific value, then the global value, then the built-in `on-failure:10` default. This computed value can be inspected via the `--ps-computed-restart-policy` report flag.
+
 Restart policies have no bearing on server reboot, and Dokku will always attempt to restart your apps at that point unless they were manually stopped.
 
 Dokku also runs `dokku-event-listener` in the background via the system's init service. This monitors container state, performing the following actions:
@@ -391,8 +405,10 @@ dokku ps:report
        Processes:                     0
        Ps can scale:                  true
        Ps computed procfile path:     Procfile2
+       Ps computed restart policy:    on-failure:10
        Ps global procfile path:       Procfile
-       Ps restart policy:             on-failure:10
+       Ps global restart policy:
+       Ps restart policy:
        Ps procfile path:              Procfile2
        Restore:                       true
        Running:                       false
@@ -401,8 +417,10 @@ dokku ps:report
        Processes:                     0
        Ps can scale:                  true
        Ps computed procfile path:     Procfile
+       Ps computed restart policy:    on-failure:10
        Ps global procfile path:       Procfile
-       Ps restart policy:             on-failure:10
+       Ps global restart policy:
+       Ps restart policy:
        Ps procfile path:
        Restore:                       true
        Running:                       false
@@ -411,8 +429,10 @@ dokku ps:report
        Processes:                     0
        Ps can scale:                  true
        Ps computed procfile path:     Procfile
+       Ps computed restart policy:    on-failure:10
        Ps global procfile path:       Procfile
-       Ps restart policy:             on-failure:10
+       Ps global restart policy:
+       Ps restart policy:
        Ps procfile path:
        Restore:                       true
        Running:                       false
@@ -429,7 +449,9 @@ dokku ps:report node-js-app
        Deployed:                      false
        Processes:                     0
        Ps can scale:                  true
-       Ps restart policy:             on-failure:10
+       Ps computed restart policy:    on-failure:10
+       Ps global restart policy:
+       Ps restart policy:
        Restore:                       true
        Running:                       false
 ```
@@ -475,7 +497,7 @@ dokku ps:set node-js-app restore
 |---|---|---|---|---|
 | `dockerfile-start-cmd` | app only | none | `--ps-dockerfile-start-cmd`, `--ps-computed-dockerfile-start-cmd` | Override `CMD` for Dockerfile-based apps |
 | `procfile-path` | app + global | `Procfile` | `--ps-procfile-path`, `--ps-global-procfile-path`, `--ps-computed-procfile-path` | Path to the app's Procfile, relative to the build root |
-| `restart-policy` | app only | `on-failure:10` | `--ps-restart-policy` | Docker restart policy applied to deployed containers (`no`, `always`, `unless-stopped`, `on-failure[:max-retries]`) |
+| `restart-policy` | app + global | `on-failure:10` | `--ps-restart-policy`, `--ps-global-restart-policy`, `--ps-computed-restart-policy` | Docker restart policy applied to deployed containers (`no`, `always`, `unless-stopped`, `on-failure[:max-retries]`) |
 | `restore` | app only | `true` | `--restore` | When `true`, the app is restarted automatically by `ps:retire` after a host reboot |
 | `skip-deploy` | app + global | `false` | `--ps-skip-deploy`, `--ps-global-skip-deploy`, `--ps-computed-skip-deploy` | When `true`, skips the deploy phase after a successful build |
 | `start-cmd` | app only | none | `--ps-start-cmd`, `--ps-computed-start-cmd` | Override start command for buildpack apps |

--- a/plugins/builder-dockerfile/builder-build
+++ b/plugins/builder-dockerfile/builder-build
@@ -33,7 +33,7 @@ trigger-builder-dockerfile-builder-build() {
   plugn trigger pre-build "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
 
   local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$BUILDER_TYPE")
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")
+  DOCKER_ARGS+=" $(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")"
   DOCKER_ARGS+=" $DOKKU_GLOBAL_BUILD_ARGS"
 
   DOCKER_ARGS=" $DOCKER_ARGS "

--- a/plugins/builder-herokuish/builder-build
+++ b/plugins/builder-herokuish/builder-build
@@ -69,7 +69,7 @@ trigger-builder-herokuish-builder-build() {
     DOCKER_ARGS+=" --env=TRACE=true "
     DOCKER_ARGS+=" --env=BUILDPACK_XTRACE=1 "
   fi
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")
+  DOCKER_ARGS+=" $(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")"
 
   declare -a ARG_ARRAY
   eval "ARG_ARRAY=($DOCKER_ARGS)"

--- a/plugins/builder-nixpacks/builder-build
+++ b/plugins/builder-nixpacks/builder-build
@@ -34,7 +34,7 @@ trigger-builder-nixpacks-builder-build() {
   fi
 
   local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$BUILDER_TYPE")
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")
+  DOCKER_ARGS+=" $(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")"
   DOCKER_ARGS+=" $DOKKU_GLOBAL_BUILD_ARGS"
 
   DOCKER_ARGS=" $DOCKER_ARGS "

--- a/plugins/builder-pack/builder-build
+++ b/plugins/builder-pack/builder-build
@@ -38,7 +38,7 @@ trigger-builder-pack-builder-build() {
   plugn trigger pre-build "$BUILDER_TYPE" "$APP" "$SOURCECODE_WORK_DIR"
 
   local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$BUILDER_TYPE")
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")
+  DOCKER_ARGS+=" $(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")"
   [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" --env=TRACE=true "
 
   DOCKER_ARGS=" $DOCKER_ARGS "

--- a/plugins/builder-pack/docker-args-process-deploy
+++ b/plugins/builder-pack/docker-args-process-deploy
@@ -23,7 +23,7 @@ trigger-builder-pack-docker-args-process-deploy() {
     output=" --entrypoint launcher"
   fi
 
-  echo -n "$STDIN$output"
+  echo -n "$STDIN $output"
 }
 
 trigger-builder-pack-docker-args-process-deploy "$@"

--- a/plugins/builder-railpack/builder-build
+++ b/plugins/builder-railpack/builder-build
@@ -34,7 +34,7 @@ trigger-builder-railpack-builder-build() {
   fi
 
   local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$BUILDER_TYPE")
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")
+  DOCKER_ARGS+=" $(: | plugn trigger docker-args-process-build "$APP" "$BUILDER_TYPE")"
 
   DOCKER_ARGS=" $DOCKER_ARGS "
   eval set -- "$DOCKER_ARGS"

--- a/plugins/caddy-vhosts/docker-args-process-deploy
+++ b/plugins/caddy-vhosts/docker-args-process-deploy
@@ -137,7 +137,7 @@ trigger-caddy-vhosts-docker-args-process-deploy() {
     done <"$proxy_labels_file_path"
   fi
 
-  echo -n "$STDIN$output"
+  echo -n "$STDIN $output"
 }
 
 trigger-caddy-vhosts-docker-args-process-deploy "$@"

--- a/plugins/haproxy-vhosts/docker-args-process-deploy
+++ b/plugins/haproxy-vhosts/docker-args-process-deploy
@@ -132,7 +132,7 @@ trigger-haproxy-vhosts-docker-args-process-deploy() {
     done <"$proxy_labels_file_path"
   fi
 
-  echo -n "$STDIN$output"
+  echo -n "$STDIN $output"
 }
 
 trigger-haproxy-vhosts-docker-args-process-deploy "$@"

--- a/plugins/openresty-vhosts/docker-args-process-deploy
+++ b/plugins/openresty-vhosts/docker-args-process-deploy
@@ -214,7 +214,7 @@ trigger-openresty-vhosts-docker-args-process-deploy() {
     done <"$proxy_labels_file_path"
   fi
 
-  echo -n "$STDIN$output"
+  echo -n "$STDIN $output"
 }
 
 trigger-openresty-vhosts-docker-args-process-deploy "$@"

--- a/plugins/ps/Makefile
+++ b/plugins/ps/Makefile
@@ -1,5 +1,5 @@
 SUBCOMMANDS = subcommands/inspect subcommands/rebuild subcommands/report subcommands/restart subcommands/restore subcommands/retire subcommands/scale subcommands/set subcommands/start subcommands/stop
-TRIGGERS = triggers/app-restart triggers/core-post-deploy triggers/core-post-extract triggers/install triggers/post-app-clone triggers/post-app-clone-setup triggers/post-app-rename triggers/post-app-rename-setup triggers/post-create triggers/post-delete triggers/post-release-builder triggers/post-stop triggers/procfile-get-command triggers/procfile-exists triggers/ps-can-scale triggers/ps-current-scale triggers/ps-get-property triggers/ps-set-scale triggers/report
+TRIGGERS = triggers/app-restart triggers/core-post-deploy triggers/core-post-extract triggers/docker-args-process-deploy triggers/install triggers/post-app-clone triggers/post-app-clone-setup triggers/post-app-rename triggers/post-app-rename-setup triggers/post-create triggers/post-delete triggers/post-release-builder triggers/post-stop triggers/procfile-get-command triggers/procfile-exists triggers/ps-can-scale triggers/ps-current-scale triggers/ps-get-property triggers/ps-set-scale triggers/report
 BUILD = commands subcommands triggers
 PLUGIN_NAME = ps
 

--- a/plugins/ps/ps.go
+++ b/plugins/ps/ps.go
@@ -25,6 +25,7 @@ var (
 	// GlobalProperties is a map of all valid global ps properties
 	GlobalProperties = map[string]bool{
 		"procfile-path":        true,
+		"restart-policy":       true,
 		"skip-deploy":          true,
 		"stop-timeout-seconds": true,
 	}

--- a/plugins/ps/report.go
+++ b/plugins/ps/report.go
@@ -20,9 +20,11 @@ func ReportSingleApp(appName string, format string, infoFlag string) error {
 	if appName == "--global" {
 		flags = map[string]common.ReportFunc{
 			"--ps-computed-procfile-path":        reportComputedProcfilePath,
+			"--ps-computed-restart-policy":       reportComputedRestartPolicy,
 			"--ps-computed-skip-deploy":          reportComputedSkipDeploy,
 			"--ps-computed-stop-timeout-seconds": reportComputedStopTimeoutSeconds,
 			"--ps-global-procfile-path":          reportGlobalProcfilePath,
+			"--ps-global-restart-policy":         reportGlobalRestartPolicy,
 			"--ps-global-skip-deploy":            reportGlobalSkipDeploy,
 			"--ps-global-stop-timeout-seconds":   reportGlobalStopTimeoutSeconds,
 		}
@@ -33,11 +35,13 @@ func ReportSingleApp(appName string, format string, infoFlag string) error {
 			"--ps-can-scale":                       reportCanScale,
 			"--ps-computed-dockerfile-start-cmd":   reportComputedDockerfileStartCmd,
 			"--ps-computed-procfile-path":          reportComputedProcfilePath,
+			"--ps-computed-restart-policy":         reportComputedRestartPolicy,
 			"--ps-computed-skip-deploy":            reportComputedSkipDeploy,
 			"--ps-computed-start-cmd":              reportComputedStartCmd,
 			"--ps-computed-stop-timeout-seconds":   reportComputedStopTimeoutSeconds,
 			"--ps-dockerfile-start-cmd":            reportDockerfileStartCmd,
 			"--ps-global-procfile-path":            reportGlobalProcfilePath,
+			"--ps-global-restart-policy":           reportGlobalRestartPolicy,
 			"--ps-global-skip-deploy":              reportGlobalSkipDeploy,
 			"--ps-global-stop-timeout-seconds":     reportGlobalStopTimeoutSeconds,
 			"--ps-procfile-path":                   reportProcfilePath,
@@ -162,13 +166,24 @@ func reportProcesses(appName string) string {
 	return strconv.Itoa(count)
 }
 
-func reportRestartPolicy(appName string) string {
-	policy, _ := getRestartPolicy(appName)
-	if policy == "" {
-		policy = DefaultProperties["restart-policy"]
+func reportComputedRestartPolicy(appName string) string {
+	value := reportRestartPolicy(appName)
+	if value == "" {
+		value = reportGlobalRestartPolicy(appName)
+	}
+	if value == "" {
+		value = DefaultProperties["restart-policy"]
 	}
 
-	return policy
+	return value
+}
+
+func reportGlobalRestartPolicy(appName string) string {
+	return common.PropertyGet("ps", "--global", "restart-policy")
+}
+
+func reportRestartPolicy(appName string) string {
+	return common.PropertyGet("ps", appName, "restart-policy")
 }
 
 func reportRestore(appName string) string {

--- a/plugins/ps/src/triggers/triggers.go
+++ b/plugins/ps/src/triggers/triggers.go
@@ -28,6 +28,9 @@ func main() {
 		appName := flag.Arg(0)
 		sourceWorkDir := flag.Arg(1)
 		err = ps.TriggerCorePostExtract(appName, sourceWorkDir)
+	case "docker-args-process-deploy":
+		appName := flag.Arg(0)
+		err = ps.TriggerDockerArgsProcessDeploy(appName)
 	case "install":
 		err = ps.TriggerInstall()
 	case "post-app-clone":

--- a/plugins/ps/subcommands.go
+++ b/plugins/ps/subcommands.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/dokku/dokku/plugins/common"
-	dockeroptions "github.com/dokku/dokku/plugins/docker-options"
 	"github.com/gofrs/flock"
 )
 
@@ -184,13 +183,8 @@ func CommandScale(appName string, skipDeploy bool, processTuples []string) error
 
 // CommandSet sets or clears a ps property for an app
 func CommandSet(appName string, property string, value string) error {
-	if property == "restart-policy" {
-		if !isValidRestartPolicy(value) {
-			return errors.New("Invalid restart-policy specified")
-		}
-
-		common.LogInfo2Quiet(fmt.Sprintf("Setting %s to %s", property, value))
-		return dockeroptions.SetDockerOptionForPhases(appName, []string{"deploy"}, "restart", value)
+	if property == "restart-policy" && value != "" && !isValidRestartPolicy(value) {
+		return errors.New("Invalid restart-policy specified")
 	}
 
 	common.CommandPropertySet("ps", appName, property, value, DefaultProperties, GlobalProperties)

--- a/plugins/ps/triggers.go
+++ b/plugins/ps/triggers.go
@@ -3,6 +3,7 @@ package ps
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -37,6 +38,24 @@ func TriggerCorePostDeploy(appName string) error {
 	}
 
 	return common.PropertyWrite("ps", appName, "restore", "true")
+}
+
+// TriggerDockerArgsProcessDeploy injects the computed restart policy as a
+// `--restart=` docker option at deploy time. The value is no longer persisted
+// in the docker-options store; it is derived from the app/global restart-policy
+// property on every deploy.
+func TriggerDockerArgsProcessDeploy(appName string) error {
+	stdin, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stdout.Write(stdin); err != nil {
+		return err
+	}
+
+	fmt.Printf(" --restart=%s", reportComputedRestartPolicy(appName))
+	return nil
 }
 
 // TriggerCorePostExtract ensures that the main Procfile is the one specified by procfile-path
@@ -104,16 +123,22 @@ func TriggerInstall() error {
 	}
 
 	for _, appName := range apps {
-		policies, err := getRestartPolicy(appName)
+		policy, err := getRestartPolicy(appName)
 		if err != nil {
 			return err
 		}
 
-		if len(policies) != 0 {
+		if policy == "" {
 			continue
 		}
 
-		if err := dockeroptions.AddDockerOptionToPhases(appName, []string{"deploy"}, "--restart=on-failure:10"); err != nil {
+		if policy != DefaultProperties["restart-policy"] {
+			if err := common.PropertyWrite("ps", appName, "restart-policy", policy); err != nil {
+				common.LogWarn(err.Error())
+			}
+		}
+
+		if err := dockeroptions.RemoveDockerOptionFromPhases(appName, []string{"deploy"}, fmt.Sprintf("--restart=%s", policy)); err != nil {
 			common.LogWarn(err.Error())
 		}
 	}
@@ -210,13 +235,8 @@ func TriggerPostAppRenameSetup(oldAppName string, newAppName string) error {
 	return common.CloneAppData("ps", oldAppName, newAppName)
 }
 
-// TriggerPostCreate ensures apps have a default restart policy
-// and scale value for web
+// TriggerPostCreate ensures apps have a default scale value for web
 func TriggerPostCreate(appName string) error {
-	if err := dockeroptions.AddDockerOptionToPhases(appName, []string{"deploy"}, "--restart=on-failure:10"); err != nil {
-		return err
-	}
-
 	if err := common.CreateAppDataDirectory("ps", appName); err != nil {
 		return err
 	}
@@ -319,6 +339,7 @@ func TriggerPsSetScale(appName string, skipDeploy bool, clearExisting bool, proc
 
 func TriggerPsGetProperty(appName string, property string) error {
 	computedValueMap := map[string]common.ReportFunc{
+		"restart-policy":       reportComputedRestartPolicy,
 		"restore":              reportRestore,
 		"skip-deploy":          reportComputedSkipDeploy,
 		"stop-timeout-seconds": reportComputedStopTimeoutSeconds,

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process
@@ -53,7 +53,7 @@ fn-scheduler-deploy-process() {
 
   local DOCKER_ARGS
   DOCKER_ARGS=$(: | plugn trigger docker-args-deploy "$APP" "$IMAGE_TAG" "$PROC_TYPE")
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG" "$PROC_TYPE")
+  DOCKER_ARGS+=" $(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG" "$PROC_TYPE")"
   DOCKER_ARGS=" $DOCKER_ARGS "
   declare -a ARG_ARRAY
   eval "ARG_ARRAY=($DOCKER_ARGS)"

--- a/plugins/scheduler-docker-local/bin/scheduler-deploy-process-container
+++ b/plugins/scheduler-docker-local/bin/scheduler-deploy-process-container
@@ -24,7 +24,7 @@ main() {
     DOCKER_ARGS+=" --init"
   fi
   DOCKER_ARGS+=" $DOCKER_RUN_LABEL_ARGS $DOKKU_GLOBAL_RUN_ARGS "
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")
+  DOCKER_ARGS+=" $(: | plugn trigger docker-args-process-deploy "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG" "$PROC_TYPE" "$CONTAINER_INDEX")"
   [[ "$DOKKU_TRACE" ]] && DOCKER_ARGS+=" --env=TRACE=true"
 
   local START_CMD

--- a/plugins/scheduler-docker-local/scheduler-run
+++ b/plugins/scheduler-docker-local/scheduler-run
@@ -74,7 +74,7 @@ trigger-scheduler-docker-local-scheduler-run() {
   local IMAGE_SOURCE_TYPE="dockerfile"
   is_image_herokuish_based "$IMAGE" "$APP" && IMAGE_SOURCE_TYPE="herokuish"
   is_image_cnb_based "$IMAGE" && IMAGE_SOURCE_TYPE="pack"
-  DOCKER_ARGS+=$(: | plugn trigger docker-args-process-run "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG")
+  DOCKER_ARGS+=" $(: | plugn trigger docker-args-process-run "$APP" "$IMAGE_SOURCE_TYPE" "$IMAGE_TAG")"
   DOCKER_ARGS+=" -e DYNO=$PROCESS_TYPE.$DYNO_NUMBER --name $APP.$PROCESS_TYPE.$DYNO_NUMBER"
 
   if [[ "$DOKKU_RM_CONTAINER" ]]; then

--- a/plugins/traefik-vhosts/docker-args-process-deploy
+++ b/plugins/traefik-vhosts/docker-args-process-deploy
@@ -166,7 +166,7 @@ trigger-traefik-vhosts-docker-args-process-deploy() {
     done <"$proxy_labels_file_path"
   fi
 
-  echo -n "$STDIN$output"
+  echo -n "$STDIN $output"
 }
 
 trigger-traefik-vhosts-docker-args-process-deploy "$@"

--- a/tests/unit/docker-options.bats
+++ b/tests/unit/docker-options.bats
@@ -193,7 +193,6 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output_contains "-v /tmp" 0
-  assert_output_contains "Docker options deploy:         --restart=on-failure:10"
 }
 
 @test "(docker-options) docker-options:remove (build phase)" {

--- a/tests/unit/logs.bats
+++ b/tests/unit/logs.bats
@@ -803,7 +803,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output "--log-opt=max-size=20m"
+  assert_output "--log-opt=max-size=20m --restart=on-failure:10"
 
   DRIVER="journald" jq '."log-driver" = env.DRIVER' <"/etc/docker/daemon.json" >"$TMP_FILE"
   mv "$TMP_FILE" /etc/docker/daemon.json
@@ -820,7 +820,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_not_exists
+  assert_output "--restart=on-failure:10"
 
   if [[ "$driver" = "null" ]]; then
     DRIVER="$driver" jq 'del(."log-driver")' <"/etc/docker/daemon.json" >"$TMP_FILE"
@@ -841,7 +841,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output "--log-opt=max-size=20m"
+  assert_output "--log-opt=max-size=20m --restart=on-failure:10"
 }
 
 @test "(logs) logs:set max-size with alternate log-driver" {
@@ -860,7 +860,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output "--log-opt=max-size=20m"
+  assert_output "--log-opt=max-size=20m --restart=on-failure:10"
 
   run /bin/bash -c "dokku docker-options:add $TEST_APP deploy --log-driver=local" 2>&1
   echo "output: $output"
@@ -871,7 +871,7 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output "--log-opt=max-size=20m"
+  assert_output "--log-opt=max-size=20m --restart=on-failure:10"
 
   run /bin/bash -c "dokku docker-options:add $TEST_APP deploy --log-driver=json-file" 2>&1
   echo "output: $output"
@@ -882,18 +882,18 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output "--log-opt=max-size=20m"
+  assert_output "--log-opt=max-size=20m --restart=on-failure:10"
 
   run /bin/bash -c "dokku docker-options:add $TEST_APP deploy --log-driver=journald" 2>&1
   echo "output: $output"
   echo "status: $status"
   assert_success
 
-  run /bin/bash -c "echo "" | dokku plugin:trigger docker-args-process-deploy $TEST_APP 2>&1"
+  run /bin/bash -c "echo "" | dokku plugin:trigger docker-args-process-deploy $TEST_APP 2>&1 | xargs"
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_not_exists
+  assert_output "--restart=on-failure:10"
 }
 
 @test "(logs) logs:vector" {

--- a/tests/unit/ps-general-1.bats
+++ b/tests/unit/ps-general-1.bats
@@ -434,6 +434,11 @@ web                                                                             
   run /bin/bash -c "dokku ps:report $TEST_APP --ps-restart-policy"
   echo "output: $output"
   echo "status: $status"
+  assert_output ""
+
+  run /bin/bash -c "dokku ps:report $TEST_APP --ps-computed-restart-policy"
+  echo "output: $output"
+  echo "status: $status"
   assert_output "on-failure:10"
 }
 
@@ -448,7 +453,84 @@ web                                                                             
     echo "output: $output"
     echo "status: $status"
     assert_output "$policy"
+
+    run /bin/bash -c "dokku ps:report $TEST_APP --ps-computed-restart-policy"
+    echo "output: $output"
+    echo "status: $status"
+    assert_output "$policy"
   done
+}
+
+@test "(ps:restart-policy) ps:set restart-policy unset" {
+  run /bin/bash -c "dokku ps:set $TEST_APP restart-policy on-failure:5"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku ps:report $TEST_APP --ps-restart-policy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "on-failure:5"
+
+  run /bin/bash -c "dokku ps:set $TEST_APP restart-policy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku ps:report $TEST_APP --ps-restart-policy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output ""
+
+  run /bin/bash -c "dokku ps:report $TEST_APP --ps-computed-restart-policy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "on-failure:10"
+}
+
+@test "(ps:restart-policy) invalid policy" {
+  run /bin/bash -c "dokku ps:set $TEST_APP restart-policy bogus"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid restart-policy specified"
+}
+
+@test "(ps:restart-policy) global policy" {
+  run /bin/bash -c "dokku ps:set --global restart-policy always"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku ps:report $TEST_APP --ps-global-restart-policy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "always"
+
+  run /bin/bash -c "dokku ps:report $TEST_APP --ps-restart-policy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output ""
+
+  run /bin/bash -c "dokku ps:report $TEST_APP --ps-computed-restart-policy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "always"
+
+  run /bin/bash -c "dokku ps:set $TEST_APP restart-policy no"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku ps:report $TEST_APP --ps-computed-restart-policy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "no"
+
+  run /bin/bash -c "dokku ps:set --global restart-policy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
 }
 
 @test "(ps:restart-policy) deployed policy" {
@@ -478,6 +560,22 @@ web                                                                             
   echo "output: $output"
   echo "status: $status"
   assert_output "$test_restart_policy"
+
+  run /bin/bash -c "dokku ps:set $TEST_APP restart-policy"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku ps:rebuild $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  CID=$(<$DOKKU_ROOT/$TEST_APP/CONTAINER.web.1)
+  run /bin/bash -c "docker inspect -f '{{ .HostConfig.RestartPolicy.Name }}:{{ .HostConfig.RestartPolicy.MaximumRetryCount }}' $CID"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "on-failure:10"
 }
 
 procfile_line_endings_to_windows() {


### PR DESCRIPTION
`dokku ps:set <app> restart-policy` with no value returned `Invalid restart-policy specified` instead of unsetting the property. Every other ps property treats the no-value form of `:set` as an unset, but `restart-policy` was special-cased to store its value directly as a Docker `--restart=` option, bypassing `common.CommandPropertySet`, so the empty-value form failed validation.

It is now managed as a normal app and global property, matching `procfile-path`, `skip-deploy`, and `stop-timeout-seconds`, with `--ps-restart-policy`, `--ps-global-restart-policy`, and `--ps-computed-restart-policy` report flags. The effective `--restart=` flag is injected at deploy time from the computed value rather than persisted in the docker-options store, and any previously stored policy is migrated to the property store on install.

Because restart-policy is no longer a stored Docker option it no longer appears in `docker-options:report`, and `--ps-restart-policy` now reports the raw value (empty when unset) with the `on-failure:10` fallback available via `--ps-computed-restart-policy`.

Closes #8695.