### PR TITLE
Support per-app letsencrypt emails on k3s

### DIFF
--- a/docs/deployment/schedulers/k3s.md
+++ b/docs/deployment/schedulers/k3s.md
@@ -306,6 +306,30 @@ dokku scheduler-k3s:set --global letsencrypt-email-stag automated@dokku.sh
 
 After enabling and rebuilding, all apps with an `http:80` port mapping will have a corresponding `https:443` added and ssl will be automatically enabled. All http requests will then be redirected to https.
 
+#### Customizing the letsencrypt email per app
+
+The `letsencrypt-email-prod` and `letsencrypt-email-stag` properties can also be set per app, overriding the global value for that app. This is useful when different apps should register their certificates under different contact emails.
+
+```shell
+dokku scheduler-k3s:set node-js-app letsencrypt-email-prod team@node-js-app.com
+```
+
+The value resolves in two steps: the app's `letsencrypt-server` selects which server (`prod` or `staging`) is used, and the matching `letsencrypt-email-<server>` property is then resolved as the app-level value, falling back to the global value. Because the two emails are per-server, an app-level `letsencrypt-email-stag` only takes effect once the app's `letsencrypt-server` is set to `staging`.
+
+When an app sets its own email for the selected server, Dokku renders a namespaced cert-manager `Issuer` into the app's own release using that email instead of pointing the app at the shared global `ClusterIssuer`. Apps without an app-level email continue to use the shared `ClusterIssuer` with the global email.
+
+The default value may be set by passing an empty value for the option, which falls the app back to the global value:
+
+```shell
+dokku scheduler-k3s:set node-js-app letsencrypt-email-prod
+```
+
+The computed value in effect for an app can be inspected via the report command:
+
+```shell
+dokku scheduler-k3s:report node-js-app --scheduler-k3s-computed-letsencrypt-email-prod
+```
+
 #### Customizing the letsencrypt server
 
 The letsencrypt integration is set to the production letsencrypt server by default. This can be changed on an app-level by setting the `letsencrypt-server` property with the `scheduler-k3s:set` command
@@ -914,8 +938,8 @@ If unspecified for any task, the default reservation will be `.1` CPU and `128Mi
 | `kube-context` | global only | none | `--scheduler-k3s-global-kube-context`, `--scheduler-k3s-computed-kube-context` | Kube context name used by helm and kubectl invocations |
 | `kubeconfig-path` | global only | `/etc/rancher/k3s/k3s.yaml` | `--scheduler-k3s-global-kubeconfig-path`, `--scheduler-k3s-computed-kubeconfig-path` | Filesystem path to the kubeconfig used to talk to the cluster |
 | `kustomize-root-path` | app + global | `config/kustomize` | `--scheduler-k3s-kustomize-root-path`, `--scheduler-k3s-global-kustomize-root-path`, `--scheduler-k3s-computed-kustomize-root-path` | Path within the app to a kustomize root applied after the helm install |
-| `letsencrypt-email-prod` | global only | none | `--scheduler-k3s-global-letsencrypt-email-prod`, `--scheduler-k3s-computed-letsencrypt-email-prod` | Contact email for the production cert-manager ClusterIssuer |
-| `letsencrypt-email-stag` | global only | none | `--scheduler-k3s-global-letsencrypt-email-stag`, `--scheduler-k3s-computed-letsencrypt-email-stag` | Contact email for the staging cert-manager ClusterIssuer |
+| `letsencrypt-email-prod` | app + global | none | `--scheduler-k3s-letsencrypt-email-prod`, `--scheduler-k3s-global-letsencrypt-email-prod`, `--scheduler-k3s-computed-letsencrypt-email-prod` | Contact email for production certificates. App-level values render a per-app namespaced Issuer; otherwise the shared production ClusterIssuer is used |
+| `letsencrypt-email-stag` | app + global | none | `--scheduler-k3s-letsencrypt-email-stag`, `--scheduler-k3s-global-letsencrypt-email-stag`, `--scheduler-k3s-computed-letsencrypt-email-stag` | Contact email for staging certificates. App-level values render a per-app namespaced Issuer; otherwise the shared staging ClusterIssuer is used |
 | `letsencrypt-server` | app + global | `prod` | `--scheduler-k3s-letsencrypt-server`, `--scheduler-k3s-global-letsencrypt-server`, `--scheduler-k3s-computed-letsencrypt-server` | ACME directory (`prod` or `staging`) used for app certificates |
 | `namespace` | app + global | `default` | `--scheduler-k3s-namespace`, `--scheduler-k3s-global-namespace`, `--scheduler-k3s-computed-namespace` | Kubernetes namespace into which the app's resources are installed |
 | `network-interface` | global only | `eth0` | `--scheduler-k3s-global-network-interface`, `--scheduler-k3s-computed-network-interface` | Host network interface used by k3s |

--- a/plugins/scheduler-k3s/certificate_template_test.go
+++ b/plugins/scheduler-k3s/certificate_template_test.go
@@ -145,6 +145,25 @@ func TestCertificateTemplateUsesSharedClusterIssuerByDefault(t *testing.T) {
 	}
 }
 
+func TestCertificateTemplateRendersWithoutIssuerValues(t *testing.T) {
+	// Reproduces the deploy failure where global.issuer is absent from values.yaml
+	// (the common case, no per-app email). The chart must still render without a
+	// nil-pointer error, use the shared ClusterIssuer, and emit no Issuer document.
+	docs := renderCertificateChart(t, testCertificateValues("ClusterIssuer", "letsencrypt-prod", nil))
+
+	issuerRef := certificateIssuerRef(t, docs)
+	if issuerRef["kind"] != "ClusterIssuer" {
+		t.Fatalf("expected issuerRef.kind ClusterIssuer, got %#v", issuerRef["kind"])
+	}
+	if issuerRef["name"] != "letsencrypt-prod" {
+		t.Fatalf("expected issuerRef.name letsencrypt-prod, got %#v", issuerRef["name"])
+	}
+
+	if len(docs["issuer"]) != 0 {
+		t.Fatalf("expected no Issuer document when global.issuer is absent, got %#v", docs["issuer"])
+	}
+}
+
 func TestCertificateTemplateDefaultsKindWhenIssuerKindEmpty(t *testing.T) {
 	docs := renderCertificateChart(t, testCertificateValues("", "letsencrypt-prod", map[string]interface{}{"enabled": false}))
 

--- a/plugins/scheduler-k3s/certificate_template_test.go
+++ b/plugins/scheduler-k3s/certificate_template_test.go
@@ -1,0 +1,199 @@
+package scheduler_k3s
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/engine"
+)
+
+// renderCertificateChart renders the certificate.yaml and issuer.yaml templates
+// together and returns the parsed documents for each, keyed by template file name.
+func renderCertificateChart(t *testing.T, values map[string]interface{}) map[string][]map[string]interface{} {
+	t.Helper()
+
+	chartDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(chartDir, "templates"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	chartYAML := []byte("apiVersion: v2\nname: test\nversion: 0.0.1\n")
+	if err := os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), chartYAML, 0o644); err != nil {
+		t.Fatalf("write Chart.yaml: %v", err)
+	}
+
+	for _, name := range []string{"certificate", "issuer", "_helpers"} {
+		ext := ".yaml"
+		if name == "_helpers" {
+			ext = ".tpl"
+		}
+		tpl, err := templates.ReadFile("templates/chart/" + name + ext)
+		if err != nil {
+			t.Fatalf("read %s template: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(chartDir, "templates", name+ext), tpl, 0o644); err != nil {
+			t.Fatalf("write %s template: %v", name, err)
+		}
+	}
+
+	loaded, err := loader.Load(chartDir)
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+
+	renderValues, err := chartutil.ToRenderValues(loaded, values, chartutil.ReleaseOptions{Name: "test", Namespace: "default"}, nil)
+	if err != nil {
+		t.Fatalf("ToRenderValues: %v", err)
+	}
+
+	rendered, err := engine.Render(loaded, renderValues)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	result := map[string][]map[string]interface{}{}
+	for _, name := range []string{"certificate", "issuer"} {
+		manifest := rendered["test/templates/"+name+".yaml"]
+		var docs []map[string]interface{}
+		decoder := yaml.NewDecoder(strings.NewReader(manifest))
+		for {
+			var doc map[string]interface{}
+			if err := decoder.Decode(&doc); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				t.Fatalf("yaml decode of %s failed: %v\nrendered:\n%s", name, err, manifest)
+			}
+			if doc != nil {
+				docs = append(docs, doc)
+			}
+		}
+		result[name] = docs
+	}
+
+	return result
+}
+
+func testCertificateValues(issuerKind string, issuerName string, issuer map[string]interface{}) map[string]interface{} {
+	global := map[string]interface{}{
+		"app_name":  "myapp",
+		"namespace": "myns",
+	}
+	if issuer != nil {
+		global["issuer"] = issuer
+	}
+
+	web := map[string]interface{}{
+		"domains": []interface{}{
+			map[string]interface{}{"name": "app.example.com"},
+		},
+		"tls": map[string]interface{}{
+			"enabled":           true,
+			"use_imported_cert": false,
+			"issuer_kind":       issuerKind,
+			"issuer_name":       issuerName,
+		},
+	}
+
+	return map[string]interface{}{
+		"global": global,
+		"processes": map[string]interface{}{
+			"web": map[string]interface{}{
+				"web": web,
+			},
+		},
+	}
+}
+
+func certificateIssuerRef(t *testing.T, docs map[string][]map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	certs := docs["certificate"]
+	if len(certs) != 1 {
+		t.Fatalf("expected 1 certificate document, got %d: %#v", len(certs), certs)
+	}
+	spec, ok := certs[0]["spec"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected certificate spec, got %#v", certs[0]["spec"])
+	}
+	issuerRef, ok := spec["issuerRef"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected certificate issuerRef, got %#v", spec["issuerRef"])
+	}
+	return issuerRef
+}
+
+func TestCertificateTemplateUsesSharedClusterIssuerByDefault(t *testing.T) {
+	docs := renderCertificateChart(t, testCertificateValues("ClusterIssuer", "letsencrypt-prod", map[string]interface{}{"enabled": false}))
+
+	issuerRef := certificateIssuerRef(t, docs)
+	if issuerRef["kind"] != "ClusterIssuer" {
+		t.Fatalf("expected issuerRef.kind ClusterIssuer, got %#v", issuerRef["kind"])
+	}
+	if issuerRef["name"] != "letsencrypt-prod" {
+		t.Fatalf("expected issuerRef.name letsencrypt-prod, got %#v", issuerRef["name"])
+	}
+
+	if len(docs["issuer"]) != 0 {
+		t.Fatalf("expected no Issuer document for shared ClusterIssuer, got %#v", docs["issuer"])
+	}
+}
+
+func TestCertificateTemplateDefaultsKindWhenIssuerKindEmpty(t *testing.T) {
+	docs := renderCertificateChart(t, testCertificateValues("", "letsencrypt-prod", map[string]interface{}{"enabled": false}))
+
+	issuerRef := certificateIssuerRef(t, docs)
+	if issuerRef["kind"] != "ClusterIssuer" {
+		t.Fatalf("expected empty issuer_kind to default to ClusterIssuer, got %#v", issuerRef["kind"])
+	}
+}
+
+func TestCertificateTemplateRendersPerAppNamespacedIssuer(t *testing.T) {
+	issuer := map[string]interface{}{
+		"enabled":       true,
+		"name":          "myapp-letsencrypt-stag",
+		"email":         "app@dokku.me",
+		"server":        LetsencryptServerStag,
+		"ingress_class": "nginx",
+	}
+	docs := renderCertificateChart(t, testCertificateValues("Issuer", "myapp-letsencrypt-stag", issuer))
+
+	issuerRef := certificateIssuerRef(t, docs)
+	if issuerRef["kind"] != "Issuer" {
+		t.Fatalf("expected issuerRef.kind Issuer, got %#v", issuerRef["kind"])
+	}
+	if issuerRef["name"] != "myapp-letsencrypt-stag" {
+		t.Fatalf("expected issuerRef.name myapp-letsencrypt-stag, got %#v", issuerRef["name"])
+	}
+
+	issuers := docs["issuer"]
+	if len(issuers) != 1 {
+		t.Fatalf("expected 1 Issuer document, got %d: %#v", len(issuers), issuers)
+	}
+	if issuers[0]["kind"] != "Issuer" {
+		t.Fatalf("expected kind Issuer, got %#v", issuers[0]["kind"])
+	}
+
+	metadata, _ := issuers[0]["metadata"].(map[string]interface{})
+	if metadata["name"] != "myapp-letsencrypt-stag" {
+		t.Fatalf("expected Issuer name myapp-letsencrypt-stag, got %#v", metadata["name"])
+	}
+	if metadata["namespace"] != "myns" {
+		t.Fatalf("expected Issuer namespace myns, got %#v", metadata["namespace"])
+	}
+
+	spec, _ := issuers[0]["spec"].(map[string]interface{})
+	acme, _ := spec["acme"].(map[string]interface{})
+	if acme["email"] != "app@dokku.me" {
+		t.Fatalf("expected Issuer acme email app@dokku.me, got %#v", acme["email"])
+	}
+	if acme["server"] != LetsencryptServerStag {
+		t.Fatalf("expected Issuer acme server %q, got %#v", LetsencryptServerStag, acme["server"])
+	}
+}

--- a/plugins/scheduler-k3s/chart.go
+++ b/plugins/scheduler-k3s/chart.go
@@ -119,24 +119,26 @@ func BuildAppChart(ctx context.Context, appName, imageTag string, opts BuildOpti
 	}
 
 	tlsEnabled := false
+	issuerKind := ""
 	issuerName := ""
 	useImportedCert := false
+	appIssuer := AppIssuer{}
 
 	if importedCertExists {
 		tlsEnabled = true
 		useImportedCert = true
 	} else {
 		server := getComputedLetsencryptServer(appName)
-		letsencryptEmailStag := getGlobalLetsencryptEmailStag()
-		letsencryptEmailProd := getGlobalLetsencryptEmailProd()
 
 		switch server {
 		case "prod", "production":
-			issuerName = "letsencrypt-prod"
-			tlsEnabled = letsencryptEmailProd != ""
+			computedEmail := getComputedLetsencryptEmailProd(appName)
+			tlsEnabled = computedEmail != ""
+			issuerKind, issuerName, appIssuer = resolveLetsencryptIssuer(appName, "letsencrypt-prod", getLetsencryptEmailProd(appName), computedEmail, LetsencryptServerProd)
 		case "stag", "staging":
-			issuerName = "letsencrypt-stag"
-			tlsEnabled = letsencryptEmailStag != ""
+			computedEmail := getComputedLetsencryptEmailStag(appName)
+			tlsEnabled = computedEmail != ""
+			issuerKind, issuerName, appIssuer = resolveLetsencryptIssuer(appName, "letsencrypt-stag", getLetsencryptEmailStag(appName), computedEmail, LetsencryptServerStag)
 		case "false":
 			issuerName = ""
 			tlsEnabled = false
@@ -297,6 +299,7 @@ func BuildAppChart(ctx context.Context, appName, imageTag string, opts BuildOpti
 				Type:             imageSourceType,
 				WorkingDir:       workingDir,
 			},
+			Issuer:    appIssuer,
 			Labels:    globalLabels,
 			Namespace: namespace,
 			Network: GlobalNetwork{
@@ -421,6 +424,7 @@ func BuildAppChart(ctx context.Context, appName, imageTag string, opts BuildOpti
 				PortMaps: []ProcessPortMap{},
 				TLS: ProcessTls{
 					Enabled:         tlsEnabled,
+					IssuerKind:      issuerKind,
 					IssuerName:      issuerName,
 					UseImportedCert: useImportedCert,
 				},
@@ -489,7 +493,7 @@ func BuildAppChart(ctx context.Context, appName, imageTag string, opts BuildOpti
 
 		templateFiles := []string{"deployment", "keda-scaled-object"}
 		if processType == "web" {
-			templateFiles = append(templateFiles, "service", "certificate", "ingress", "ingress-route", "compression-middleware", "https-redirect-middleware", "keda-http-scaled-object", "keda-interceptor-proxy-service")
+			templateFiles = append(templateFiles, "service", "certificate", "issuer", "ingress", "ingress-route", "compression-middleware", "https-redirect-middleware", "keda-http-scaled-object", "keda-interceptor-proxy-service")
 		}
 		for _, templateName := range templateFiles {
 			b, err := templates.ReadFile(fmt.Sprintf("templates/chart/%s.yaml", templateName))

--- a/plugins/scheduler-k3s/functions.go
+++ b/plugins/scheduler-k3s/functions.go
@@ -309,14 +309,14 @@ func applyClusterIssuers(ctx context.Context) error {
 				Enabled:      letsencryptEmailStag != "",
 				IngressClass: getComputedIngressClass(),
 				Name:         "letsencrypt-stag",
-				Server:       "https://acme-staging-v02.api.letsencrypt.org/directory",
+				Server:       LetsencryptServerStag,
 			},
 			"letsencrypt-prod": {
 				Email:        letsencryptEmailProd,
 				Enabled:      letsencryptEmailProd != "",
 				IngressClass: getComputedIngressClass(),
 				Name:         "letsencrypt-prod",
-				Server:       "https://acme-v02.api.letsencrypt.org/directory",
+				Server:       LetsencryptServerProd,
 			},
 		},
 	}
@@ -1233,20 +1233,57 @@ func getComputedLetsencryptServer(appName string) string {
 	return letsencryptServer
 }
 
+func getLetsencryptEmailProd(appName string) string {
+	return common.PropertyGet("scheduler-k3s", appName, "letsencrypt-email-prod")
+}
+
 func getGlobalLetsencryptEmailProd() string {
 	return common.PropertyGet("scheduler-k3s", "--global", "letsencrypt-email-prod")
 }
 
-func getComputedLetsencryptEmailProd() string {
-	return getGlobalLetsencryptEmailProd()
+func getComputedLetsencryptEmailProd(appName string) string {
+	letsencryptEmail := getLetsencryptEmailProd(appName)
+	if letsencryptEmail == "" {
+		letsencryptEmail = getGlobalLetsencryptEmailProd()
+	}
+
+	return letsencryptEmail
+}
+
+func getLetsencryptEmailStag(appName string) string {
+	return common.PropertyGet("scheduler-k3s", appName, "letsencrypt-email-stag")
 }
 
 func getGlobalLetsencryptEmailStag() string {
 	return common.PropertyGet("scheduler-k3s", "--global", "letsencrypt-email-stag")
 }
 
-func getComputedLetsencryptEmailStag() string {
-	return getGlobalLetsencryptEmailStag()
+func getComputedLetsencryptEmailStag(appName string) string {
+	letsencryptEmail := getLetsencryptEmailStag(appName)
+	if letsencryptEmail == "" {
+		letsencryptEmail = getGlobalLetsencryptEmailStag()
+	}
+
+	return letsencryptEmail
+}
+
+// resolveLetsencryptIssuer determines the issuer kind and name an app's Certificate should
+// reference for the selected letsencrypt server. When the app sets its own email for that
+// server, a namespaced Issuer is rendered into the app's chart using the app's email;
+// otherwise the app references the shared global ClusterIssuer.
+func resolveLetsencryptIssuer(appName string, clusterIssuerName string, appEmail string, computedEmail string, server string) (string, string, AppIssuer) {
+	if appEmail == "" {
+		return "ClusterIssuer", clusterIssuerName, AppIssuer{}
+	}
+
+	issuerName := fmt.Sprintf("%s-%s", appName, clusterIssuerName)
+	return "Issuer", issuerName, AppIssuer{
+		Email:        computedEmail,
+		Enabled:      true,
+		IngressClass: getComputedIngressClass(),
+		Name:         issuerName,
+		Server:       server,
+	}
 }
 
 func getKustomizeDirectory(appName string) string {

--- a/plugins/scheduler-k3s/report.go
+++ b/plugins/scheduler-k3s/report.go
@@ -89,8 +89,10 @@ func ReportSingleApp(appName string, format string, infoFlag string) error {
 			"--scheduler-k3s-letsencrypt-server":              reportLetsencryptServer,
 			"--scheduler-k3s-global-letsencrypt-server":       reportGlobalLetsencryptServer,
 			"--scheduler-k3s-computed-letsencrypt-email-prod": reportComputedLetsencryptEmailProd,
+			"--scheduler-k3s-letsencrypt-email-prod":          reportLetsencryptEmailProd,
 			"--scheduler-k3s-global-letsencrypt-email-prod":   reportGlobalLetsencryptEmailProd,
 			"--scheduler-k3s-computed-letsencrypt-email-stag": reportComputedLetsencryptEmailStag,
+			"--scheduler-k3s-letsencrypt-email-stag":          reportLetsencryptEmailStag,
 			"--scheduler-k3s-global-letsencrypt-email-stag":   reportGlobalLetsencryptEmailStag,
 			"--scheduler-k3s-computed-namespace":              reportComputedNamespace,
 			"--scheduler-k3s-namespace":                       reportNamespace,
@@ -658,7 +660,11 @@ func reportGlobalLetsencryptServer(appName string) string {
 }
 
 func reportComputedLetsencryptEmailProd(appName string) string {
-	return getComputedLetsencryptEmailProd()
+	return getComputedLetsencryptEmailProd(appName)
+}
+
+func reportLetsencryptEmailProd(appName string) string {
+	return getLetsencryptEmailProd(appName)
 }
 
 func reportGlobalLetsencryptEmailProd(appName string) string {
@@ -666,7 +672,11 @@ func reportGlobalLetsencryptEmailProd(appName string) string {
 }
 
 func reportComputedLetsencryptEmailStag(appName string) string {
-	return getComputedLetsencryptEmailStag()
+	return getComputedLetsencryptEmailStag(appName)
+}
+
+func reportLetsencryptEmailStag(appName string) string {
+	return getLetsencryptEmailStag(appName)
 }
 
 func reportGlobalLetsencryptEmailStag(appName string) string {

--- a/plugins/scheduler-k3s/scheduler_k3s.go
+++ b/plugins/scheduler-k3s/scheduler_k3s.go
@@ -18,13 +18,15 @@ import (
 var (
 	// DefaultProperties is a map of all valid k3s properties with corresponding default property values
 	DefaultProperties = map[string]string{
-		"deploy-timeout":      "",
-		"letsencrypt-server":  "",
-		"kustomize-root-path": "",
-		"image-pull-secrets":  "",
-		"namespace":           "",
-		"rollback-on-failure": "",
-		"shm-size":            "",
+		"deploy-timeout":         "",
+		"letsencrypt-email-prod": "",
+		"letsencrypt-email-stag": "",
+		"letsencrypt-server":     "",
+		"kustomize-root-path":    "",
+		"image-pull-secrets":     "",
+		"namespace":              "",
+		"rollback-on-failure":    "",
+		"shm-size":               "",
 	}
 
 	// GlobalProperties is a map of all valid global k3s properties
@@ -51,6 +53,8 @@ const GlobalProcessType = "--global"
 const KubeConfigPath = "/etc/rancher/k3s/k3s.yaml"
 const DefaultKubeContext = ""
 const TriggerAuthPropertyPrefix = "trigger-auth."
+const LetsencryptServerProd = "https://acme-v02.api.letsencrypt.org/directory"
+const LetsencryptServerStag = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
 // AnnotationResourceTypes lists the kubernetes resource types that scheduler-k3s
 // supports user-provided annotations for. The order here is also the iteration order

--- a/plugins/scheduler-k3s/template.go
+++ b/plugins/scheduler-k3s/template.go
@@ -46,6 +46,7 @@ type GlobalValues struct {
 	AppName         string             `yaml:"app_name"`
 	DeploymentID    string             `yaml:"deployment_id"`
 	Image           GlobalImage        `yaml:"image"`
+	Issuer          AppIssuer          `yaml:"issuer,omitempty"`
 	Labels          ProcessLabels      `yaml:"labels,omitempty"`
 	Keda            GlobalKedaValues   `yaml:"keda"`
 	Namespace       string             `yaml:"namespace"`
@@ -343,8 +344,17 @@ func (a NameSorter) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
 type ProcessTls struct {
 	Enabled         bool   `yaml:"enabled"`
+	IssuerKind      string `yaml:"issuer_kind"`
 	IssuerName      string `yaml:"issuer_name"`
 	UseImportedCert bool   `yaml:"use_imported_cert"`
+}
+
+type AppIssuer struct {
+	Email        string `yaml:"email"`
+	Enabled      bool   `yaml:"enabled"`
+	IngressClass string `yaml:"ingress_class"`
+	Name         string `yaml:"name"`
+	Server       string `yaml:"server"`
 }
 
 type ClusterIssuer struct {

--- a/plugins/scheduler-k3s/template.go
+++ b/plugins/scheduler-k3s/template.go
@@ -46,7 +46,7 @@ type GlobalValues struct {
 	AppName         string             `yaml:"app_name"`
 	DeploymentID    string             `yaml:"deployment_id"`
 	Image           GlobalImage        `yaml:"image"`
-	Issuer          AppIssuer          `yaml:"issuer,omitempty"`
+	Issuer          AppIssuer          `yaml:"issuer"`
 	Labels          ProcessLabels      `yaml:"labels,omitempty"`
 	Keda            GlobalKedaValues   `yaml:"keda"`
 	Namespace       string             `yaml:"namespace"`

--- a/plugins/scheduler-k3s/templates/chart/certificate.yaml
+++ b/plugins/scheduler-k3s/templates/chart/certificate.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: {{ $.Values.global.namespace }}
 spec:
   issuerRef:
-    kind: ClusterIssuer
+    kind: {{ $config.web.tls.issuer_kind | default "ClusterIssuer" }}
     name: {{ $config.web.tls.issuer_name }}
   secretName: tls-{{ $.Values.global.app_name }}-{{ $processName }}
   secretTemplate:

--- a/plugins/scheduler-k3s/templates/chart/issuer.yaml
+++ b/plugins/scheduler-k3s/templates/chart/issuer.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.global.issuer.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  annotations:
+    dokku.com/managed: "true"
+  labels:
+    app.kubernetes.io/name: {{ .Values.global.issuer.name }}
+    app.kubernetes.io/part-of: {{ .Values.global.app_name }}
+  name: {{ .Values.global.issuer.name }}
+  namespace: {{ .Values.global.namespace }}
+spec:
+  acme:
+    email: {{ .Values.global.issuer.email }}
+    server: {{ .Values.global.issuer.server }}
+    privateKeySecretRef:
+      name: {{ .Values.global.issuer.name }}
+    solvers:
+    - http01:
+        ingress:
+          class: {{ .Values.global.issuer.ingress_class }}
+{{- end }}

--- a/plugins/scheduler-k3s/templates/chart/issuer.yaml
+++ b/plugins/scheduler-k3s/templates/chart/issuer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.issuer.enabled }}
+{{- if and .Values.global.issuer .Values.global.issuer.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/tests/unit/scheduler-k3s-certs-deploy-2.bats
+++ b/tests/unit/scheduler-k3s-certs-deploy-2.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+TEST_APP="rdmtestapp"
+
+setup() {
+  uninstall_k3s || true
+  global_setup
+  dokku nginx:stop
+  export KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+}
+
+teardown() {
+  global_teardown
+  dokku nginx:start
+  uninstall_k3s || true
+}
+
+@test "(scheduler-k3s:certs) app-level letsencrypt email renders a per-app namespaced Issuer" {
+  if [[ -z "$DOCKERHUB_USERNAME" ]] || [[ -z "$DOCKERHUB_TOKEN" ]]; then
+    skip "skipping due to missing docker.io credentials DOCKERHUB_USERNAME:DOCKERHUB_TOKEN"
+  fi
+
+  INGRESS_CLASS=nginx install_k3s
+
+  run /bin/bash -c "dokku apps:create $TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-k3s:set $TEST_APP letsencrypt-server staging"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-k3s:set $TEST_APP letsencrypt-email-stag app@dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "dokku domains:set $TEST_APP $TEST_APP.dokku.me"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run deploy_app python "dokku@$DOKKU_DOMAIN:$TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "sleep 30"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "kubectl get certificate ${TEST_APP}-web -n default -o jsonpath='{.spec.issuerRef.kind}'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "Issuer"
+
+  run /bin/bash -c "kubectl get certificate ${TEST_APP}-web -n default -o jsonpath='{.spec.issuerRef.name}'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "${TEST_APP}-letsencrypt-stag"
+
+  run /bin/bash -c "kubectl get issuer ${TEST_APP}-letsencrypt-stag -n default -o jsonpath='{.spec.acme.email}'"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "app@dokku.me"
+}

--- a/tests/unit/scheduler-k3s-report.bats
+++ b/tests/unit/scheduler-k3s-report.bats
@@ -123,6 +123,37 @@ assert_k3s_global_unset_set() {
   assert_output ""
 }
 
+@test "(scheduler-k3s:report) app-level letsencrypt email overrides global and falls back when unset" {
+  run /bin/bash -c "dokku apps:create $TEST_APP"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-k3s:set $TEST_APP letsencrypt-email-prod team@dokku.me"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-k3s:report $TEST_APP --format json | jq -r '.\"scheduler-k3s-letsencrypt-email-prod\"'"
+  assert_success
+  assert_output "team@dokku.me"
+
+  run /bin/bash -c "dokku scheduler-k3s:report $TEST_APP --format json | jq -r '.\"scheduler-k3s-computed-letsencrypt-email-prod\"'"
+  assert_success
+  assert_output "team@dokku.me"
+
+  run /bin/bash -c "dokku scheduler-k3s:report $TEST_APP --scheduler-k3s-letsencrypt-email-prod"
+  assert_success
+  assert_output "team@dokku.me"
+
+  run /bin/bash -c "dokku scheduler-k3s:set $TEST_APP letsencrypt-email-prod"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler-k3s:report $TEST_APP --format json | jq -r '.\"scheduler-k3s-letsencrypt-email-prod\"'"
+  assert_success
+  assert_output ""
+
+  run /bin/bash -c "dokku scheduler-k3s:report $TEST_APP --format json | jq -r '.\"scheduler-k3s-computed-letsencrypt-email-prod\"'"
+  assert_success
+  assert_output ""
+}
+
 @test "(scheduler-k3s:report --global) token masked in stdout but exposed via json or explicit flag" {
   run /bin/bash -c "dokku scheduler-k3s:set --global token"
   assert_success


### PR DESCRIPTION
The `letsencrypt-email-prod` and `letsencrypt-email-stag` properties can now be set per app in addition to globally, resolving app-level before the global value for the app's selected `letsencrypt-server`. An app that sets its own email renders a namespaced cert-manager `Issuer` using that email, while apps without an override continue to use the shared `ClusterIssuer` with the global email.