### PR TITLE
Added instructions for restoring backups on different CPU architectures.

### DIFF
--- a/docs/advanced-usage/backup-recovery.md
+++ b/docs/advanced-usage/backup-recovery.md
@@ -96,6 +96,14 @@ System administrators are highly encouraged to store persistent data in app-spec
 
 See the [persistent storage documentation](/docs/advanced-usage/persistent-storage.md) for more information on how to attach persistent storage to your app.
 
+### Restoring on a machine with a different CPU Architecture
+
+When restoring a backup on a machine that has a different CPU architecture, you will need to reinstall `basher` as it's not portable across different CPU architectures. Do so with the following command immediately after restoring your dokku configs:
+```shell
+export BASHER_PREFIX=/home/dokku/.basher
+curl -s https://raw.githubusercontent.com/basherpm/basher/master/install.sh | sudo -u dokku bash
+```
+
 ## Recovering app code
 
 In case of an emergency when your git repo and backups are completely lost, you can recover the last pushed copy from your remote Dokku server (assuming you still have the ssh key).

--- a/docs/advanced-usage/backup-recovery.md
+++ b/docs/advanced-usage/backup-recovery.md
@@ -98,10 +98,10 @@ See the [persistent storage documentation](/docs/advanced-usage/persistent-stora
 
 ### Restoring on a machine with a different CPU Architecture
 
-When restoring a backup on a machine that has a different CPU architecture, you will need to reinstall `basher` as it's not portable across different CPU architectures. Do so with the following command immediately after restoring your dokku configs:
+When restoring a backup on a machine that has a different CPU architecture, you will need to clear out the `~/.basher`  as it's not portable across different CPU architectures. Do so with the following command immediately after restoring your dokku configs:
+
 ```shell
-export BASHER_PREFIX=/home/dokku/.basher
-curl -s https://raw.githubusercontent.com/basherpm/basher/master/install.sh | sudo -u dokku bash
+rm -rf /home/dokku/.basher
 ```
 
 ## Recovering app code


### PR DESCRIPTION
I made a backup on an arm64 host and tried to restore on an amd64 host, only to realize upon getting an error about executable format when doing a dokku domains:set, that the `basher` executable was built for arm64. 

The fix for this is to reinstall basher, then everything works as expected. Added docs for this solution.