### PR TITLE
Add --format json support to ps:scale

### DIFF
--- a/docs/processes/process-management.md
+++ b/docs/processes/process-management.md
@@ -4,15 +4,15 @@
 > New as of 0.3.14, Enhanced in 0.7.0
 
 ```
-ps:inspect <app>                                                  # Displays a sanitized version of docker inspect for an app
-ps:rebuild [--parallel count] [--all|<app>]                       # Rebuilds an app from source
-ps:report [<app>] [<flag>]                                        # Displays a process report for one or more apps
-ps:restart [--parallel count] [--all|<app>]  [<process-name>]     # Restart an app
-ps:restore [<app>]                                                # Start previously running apps e.g. after reboot
-ps:scale [--skip-deploy] <app> <proc>=<count> [<proc>=<count>...] # Get/Set how many instances of a given process to run
-ps:set <app> <key> <value>                                        # Set or clear a ps property for an app
-ps:start [--parallel count] [--all|<app>]                         # Start an app
-ps:stop [--parallel count] [--all|<app>]                          # Stop an app
+ps:inspect <app>                                                          # Displays a sanitized version of docker inspect for an app
+ps:rebuild [--parallel count] [--all|<app>]                               # Rebuilds an app from source
+ps:report [<app>] [<flag>]                                                # Displays a process report for one or more apps
+ps:restart [--parallel count] [--all|<app>]  [<process-name>]             # Restart an app
+ps:restore [<app>]                                                        # Start previously running apps e.g. after reboot
+ps:scale [--skip-deploy] [--format stdout|json] <app> [<proc>=<count>...] # Get/Set how many instances of a given process to run
+ps:set <app> <key> <value>                                                # Set or clear a ps property for an app
+ps:start [--parallel count] [--all|<app>]                                 # Start an app
+ps:stop [--parallel count] [--all|<app>]                                  # Stop an app
 ```
 
 ## Usage
@@ -106,6 +106,18 @@ proctype: qty
 --------: ---
 web:  1
 ```
+
+The formation can also be retrieved as JSON by using the `--format json` flag, which is useful for programmatic consumption. Each entry maps a process type to its desired quantity:
+
+```shell
+dokku ps:scale node-js-app --format json
+```
+
+```json
+[{"process_type":"web","quantity":1},{"process_type":"worker","quantity":4}]
+```
+
+When no scale has been set for the app, the JSON output is an empty array (`[]`).
 
 ### Changing process management settings
 

--- a/plugins/ps/functions.go
+++ b/plugins/ps/functions.go
@@ -1,6 +1,7 @@
 package ps
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -243,10 +244,20 @@ func restorePrep() error {
 	return nil
 }
 
-func scaleReport(appName string) error {
+func scaleReport(appName string, format string) error {
 	formations, err := getFormations(appName)
 	if err != nil {
 		return err
+	}
+
+	if format == "json" {
+		out, err := json.Marshal(formations)
+		if err != nil {
+			return err
+		}
+
+		common.Log(string(out))
+		return nil
 	}
 
 	common.LogInfo1Quiet(fmt.Sprintf("Scaling for %s", appName))

--- a/plugins/ps/src/commands/commands.go
+++ b/plugins/ps/src/commands/commands.go
@@ -23,7 +23,7 @@ Additional commands:`
     ps:report [<app>] [<flag>], Displays a process report for one or more apps
     ps:restart [--parallel count] [--all|<app>] [<process-name>], Restart an app
     ps:restore [<app>], Start previously running apps e.g. after reboot
-    ps:scale [--skip-deploy] <app> <proc>=<count> [<proc>=<count>...], Get/Set how many instances of a given process to run
+    ps:scale [--skip-deploy] [--format stdout|json] <app> [<proc>=<count>...], Get/Set how many instances of a given process to run
     ps:set <app> <key> <value>, Set or clear a ps property for an app
     ps:start [--parallel count] [--all|<app>], Start an app
     ps:stop [--parallel count] [--all|<app>], Stop an app

--- a/plugins/ps/src/subcommands/subcommands.go
+++ b/plugins/ps/src/subcommands/subcommands.go
@@ -65,10 +65,11 @@ func main() {
 	case "scale":
 		args := flag.NewFlagSet("ps:scale", flag.ExitOnError)
 		skipDeploy := args.Bool("skip-deploy", false, "--skip-deploy: skip deploy of the app")
+		format := args.String("format", "stdout", "format: [ stdout | json ]")
 		args.Parse(os.Args[2:])
 		appName := args.Arg(0)
 		_, processTuples := common.ShiftString(args.Args())
-		err = ps.CommandScale(appName, *skipDeploy, processTuples)
+		err = ps.CommandScale(appName, *skipDeploy, *format, processTuples)
 	case "set":
 		args := flag.NewFlagSet("ps:set", flag.ExitOnError)
 		global := args.Bool("global", false, "--global: set a global property")

--- a/plugins/ps/subcommands.go
+++ b/plugins/ps/subcommands.go
@@ -158,13 +158,13 @@ func CommandRetire(appName string) error {
 }
 
 // CommandScale gets or sets how many instances of a given process to run
-func CommandScale(appName string, skipDeploy bool, processTuples []string) error {
+func CommandScale(appName string, skipDeploy bool, format string, processTuples []string) error {
 	if err := common.VerifyAppName(appName); err != nil {
 		return err
 	}
 
 	if len(processTuples) == 0 {
-		return scaleReport(appName)
+		return scaleReport(appName, format)
 	}
 
 	if !canScaleApp(appName) {

--- a/tests/unit/ps-general-1.bats
+++ b/tests/unit/ps-general-1.bats
@@ -269,6 +269,42 @@ web                                                                             
   assert_output $'beat: 0\nweb:  4\nworker: 1'
 }
 
+@test "(ps:scale) --format json" {
+  run /bin/bash -c "dokku ps:scale $TEST_APP --format json"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output '[{"process_type":"web","quantity":1}]'
+
+  echo "web=4
+worker=1" >/var/lib/dokku/config/ps/$TEST_APP/scale
+
+  run /bin/bash -c "dokku ps:scale $TEST_APP --format json | jq '. | length'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "2"
+
+  run /bin/bash -c "dokku ps:scale $TEST_APP --format json | jq -r '.[] | select(.process_type==\"web\") | .quantity'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "4"
+
+  run /bin/bash -c "dokku ps:scale $TEST_APP --format json | jq -r '.[] | select(.process_type==\"worker\") | .quantity'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "1"
+
+  rm -f /var/lib/dokku/config/ps/$TEST_APP/scale
+  run /bin/bash -c "dokku ps:scale $TEST_APP --format json"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "[]"
+}
+
 @test "(ps) handle windows newlines in procfile" {
   run deploy_app python dokku@$DOKKU_DOMAIN:$TEST_APP procfile_line_endings_to_windows
   echo "output: $output"


### PR DESCRIPTION
`ps:scale <app>` printed the current formation only as a text table and accepted no `--format` flag, and the desired scale quantities were not exposed by `ps:report --format json` (which only surfaces running container counts via the `status-<proctype>` keys), so there was no structured way to retrieve an app's formation.

`ps:scale` now accepts a `--format` flag that defaults to `stdout` and can be set to `json` to emit the current formation as a JSON array of process type and quantity objects, matching the JSON support the `:report` subcommands already provide. The flag only applies when displaying the current formation and is ignored when process types are supplied for scaling. When no scale has been set for the app, the JSON output is an empty array.

Closes #8793.