### PR TITLE
Ignore minor and patch updates for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -330,6 +330,11 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "type: dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Add ignore rules for minor and patch updates in Dependabot configuration.