### PR TITLE
Redirect app.json cron task output to host log file(s)

### DIFF
--- a/docs/processes/scheduled-cron-tasks.md
+++ b/docs/processes/scheduled-cron-tasks.md
@@ -39,6 +39,51 @@ A cron task takes the following properties:
 - `maintenance`: A boolean value that decides whether the cron task is in maintenance and therefore executable or not.
 - `schedule`: A [cron-compatible](https://en.wikipedia.org/wiki/Cron#Overview) scheduling definition upon which to run the command. Seconds are generally not supported.
 - `concurrency_policy`: A string (default: `allow`), that controls whether the cron task can be run concurrently with another invocation of itself. Valid options are `allow` (allow concurrency), `forbid` (exit the new cron task if there is an existing one), `replace` (delete any existing cron task and start the new one).
+- `logfile`: A host path to which the task's **merged** standard output and standard error are appended. Mutually exclusive with `stdout_logfile`/`stderr_logfile`.
+- `stdout_logfile`: A host path to which the task's standard output is appended.
+- `stderr_logfile`: A host path to which the task's standard error is appended.
+
+#### Redirecting task output to a log file
+
+By default a scheduled cron task produces no on-host log file - its output is only delivered to the `dokku` user's cron mail (see the `MAILTO`/`MAILFROM` settings below). To persist output to a file on the host instead, set one or more of the `logfile`, `stdout_logfile`, and `stderr_logfile` properties. Paths are on the **host** (not inside the container) and output is **appended** to them; the file is created by cron on first write, but any parent directories must already exist and be writable by the `dokku` user.
+
+Use `logfile` to send merged standard output and standard error to a single file:
+
+```json
+{
+  "cron": [
+    {
+      "command": "npm run send-email",
+      "schedule": "@daily",
+      "logfile": "/var/log/dokku/send-email.log"
+    }
+  ]
+}
+```
+
+This renders in the crontab as the equivalent of `... &>> /var/log/dokku/send-email.log`.
+
+Alternatively, redirect standard output and standard error to separate files. Either may be set independently:
+
+```json
+{
+  "cron": [
+    {
+      "command": "npm run send-email",
+      "schedule": "@daily",
+      "stdout_logfile": "/var/log/dokku/send-email.out.log",
+      "stderr_logfile": "/var/log/dokku/send-email.err.log"
+    }
+  ]
+}
+```
+
+This renders as `... >> /var/log/dokku/send-email.out.log 2>> /var/log/dokku/send-email.err.log`.
+
+> [!NOTE]
+> `logfile` cannot be combined with `stdout_logfile` or `stderr_logfile`; doing so fails validation at deploy time.
+>
+> Because the log path is interpolated directly into a crontab line executed via `/bin/bash`, each log path is validated at deploy time and must be an absolute path composed only of letters, digits, and the characters `.`, `_`, `-`, and `/`. Paths containing whitespace or shell metacharacters (such as `;`, `|`, `&`, `$`, `` ` ``, `(`, `)`, `<`, `>`, quotes, or glob characters) are rejected to prevent breaking the crontab or injecting commands.
 
 
 Zero or more cron tasks can be specified per app. Cron tasks are validated after the build artifact is created but before the app is deployed, and the cron schedule is updated during the post-deploy phase.

--- a/plugins/app-json/appjson.go
+++ b/plugins/app-json/appjson.go
@@ -115,6 +115,16 @@ type CronTask struct {
 
 	// ConcurrencyPolicy is the concurrency policy for the cron command
 	ConcurrencyPolicy string `json:"concurrency_policy"`
+
+	// LogFile is a host path to which merged stdout and stderr are appended.
+	// Mutually exclusive with StdoutLogFile/StderrLogFile.
+	LogFile string `json:"logfile,omitempty"`
+
+	// StdoutLogFile is a host path to which stdout is appended
+	StdoutLogFile string `json:"stdout_logfile,omitempty"`
+
+	// StderrLogFile is a host path to which stderr is appended
+	StderrLogFile string `json:"stderr_logfile,omitempty"`
 }
 
 // Formation is a struct that represents the scale for a process from an app.json file

--- a/plugins/cron/cron.go
+++ b/plugins/cron/cron.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -22,6 +23,24 @@ func ValidateCronCommand(command string) error {
 		return ""
 	})
 	return err
+}
+
+// cronLogPathPattern matches absolute paths composed solely of characters that
+// are safe to interpolate into a crontab shell line without quoting.
+var cronLogPathPattern = regexp.MustCompile(`^/[A-Za-z0-9._/-]+$`)
+
+// ValidateCronLogPath returns an error if the path is not an absolute path
+// composed only of a conservative safe character set. Log file paths are
+// interpolated directly into the crontab line that cron executes via
+// /bin/bash, so a path containing whitespace or shell metacharacters
+// (; | & $ ( ) < > ` newlines, quotes, globs, ...) could break the crontab
+// entry or inject arbitrary commands. Rejecting at deploy time surfaces the
+// error before the schedule is written.
+func ValidateCronLogPath(path string) error {
+	if !cronLogPathPattern.MatchString(path) {
+		return fmt.Errorf("must be an absolute path containing only letters, digits, and the characters '.', '_', '-', '/'")
+	}
+	return nil
 }
 
 var (
@@ -65,8 +84,14 @@ type CronTask struct {
 	// AltCommand is an alternate command to run
 	AltCommand string `json:"-"`
 
-	// LogFile is the log file to write to
+	// LogFile is a host path to which merged stdout and stderr are appended
 	LogFile string `json:"-"`
+
+	// StdoutLogFile is a host path to which stdout is appended
+	StdoutLogFile string `json:"-"`
+
+	// StderrLogFile is a host path to which stderr is appended
+	StderrLogFile string `json:"-"`
 
 	// AppInMaintenance is whether the app's cron is in maintenance mode
 	AppInMaintenance bool `json:"app-in-maintenance"`
@@ -80,14 +105,25 @@ type CronTask struct {
 
 // DokkuRunCommand returns the dokku run command to execute for a given cron task
 func (t CronTask) DokkuRunCommand() string {
+	base := fmt.Sprintf("dokku cron:run %s %s", t.App, t.ID)
 	if t.AltCommand != "" {
-		if t.LogFile != "" {
-			return fmt.Sprintf("%s &>> %s", t.AltCommand, t.LogFile)
-		}
-		return t.AltCommand
+		base = t.AltCommand
 	}
 
-	return fmt.Sprintf("dokku cron:run %s %s", t.App, t.ID)
+	// A merged log file appends both stdout and stderr to a single path.
+	if t.LogFile != "" {
+		return fmt.Sprintf("%s &>> %s", base, t.LogFile)
+	}
+
+	// Otherwise stdout and stderr may each be redirected independently.
+	if t.StdoutLogFile != "" {
+		base = fmt.Sprintf("%s >> %s", base, t.StdoutLogFile)
+	}
+	if t.StderrLogFile != "" {
+		base = fmt.Sprintf("%s 2>> %s", base, t.StderrLogFile)
+	}
+
+	return base
 }
 
 // FetchCronTasksInput is the input for the FetchCronTasks function
@@ -174,6 +210,40 @@ func FetchCronTasks(input FetchCronTasksInput) ([]CronTask, error) {
 			return tasks, fmt.Errorf("Invalid cron concurrency policy for app %s (schedule %s): %s", appName, c.Schedule, c.ConcurrencyPolicy)
 		}
 
+		if c.LogFile != "" && (c.StdoutLogFile != "" || c.StderrLogFile != "") {
+			if input.WarnToFailure {
+				return tasks, fmt.Errorf("Cannot set both logfile and stdout_logfile/stderr_logfile for app %s (index %d)", appName, i)
+			}
+
+			common.LogWarn(fmt.Sprintf("Cannot set both logfile and stdout_logfile/stderr_logfile for app %s (index %d)", appName, i))
+			continue
+		}
+
+		logPaths := map[string]string{
+			"logfile":        c.LogFile,
+			"stdout_logfile": c.StdoutLogFile,
+			"stderr_logfile": c.StderrLogFile,
+		}
+		invalidLogPath := false
+		for field, path := range logPaths {
+			if path == "" {
+				continue
+			}
+
+			if err := ValidateCronLogPath(path); err != nil {
+				if input.WarnToFailure {
+					return tasks, fmt.Errorf("Invalid cron %s for app %s (path %q): %s", field, appName, path, err.Error())
+				}
+
+				common.LogWarn(fmt.Sprintf("Invalid cron %s for app %s (path %q): %s", field, appName, path, err.Error()))
+				invalidLogPath = true
+				break
+			}
+		}
+		if invalidLogPath {
+			continue
+		}
+
 		tasks = append(tasks, CronTask{
 			App:               appName,
 			Command:           c.Command,
@@ -183,6 +253,9 @@ func FetchCronTasks(input FetchCronTasksInput) ([]CronTask, error) {
 			Maintenance:       isAppCronInMaintenance || maintenance,
 			AppInMaintenance:  isAppCronInMaintenance,
 			TaskInMaintenance: maintenance,
+			LogFile:           c.LogFile,
+			StdoutLogFile:     c.StdoutLogFile,
+			StderrLogFile:     c.StderrLogFile,
 		})
 	}
 

--- a/plugins/cron/cron_test.go
+++ b/plugins/cron/cron_test.go
@@ -3,6 +3,8 @@ package cron
 import (
 	"strings"
 	"testing"
+
+	appjson "github.com/dokku/dokku/plugins/app-json"
 )
 
 func TestDokkuRunCommandAppTaskDispatchesViaCronRun(t *testing.T) {
@@ -98,5 +100,204 @@ func TestDokkuRunCommandAltCommandWithLogFile(t *testing.T) {
 	want := "/usr/bin/some-internal-task &>> /var/log/dokku/internal-task.log"
 	if got != want {
 		t.Errorf("DokkuRunCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestDokkuRunCommandStdoutLogFile(t *testing.T) {
+	task := CronTask{
+		App:           "myapp",
+		ID:            "abc123",
+		StdoutLogFile: "/var/log/dokku/out.log",
+	}
+
+	got := task.DokkuRunCommand()
+	want := "dokku cron:run myapp abc123 >> /var/log/dokku/out.log"
+	if got != want {
+		t.Errorf("DokkuRunCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestDokkuRunCommandStderrLogFile(t *testing.T) {
+	task := CronTask{
+		App:           "myapp",
+		ID:            "abc123",
+		StderrLogFile: "/var/log/dokku/err.log",
+	}
+
+	got := task.DokkuRunCommand()
+	want := "dokku cron:run myapp abc123 2>> /var/log/dokku/err.log"
+	if got != want {
+		t.Errorf("DokkuRunCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestDokkuRunCommandSeparateStdoutAndStderrLogFiles(t *testing.T) {
+	task := CronTask{
+		App:           "myapp",
+		ID:            "abc123",
+		StdoutLogFile: "/var/log/dokku/out.log",
+		StderrLogFile: "/var/log/dokku/err.log",
+	}
+
+	got := task.DokkuRunCommand()
+	want := "dokku cron:run myapp abc123 >> /var/log/dokku/out.log 2>> /var/log/dokku/err.log"
+	if got != want {
+		t.Errorf("DokkuRunCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestDokkuRunCommandMergedLogFile(t *testing.T) {
+	task := CronTask{
+		App:     "myapp",
+		ID:      "abc123",
+		LogFile: "/var/log/dokku/merged.log",
+	}
+
+	got := task.DokkuRunCommand()
+	want := "dokku cron:run myapp abc123 &>> /var/log/dokku/merged.log"
+	if got != want {
+		t.Errorf("DokkuRunCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestValidateCronLogPathAcceptsSafePaths(t *testing.T) {
+	cases := []string{
+		"/var/log/dokku/app.log",
+		"/var/log/dokku/app-task_1.log",
+		"/tmp/out.log",
+	}
+	for _, path := range cases {
+		if err := ValidateCronLogPath(path); err != nil {
+			t.Errorf("ValidateCronLogPath(%q) returned error: %v", path, err)
+		}
+	}
+}
+
+func TestValidateCronLogPathRejectsUnsafePaths(t *testing.T) {
+	cases := []string{
+		"",                         // empty
+		"relative/path.log",        // not absolute
+		"/var/log/dokku/a b.log",   // whitespace
+		"/var/log/$(whoami).log",   // command substitution
+		"/var/log/x.log; rm -rf /", // command injection
+		"/var/log/x.log | cat",     // pipe
+		"/var/log/x&.log",          // ampersand
+		"/var/log/`id`.log",        // backticks
+		"/var/log/*.log",           // glob
+		"/var/log/x.log\nnewline",  // newline
+		"/var/log/\"quoted\".log",  // quote
+	}
+	for _, path := range cases {
+		if err := ValidateCronLogPath(path); err == nil {
+			t.Errorf("ValidateCronLogPath(%q) accepted an unsafe path", path)
+		}
+	}
+}
+
+func fetchTasksForCron(t *testing.T, c appjson.CronTask, warnToFailure bool) ([]CronTask, error) {
+	t.Helper()
+	t.Setenv("DOKKU_LIB_ROOT", t.TempDir())
+	return FetchCronTasks(FetchCronTasksInput{
+		AppName:       "testapp",
+		WarnToFailure: warnToFailure,
+		AppJSON: &appjson.AppJSON{
+			Cron: []appjson.CronTask{c},
+		},
+	})
+}
+
+func TestFetchCronTasksWiresSeparateLogFiles(t *testing.T) {
+	tasks, err := fetchTasksForCron(t, appjson.CronTask{
+		Command:       "npm run send-email",
+		Schedule:      "@daily",
+		StdoutLogFile: "/var/log/dokku/out.log",
+		StderrLogFile: "/var/log/dokku/err.log",
+	}, true)
+	if err != nil {
+		t.Fatalf("FetchCronTasks returned error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].StdoutLogFile != "/var/log/dokku/out.log" {
+		t.Errorf("StdoutLogFile = %q, want /var/log/dokku/out.log", tasks[0].StdoutLogFile)
+	}
+	if tasks[0].StderrLogFile != "/var/log/dokku/err.log" {
+		t.Errorf("StderrLogFile = %q, want /var/log/dokku/err.log", tasks[0].StderrLogFile)
+	}
+}
+
+func TestFetchCronTasksWiresMergedLogFile(t *testing.T) {
+	tasks, err := fetchTasksForCron(t, appjson.CronTask{
+		Command:  "npm run send-email",
+		Schedule: "@daily",
+		LogFile:  "/var/log/dokku/merged.log",
+	}, true)
+	if err != nil {
+		t.Fatalf("FetchCronTasks returned error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].LogFile != "/var/log/dokku/merged.log" {
+		t.Errorf("LogFile = %q, want /var/log/dokku/merged.log", tasks[0].LogFile)
+	}
+}
+
+func TestFetchCronTasksRejectsLogFileWithSeparateLogFiles(t *testing.T) {
+	_, err := fetchTasksForCron(t, appjson.CronTask{
+		Command:       "npm run send-email",
+		Schedule:      "@daily",
+		LogFile:       "/var/log/dokku/merged.log",
+		StdoutLogFile: "/var/log/dokku/out.log",
+	}, true)
+	if err == nil {
+		t.Fatalf("expected error for mutually exclusive log files, got nil")
+	}
+	if !strings.Contains(err.Error(), "logfile") {
+		t.Errorf("error = %q, want it to mention the mutual exclusion", err.Error())
+	}
+}
+
+func TestFetchCronTasksMutualExclusionSkipsWhenNotFailing(t *testing.T) {
+	tasks, err := fetchTasksForCron(t, appjson.CronTask{
+		Command:       "npm run send-email",
+		Schedule:      "@daily",
+		LogFile:       "/var/log/dokku/merged.log",
+		StderrLogFile: "/var/log/dokku/err.log",
+	}, false)
+	if err != nil {
+		t.Fatalf("FetchCronTasks returned error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("expected the conflicting task to be skipped, got %d tasks", len(tasks))
+	}
+}
+
+func TestFetchCronTasksRejectsUnsafeLogPath(t *testing.T) {
+	_, err := fetchTasksForCron(t, appjson.CronTask{
+		Command:       "npm run send-email",
+		Schedule:      "@daily",
+		StdoutLogFile: "/var/log/$(whoami).log",
+	}, true)
+	if err == nil {
+		t.Fatalf("expected error for unsafe log path, got nil")
+	}
+	if !strings.Contains(err.Error(), "stdout_logfile") {
+		t.Errorf("error = %q, want it to identify the offending field", err.Error())
+	}
+}
+
+func TestFetchCronTasksUnsafeLogPathSkipsWhenNotFailing(t *testing.T) {
+	tasks, err := fetchTasksForCron(t, appjson.CronTask{
+		Command:       "npm run send-email",
+		Schedule:      "@daily",
+		StderrLogFile: "/var/log/x.log; rm -rf /",
+	}, false)
+	if err != nil {
+		t.Fatalf("FetchCronTasks returned error: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("expected the invalid task to be skipped, got %d tasks", len(tasks))
 	}
 }


### PR DESCRIPTION
# Redirect app.json cron task output to host log file(s)

Fixes #8890

## What

Adds three optional per-task fields to the `app.json` `cron` schema so a
scheduled task can append its output to log file(s) on the host:

- `logfile` — merged stdout+stderr appended to one host path
- `stdout_logfile` — stdout appended to a host path
- `stderr_logfile` — stderr appended to a host path

## Why

Previously an `app.json` cron task rendered as a bare
`dokku cron:run <app> <id>` line with no output redirection — output only
reached the `dokku` user's cron mail (`MAILTO`). Users could not redirect it
themselves either: `command` is tokenized/exec'd directly and bare shell
operators are rejected at validation time. The internal/global cron path already
supported a log file (`CronTask.LogFile`, rendered `&>> <path>`); this brings the
same capability to app-defined tasks, with separate-stream and merged options.

## How

- `plugins/app-json/appjson.go`: adds `logfile`, `stdout_logfile`,
  `stderr_logfile` to the app.json `CronTask` schema.
- `plugins/cron/cron.go`:
  - `CronTask` gains `StdoutLogFile`/`StderrLogFile` (`json:"-"`) alongside the
    existing `LogFile`.
  - `DokkuRunCommand()` now appends redirection to the `dokku cron:run` branch
    as well as the existing `AltCommand` branch. Merged `LogFile` keeps its
    existing `&>> <path>` rendering (back-compat); separate streams render
    `>> <stdout>` and/or `2>> <stderr>`.
  - `FetchCronTasks()` wires the new fields through, enforces mutual exclusion of
    `logfile` with `stdout_logfile`/`stderr_logfile`, and validates every log
    path. As with the existing command/schedule validation, `WarnToFailure`
    turns violations into deploy errors; otherwise the task is skipped with a
    warning.
  - New exported `ValidateCronLogPath()` rejects anything that is not an
    absolute path made of a conservative safe character set (letters, digits,
    `. _ - /`). This is a security guard: the path is interpolated into a
    crontab line cron executes via `/bin/bash`, so whitespace or shell
    metacharacters (`; | & $ \` ( ) < >`, newlines, quotes, globs) must not reach
    it.

### Rendered crontab lines

| app.json | rendered |
|---|---|
| `logfile: /var/log/dokku/x.log` | `dokku cron:run app id &>> /var/log/dokku/x.log` |
| `stdout_logfile: /a.log` | `dokku cron:run app id >> /a.log` |
| `stderr_logfile: /b.log` | `dokku cron:run app id 2>> /b.log` |
| both separate | `dokku cron:run app id >> /a.log 2>> /b.log` |

## Tests

Added Go tests in `plugins/cron/cron_test.go` covering: stdout-only, stderr-only,
both-separate, and merged rendering; the preserved back-compat rendering of the
internal `AltCommand` + `LogFile` case; `ValidateCronLogPath` accept/reject
tables; and `FetchCronTasks` wiring, mutual-exclusion (both fail-hard and skip
modes), and unsafe-path rejection (both modes).

```
go test ./plugins/cron/... ./plugins/app-json/...   # ok
gofmt -l <changed files>                             # empty
git diff --check                                     # clean
```

## Docs

`docs/processes/scheduled-cron-tasks.md` documents the three new properties, a
JSON example each for the merged and separate-stream forms, the merge semantics,
the mutual-exclusion rule, and the path-validation restriction.

## Open question for maintainers — configuration surface

I implemented this as **`app.json` fields** because it mirrors the existing
`command`/`schedule`/`concurrency_policy` fields and the existing internal
`CronTask.LogFile` mechanism. The tradeoff is that the log path is *host* state
authored by whoever can push the repo — hence the strict `ValidateCronLogPath`
guard (the paths still can't write anywhere the `dokku` user couldn't already,
but they are repo-authored host paths).

The alternative is a **`cron:set` property** (host-operator-controlled), which
keeps host paths out of the deployable artifact but is less discoverable, not
co-located with the task, and awkward to target per-task (cron IDs are derived
from command+schedule). I'm happy to rework this as a property (or support both)
if that better matches the project's trust model — just let me know your
preference. I can also open a tracking issue first if you'd rather discuss there.

## Notes

- The existing internal-task rendering (`&>> <logfile>`) is unchanged, so the
  global/injected cron path and its test are unaffected.
- Log paths are host paths; parent directories must already exist and be
  writable by the `dokku` user. Output is appended.
