### PR TITLE
Align apps:set/apps:report with what dokku actually reads

### DIFF
--- a/docs/deployment/application-management.md
+++ b/docs/deployment/application-management.md
@@ -315,6 +315,15 @@ dokku apps:report node-js-app --app-dir
 
 ## Properties
 
+### Settable properties
+
+> [!NOTE]
+> The `Report flags` column lists the CLI argument names accepted by `apps:report`. The JSON keys emitted by `apps:report --format json` are the same names with the leading `--app-` stripped (e.g. `global-disable-autocreation`). Legacy keys with the `app-` prefix (e.g. `app-global-disable-autocreation`) are also emitted during the 0.38.x deprecation window and will be removed in a future major release.
+
+| Property | Scope | Default | Report flags | Description |
+|---|---|---|---|---|
+| `disable-autocreation` | global only | `false` | `--app-global-disable-autocreation` | When `true`, pushes to a remote for an app that does not yet exist are rejected instead of auto-creating the app |
+
 ### Read-only flags
 
 The following flags surface in `apps:report` but are not managed by `apps:set`:

--- a/plugins/apps/apps.go
+++ b/plugins/apps/apps.go
@@ -10,8 +10,6 @@ var (
 
 	// GlobalProperties is a map of all valid global apps properties
 	GlobalProperties = map[string]bool{
-		"deploy-source":          true,
-		"deploy-source-metadata": true,
-		"disable-autocreation":   true,
+		"disable-autocreation": true,
 	}
 )

--- a/plugins/apps/report.go
+++ b/plugins/apps/report.go
@@ -17,14 +17,17 @@ func ReportSingleApp(appName string, format string, infoFlag string) error {
 
 	var flags map[string]common.ReportFunc
 	if appName == "--global" {
-		flags = map[string]common.ReportFunc{}
+		flags = map[string]common.ReportFunc{
+			"--app-global-disable-autocreation": reportGlobalDisableAutocreation,
+		}
 	} else {
 		flags = map[string]common.ReportFunc{
-			"--app-created-at":             reportCreatedAt,
-			"--app-deploy-source":          reportDeploySource,
-			"--app-deploy-source-metadata": reportDeploySourceMetadata,
-			"--app-dir":                    reportDir,
-			"--app-locked":                 reportLocked,
+			"--app-created-at":                  reportCreatedAt,
+			"--app-deploy-source":               reportDeploySource,
+			"--app-deploy-source-metadata":      reportDeploySourceMetadata,
+			"--app-dir":                         reportDir,
+			"--app-global-disable-autocreation": reportGlobalDisableAutocreation,
+			"--app-locked":                      reportLocked,
 		}
 	}
 
@@ -65,6 +68,10 @@ func reportDeploySourceMetadata(appName string) string {
 
 func reportDir(appName string) string {
 	return common.AppRoot(appName)
+}
+
+func reportGlobalDisableAutocreation(appName string) string {
+	return common.PropertyGet("apps", "--global", "disable-autocreation")
 }
 
 func reportLocked(appName string) string {

--- a/plugins/apps/subcommands.go
+++ b/plugins/apps/subcommands.go
@@ -228,6 +228,9 @@ func CommandReport(appName string, format string, infoFlag string) error {
 
 // CommandSet set or clear an apps property for an app
 func CommandSet(appName string, property string, value string) error {
+	if appName != "--global" && property == "disable-autocreation" {
+		common.LogFail("Property can only be specified globally")
+	}
 	common.CommandPropertySet("apps", appName, property, value, DefaultProperties, GlobalProperties)
 	return nil
 }

--- a/tests/unit/apps_1.bats
+++ b/tests/unit/apps_1.bats
@@ -383,5 +383,79 @@ teardown() {
   assert_success
   assert_output "true"
 
+  run /bin/bash -c "dokku apps:report $TEST_APP --format json | jq -r 'has(\"global-disable-autocreation\") and has(\"app-global-disable-autocreation\")'"
+  assert_success
+  assert_output "true"
+
+  destroy_app
+}
+
+@test "(apps:report --global) emits global-disable-autocreation" {
+  run /bin/bash -c "dokku apps:report --global --app-global-disable-autocreation"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku apps:set --global disable-autocreation true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku apps:report --global --app-global-disable-autocreation"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku apps:report --global --format json | jq -r '.\"global-disable-autocreation\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  run /bin/bash -c "dokku apps:report --global --format json | jq -r '.\"app-global-disable-autocreation\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  create_app
+
+  run /bin/bash -c "dokku apps:report $TEST_APP --format json | jq -r '.\"global-disable-autocreation\"'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "true"
+
+  destroy_app
+
+  run /bin/bash -c "dokku apps:set --global disable-autocreation"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+}
+
+@test "(apps:set) rejects dead writes" {
+  run /bin/bash -c "dokku apps:set --global deploy-source git"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Property cannot be specified globally"
+
+  run /bin/bash -c "dokku apps:set --global deploy-source-metadata foo"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Property cannot be specified globally"
+
+  create_app
+
+  run /bin/bash -c "dokku apps:set $TEST_APP disable-autocreation true"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Property can only be specified globally"
+
   destroy_app
 }


### PR DESCRIPTION
## Summary

The apps plugin accepted `apps:set --global deploy-source` and `apps:set --global deploy-source-metadata` even though nothing reads those properties globally, accepted `apps:set <app> disable-autocreation` even though only the global form is consulted by `maybeCreateApp`, and never emitted `disable-autocreation` in `apps:report` for either scope. Drop the global `deploy-source*` writes from `GlobalProperties`, reject per-app `disable-autocreation` writes at the plugin level, and surface `--app-global-disable-autocreation` in both the per-app and `--global` reports so the property the runtime actually reads is round-trippable.

Fixes #8705