### PR TITLE
Add Ubuntu 26.04 LTS to bootstrap supported versions

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 [[ $TRACE ]] && set -x
 
 # A script to bootstrap dokku.
-# It expects to be run on Ubuntu 22.04/24.04 via 'sudo`
+# It expects to be run on Ubuntu 22.04/24.04/26.04 via 'sudo`
 # If installing a tag higher than 0.3.13, it may install dokku via a package (so long as the package is higher than 0.3.13)
 # It checks out the dokku source code from GitHub into ~/dokku and then runs 'make install' from dokku source.
 
@@ -12,7 +12,7 @@ set -eo pipefail
 # That's good because it prevents our output overlapping with wget's.
 # It also means that we can't run a partially downloaded script.
 
-SUPPORTED_VERSIONS="Debian [11, 12, 13], Ubuntu [22.04, 24.04]"
+SUPPORTED_VERSIONS="Debian [11, 12, 13], Ubuntu [22.04, 24.04, 26.04]"
 
 log-fail() {
   declare desc="log fail formatter"
@@ -181,7 +181,7 @@ install-dokku-from-deb-package() {
   local NO_INSTALL_RECOMMENDS=${DOKKU_NO_INSTALL_RECOMMENDS:=""}
   local OS_ID
 
-  if ! in-array "$DOKKU_DISTRO_VERSION" "22.04" "24.04" "10" "11" "12" "13"; then
+  if ! in-array "$DOKKU_DISTRO_VERSION" "22.04" "24.04" "26.04" "10" "11" "12" "13"; then
     log-fail "Unsupported Linux distribution. Only the following versions are supported: $SUPPORTED_VERSIONS"
   fi
 


### PR DESCRIPTION
## Summary

Fixes #8768. The bootstrap installer (`bootstrap.sh`) rejected Ubuntu 26.04 LTS before any package work happened, because `install-dokku-from-deb-package()` hard-gated the allowed versions to `22.04`/`24.04` (plus Debian):

```
Unsupported Linux distribution. Only the following versions are supported: Debian [11, 12, 13], Ubuntu [22.04, 24.04]
```

This mirrors how 24.04 was added in #7000.

## Changes

- Add `26.04` to the version whitelist in `install-dokku-from-deb-package()`.
- Add `26.04` to the `SUPPORTED_VERSIONS` message.
- Update the header comment to mention 26.04.

## Notes

- Ubuntu 26.04's codename is `resolute` (Resolute Raccoon). I intentionally did **not** add it to `OS_IDS`, because there is no matching packagecloud component published yet — adding it would make 26.04 point at a nonexistent repo. The existing codename fallback already pins unknown Ubuntu codenames to the `noble` (24.04) packagecloud repo, which installs cleanly on 26.04 per the issue.
- Follow-up for maintainers: once a `resolute` packagecloud component is published, add the codename to the Ubuntu `OS_IDS` list.

## Test plan

- [ ] Confirm a fresh install on Ubuntu 26.04 LTS passes the version gate and installs via the `noble` packagecloud repo.

Made with [Cursor](https://cursor.com)