### PR TITLE
Add documentation comment to hello function

### DIFF
--- a/tests/apps/go/web.go
+++ b/tests/apps/go/web.go
@@ -15,6 +15,7 @@ func main() {
     }
 }
 
+// hello handles HTTP requests to the root path and responds with "go".
 func hello(res http.ResponseWriter, req *http.Request) {
     fmt.Fprintln(res, "go")
 }


### PR DESCRIPTION
## Problem

The public function `hello` in `tests/apps/go/web.go` lacks a documentation comment, which reduces code readability and maintainability. Clear documentation is essential for developers to understand the purpose and usage of functions, especially in open-source projects.

## Changes

- Added a documentation comment to the `hello` function to describe its behavior: it handles HTTP requests to the root path and responds with "go".

## Verification

- The change only adds a comment and does not alter the code's functionality or API.
- Verify by reviewing the diff to ensure the comment is accurate and follows Go documentation conventions.
- No additional tests are required as the modification is purely informational and preserves existing behavior.