### PR TITLE
fix(scheduler-docker-local): rebuild proxy config after container rename

### DIFF
--- a/plugins/scheduler-docker-local/core-post-deploy
+++ b/plugins/scheduler-docker-local/core-post-deploy
@@ -77,6 +77,16 @@ trigger-scheduler-docker-local-core-post-deploy() {
     fi
   done
   shopt -u nullglob
+
+  # Rebuild proxy config after rename so the upstream IP is guaranteed to
+  # reflect the new container. The pre-rename rebuilds (scheduler-post-deploy-process
+  # and nginx-vhosts/core-post-deploy) call network-build-config, which inspects
+  # the running container via CONTAINER.web.N files. If ContainerIsRunning races
+  # the container's network interface coming fully online, the IP file is not
+  # updated and nginx ends up with the old container's address. When the old
+  # container shuts down, all traffic returns 502. A post-rename rebuild is
+  # immune to this race: the container is fully settled and correctly named.
+  plugn trigger proxy-build-config "$APP"
 }
 
 trigger-scheduler-docker-local-core-post-deploy "$@"


### PR DESCRIPTION
## Problem

After a `git push` deploy, nginx can end up pointing to the old container's IP, causing 502 errors once that container shuts down (after the `DOKKU_WAIT_TO_RETIRE` grace period).

The current deploy sequence:

```
=====> Triggering early nginx proxy rebuild   ← pre-rename, inside scheduler-post-deploy-process
       Reloading nginx
-----> Running post-deploy
       Reloading nginx                        ← pre-rename, inside nginx-vhosts/core-post-deploy
-----> Renaming containers                    ← rename happens after both rebuilds
       old-container  → app.web.1.retiring
       app.web.1.upcoming-XXXX → app.web.1
-----> Shutting down old containers in 60 seconds
```

Both nginx rebuilds fire before the container rename. Each calls `network-build-config`, which reads `CONTAINER.web.N`, checks `ContainerIsRunning()`, then docker-inspects the container for its IP. If that check returns false — e.g. the new container's network interface is not yet fully settled despite the healthcheck having passed — `network-build-config` silently skips the IP file update. `IP.web.1` keeps the previous container's address. nginx is (re)configured with the stale IP. When the old container shuts down, all traffic returns 502.

Observed consistently on a Dockerfile-based app using bridge networking.

## Fix

Add a `plugn trigger proxy-build-config "$APP"` call at the end of `scheduler-docker-local/core-post-deploy`, after all container renames have completed. By this point:

- The rename is done: `app.web.1` is the new container.
- `network-build-config` can inspect the container in its final, settled state.
- `IP.web.1` is written with the correct address before nginx reloads.

The two existing pre-rename rebuilds are left in place — they still provide zero-downtime cutover (nginx starts routing to the new container before the old one is signalled). This adds a third, authoritative rebuild after the rename that closes the race.

## Change

One line added to `plugins/scheduler-docker-local/core-post-deploy`:

```bash
plugn trigger proxy-build-config "$APP"
```

appended inside the function body, after the `shopt -u nullglob` that closes the rename loop.

---

> **Note:** The problem and fix described here are human-verified on a live Dokku instance. This pull request was prepared with AI assistance (Claude Code / Anthropic).
