### PR TITLE
Link herokuish buildpack references to buildpack management page

### DIFF
--- a/docs/deployment/builders/herokuish-buildpacks.md
+++ b/docs/deployment/builders/herokuish-buildpacks.md
@@ -185,32 +185,32 @@ See the [Procfile documentation](/docs/processes/process-management.md#procfile)
 
 ### Listing Buildpacks in Use
 
-See the [buildpack management documentation](/docs/processes/process-management.md#listing-buildpacks-in-use) for more information on how to list buildpacks in use.
+See the [buildpack management documentation](/docs/deployment/builders/buildpack-management.md#listing-buildpacks-in-use) for more information on how to list buildpacks in use.
 
 ### Adding custom buildpacks
 
-See the [buildpack management documentation](/docs/processes/process-management.md#adding-custom-buildpacks) for more information on how to add custom buildpacks.
+See the [buildpack management documentation](/docs/deployment/builders/buildpack-management.md#adding-custom-buildpacks) for more information on how to add custom buildpacks.
 
 ### Overwriting a buildpack position
 
-See the [buildpack management documentation](/docs/processes/process-management.md#overwriting-a-buildpack-position) for more information on how to overwrite a buildpack position.
+See the [buildpack management documentation](/docs/deployment/builders/buildpack-management.md#overwriting-a-buildpack-position) for more information on how to overwrite a buildpack position.
 
 ### Removing a buildpack
 
-See the [buildpack management documentation](/docs/processes/process-management.md#removing-a-buildpack) for more information on how to remove a buildpack.
+See the [buildpack management documentation](/docs/deployment/builders/buildpack-management.md#removing-a-buildpack) for more information on how to remove a buildpack.
 
 ### Clearing all buildpacks
 
-See the [buildpack management documentation](/docs/processes/process-management.md#clearing-all-buildpacks) for more information on how to clear all buildpacks.
+See the [buildpack management documentation](/docs/deployment/builders/buildpack-management.md#clearing-all-buildpacks) for more information on how to clear all buildpacks.
 
 ### Using a specific buildpack version
 
-See the [buildpack management documentation](/docs/processes/process-management.md#using-a-specific-buildpack-version) for more information on how to using a specific buildpack version
+See the [buildpack management documentation](/docs/deployment/builders/buildpack-management.md#using-a-specific-buildpack-version) for more information on how to using a specific buildpack version
 
 
 ### Displaying buildpack reports for an app
 
-See the [buildpack management documentation](/docs/processes/process-management.md#displaying-buildpack-reports-for-an-app) for more information on how to display buildpack reports for an app.
+See the [buildpack management documentation](/docs/deployment/builders/buildpack-management.md#displaying-buildpack-reports-for-an-app) for more information on how to display buildpack reports for an app.
 
 ## Properties
 

--- a/docs/template.html
+++ b/docs/template.html
@@ -144,6 +144,7 @@
             <a href="#" class="list-group-item disabled">Builders</a>
 
             <a href="/{{NAME}}/deployment/builders/builder-management/" class="list-group-item">Builder Management</a>
+            <a href="/{{NAME}}/deployment/builders/buildpack-management/" class="list-group-item">Buildpack Management</a>
             <a href="/{{NAME}}/deployment/builders/cloud-native-buildpacks/" class="list-group-item">Cloud Native Buildpacks</a>
             <a href="/{{NAME}}/deployment/builders/herokuish-buildpacks/" class="list-group-item">Herokuish Buildpacks</a>
             <a href="/{{NAME}}/deployment/builders/dockerfiles/" class="list-group-item">Dockerfile Deployment</a>


### PR DESCRIPTION
The Herokuish Buildpacks doc linked buildpack topics to anchors on the process management page that do not exist, so those links resolved to the wrong page. Point them at the corresponding sections of the buildpack management page and add that page to the sidebar so it is reachable.

Fixes #8835.