### PR TITLE
Reject scheduler mismatch at mount time

### DIFF
--- a/plugins/scheduler-k3s/storage.go
+++ b/plugins/scheduler-k3s/storage.go
@@ -285,8 +285,8 @@ func ToProcessVolumes(pairs []AppMountPair) ([]ProcessVolume, error) {
 		if pair.Entry == nil || pair.Attachment == nil {
 			continue
 		}
-		if pair.Entry.Scheduler == storage.SchedulerDockerLocal {
-			return nil, fmt.Errorf("storage entry %q is scheduler=docker-local but is mounted on a k3s app; recreate it with --scheduler k3s", pair.Entry.Name)
+		if pair.Entry.Scheduler != storage.SchedulerK3s {
+			return nil, fmt.Errorf("storage entry %q is scheduler=%s but is mounted on a k3s app; recreate it with --scheduler k3s", pair.Entry.Name, pair.Entry.Scheduler)
 		}
 		volumes = append(volumes, ProcessVolume{
 			Name:      pair.Entry.Name,

--- a/plugins/scheduler-k3s/storage_test.go
+++ b/plugins/scheduler-k3s/storage_test.go
@@ -1,0 +1,109 @@
+package scheduler_k3s
+
+import (
+	"testing"
+
+	"github.com/dokku/dokku/plugins/storage"
+)
+
+func TestToProcessVolumesRejectsDockerLocalEntry(t *testing.T) {
+	pairs := []AppMountPair{
+		{
+			Entry: &storage.Entry{
+				Name:      "demo-data",
+				Scheduler: storage.SchedulerDockerLocal,
+			},
+			Attachment: &storage.Attachment{
+				ContainerPath: "/data",
+			},
+		},
+	}
+
+	_, err := ToProcessVolumes(pairs)
+	if err == nil {
+		t.Fatal("expected error for docker-local entry, got nil")
+	}
+	expected := `storage entry "demo-data" is scheduler=docker-local but is mounted on a k3s app; recreate it with --scheduler k3s`
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestToProcessVolumesRejectsNonK3sEntry(t *testing.T) {
+	pairs := []AppMountPair{
+		{
+			Entry: &storage.Entry{
+				Name:      "demo-custom",
+				Scheduler: "nomad",
+			},
+			Attachment: &storage.Attachment{
+				ContainerPath: "/data",
+			},
+		},
+	}
+
+	_, err := ToProcessVolumes(pairs)
+	if err == nil {
+		t.Fatal("expected error for non-k3s entry, got nil")
+	}
+	expected := `storage entry "demo-custom" is scheduler=nomad but is mounted on a k3s app; recreate it with --scheduler k3s`
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestToProcessVolumesAcceptsK3sEntry(t *testing.T) {
+	pairs := []AppMountPair{
+		{
+			Entry: &storage.Entry{
+				Name:      "demo-pvc",
+				Scheduler: storage.SchedulerK3s,
+			},
+			Attachment: &storage.Attachment{
+				ContainerPath: "/app/data",
+				Subpath:       "sub",
+				Readonly:      true,
+			},
+		},
+	}
+
+	volumes, err := ToProcessVolumes(pairs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(volumes))
+	}
+	v := volumes[0]
+	if v.Name != "demo-pvc" {
+		t.Errorf("expected volume name demo-pvc, got %s", v.Name)
+	}
+	if v.MountPath != "/app/data" {
+		t.Errorf("expected mount path /app/data, got %s", v.MountPath)
+	}
+	if v.SubPath != "sub" {
+		t.Errorf("expected subpath sub, got %s", v.SubPath)
+	}
+	if !v.ReadOnly {
+		t.Errorf("expected read only true, got %v", v.ReadOnly)
+	}
+	if v.PersistentClaim == nil || v.PersistentClaim.ClaimName != "demo-pvc" {
+		t.Errorf("expected persistent claim name demo-pvc, got %+v", v.PersistentClaim)
+	}
+}
+
+func TestToProcessVolumesSkipsNilPairs(t *testing.T) {
+	pairs := []AppMountPair{
+		{Entry: nil, Attachment: nil},
+		{Entry: &storage.Entry{Name: "demo", Scheduler: storage.SchedulerK3s}, Attachment: nil},
+		{Entry: nil, Attachment: &storage.Attachment{ContainerPath: "/data"}},
+	}
+
+	volumes, err := ToProcessVolumes(pairs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(volumes) != 0 {
+		t.Fatalf("expected 0 volumes, got %d", len(volumes))
+	}
+}

--- a/plugins/storage/subcommands.go
+++ b/plugins/storage/subcommands.go
@@ -152,11 +152,16 @@ func CommandMount(input CommandMountInput) error {
 		return err
 	}
 
+	appScheduler := common.GetAppScheduler(input.AppName)
+
 	// Legacy colon form: synthesize a legacy-<hash> entry plus an
 	// attachment so storage:list (now attachment-only) sees the mount.
 	// The storage docker-args trigger emits the corresponding -v flag at
 	// deploy time, so behavior at the docker-run boundary is unchanged.
 	if strings.Contains(input.NameOrPath, ":") {
+		if appScheduler != SchedulerDockerLocal {
+			return fmt.Errorf("colon-form mounts are only supported on docker-local apps; %s is a %s app. Create a named entry with 'dokku storage:create --scheduler %s' and mount it instead", input.AppName, appScheduler, appScheduler)
+		}
 		return mountLegacyColon(input.AppName, input.NameOrPath)
 	}
 
@@ -171,6 +176,10 @@ func CommandMount(input CommandMountInput) error {
 	entry, err := LoadEntry(input.NameOrPath)
 	if err != nil {
 		return err
+	}
+
+	if entry.Scheduler != appScheduler {
+		return fmt.Errorf("storage entry %q is scheduler=%s but cannot be mounted on a %s app; recreate it with --scheduler %s", entry.Name, entry.Scheduler, appScheduler, appScheduler)
 	}
 
 	phases := input.Phases

--- a/plugins/storage/subcommands_test.go
+++ b/plugins/storage/subcommands_test.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,4 +16,61 @@ func TestResolveChownIDRejectsOutOfBoundsValues(t *testing.T) {
 		Expect(err).To(HaveOccurred(), "expected %q to be rejected", chownFlag)
 		Expect(err.Error()).To(ContainSubstring("Unsupported chown permissions"))
 	}
+}
+
+func setupTestApp(t *testing.T, appName string) {
+	t.Helper()
+	libRoot := withTempLibRoot(t)
+	dokkuRoot := t.TempDir()
+	t.Setenv("DOKKU_ROOT", dokkuRoot)
+	t.Setenv("PLUGIN_PATH", filepath.Join(libRoot, "plugins"))
+	if err := os.MkdirAll(filepath.Join(dokkuRoot, appName), 0755); err != nil {
+		t.Fatalf("mkdir app root: %v", err)
+	}
+}
+
+func TestCommandMountRejectsSchedulerMismatch(t *testing.T) {
+	RegisterTestingT(t)
+	setupTestApp(t, "demo")
+
+	Expect(SaveEntry(&Entry{
+		Name:      "demo-pvc",
+		Scheduler: SchedulerK3s,
+	})).To(Succeed())
+
+	err := CommandMount(CommandMountInput{
+		AppName:      "demo",
+		NameOrPath:   "demo-pvc",
+		ContainerDir: "/data",
+	})
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(Equal(`storage entry "demo-pvc" is scheduler=k3s but cannot be mounted on a docker-local app; recreate it with --scheduler docker-local`))
+
+	attachments, err := LoadAttachments("demo")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(attachments).To(BeEmpty())
+}
+
+func TestCommandMountAcceptsMatchingScheduler(t *testing.T) {
+	RegisterTestingT(t)
+	setupTestApp(t, "demo")
+
+	Expect(SaveEntry(&Entry{
+		Name:      "demo-data",
+		Scheduler: SchedulerDockerLocal,
+		HostPath:  "/data",
+	})).To(Succeed())
+
+	err := CommandMount(CommandMountInput{
+		AppName:      "demo",
+		NameOrPath:   "demo-data",
+		ContainerDir: "/data",
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	attachments, err := LoadAttachments("demo")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(attachments).To(HaveLen(1))
+	Expect(attachments[0].EntryName).To(Equal("demo-data"))
+	Expect(attachments[0].ContainerPath).To(Equal("/data"))
 }

--- a/plugins/storage/triggers.go
+++ b/plugins/storage/triggers.go
@@ -252,7 +252,7 @@ func TriggerDockerArgs(appName string, phase string) error {
 			return fmt.Errorf("attachment on %q references missing entry %q: %w", appName, attachment.EntryName, err)
 		}
 		if entry.Scheduler != SchedulerDockerLocal {
-			continue
+			return fmt.Errorf("storage entry %q is scheduler=%s but is mounted on a docker-local app; recreate it with --scheduler docker-local", entry.Name, entry.Scheduler)
 		}
 		flag := buildDockerVFlag(entry, attachment)
 		if flag == "" {

--- a/plugins/storage/triggers_test.go
+++ b/plugins/storage/triggers_test.go
@@ -60,3 +60,25 @@ func TestBuildDockerVFlagVolumeOptions(t *testing.T) {
 	roOpts := buildDockerVFlag(entry, &Attachment{ContainerPath: "/container", Readonly: true, VolumeOptions: "noexec,nosuid"})
 	Expect(roOpts).To(Equal("-v /host:/container:ro,noexec,nosuid"))
 }
+
+func TestTriggerDockerArgsRejectsSchedulerMismatch(t *testing.T) {
+	RegisterTestingT(t)
+	root := withTempLibRoot(t)
+
+	Expect(SaveEntry(&Entry{
+		Name:      "demo-pvc",
+		Scheduler: SchedulerK3s,
+	})).To(Succeed())
+
+	writeAttachmentsFile(t, root, "demo", []*Attachment{
+		{
+			EntryName:     "demo-pvc",
+			ContainerPath: "/data",
+			Phases:        []string{PhaseDeploy},
+		},
+	})
+
+	err := TriggerDockerArgs("demo", PhaseDeploy)
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(Equal(`storage entry "demo-pvc" is scheduler=k3s but is mounted on a docker-local app; recreate it with --scheduler docker-local`))
+}

--- a/tests/unit/storage-2.bats
+++ b/tests/unit/storage-2.bats
@@ -842,3 +842,57 @@ teardown() {
   run /bin/bash -c "dokku storage:destroy rdmtest-set-annot --destroy-host-dir --force"
   assert_success
 }
+
+@test "(storage:mount) rejects k3s storage entry on docker-local app" {
+  entry_path="$DOKKU_LIB_ROOT/data/storage-registry/entries/rdmtest-k3s-entry.json"
+  run /bin/bash -c "echo '{\"name\":\"rdmtest-k3s-entry\",\"scheduler\":\"k3s\",\"size\":\"1Gi\",\"schema_version\":1}' | sudo tee $entry_path >/dev/null"
+  assert_success
+  run /bin/bash -c "sudo chown dokku:dokku $entry_path"
+  assert_success
+
+  run /bin/bash -c "dokku storage:mount $TEST_APP rdmtest-k3s-entry --container-dir /data"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "storage entry \"rdmtest-k3s-entry\" is scheduler=k3s but cannot be mounted on a docker-local app; recreate it with --scheduler docker-local"
+
+  run /bin/bash -c "dokku storage:list $TEST_APP --format json | jq -r '.[].entry_name' | grep '^rdmtest-k3s-entry$' || true"
+  assert_output ""
+
+  run /bin/bash -c "sudo rm -f $entry_path"
+  assert_success
+}
+
+@test "(storage:mount) rejects docker-local storage entry on k3s app" {
+  run /bin/bash -c "dokku storage:create rdmtest-local-entry"
+  assert_success
+
+  run /bin/bash -c "dokku scheduler:set $TEST_APP selected k3s"
+  assert_success
+
+  run /bin/bash -c "dokku storage:mount $TEST_APP rdmtest-local-entry --container-dir /data"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "storage entry \"rdmtest-local-entry\" is scheduler=docker-local but cannot be mounted on a k3s app; recreate it with --scheduler k3s"
+
+  run /bin/bash -c "dokku scheduler:set $TEST_APP selected docker-local"
+  assert_success
+
+  run /bin/bash -c "dokku storage:destroy rdmtest-local-entry --destroy-host-dir --force"
+  assert_success
+}
+
+@test "(storage:mount) rejects colon-form mount on k3s app" {
+  run /bin/bash -c "dokku scheduler:set $TEST_APP selected k3s"
+  assert_success
+
+  run /bin/bash -c "dokku storage:mount $TEST_APP /tmp/custom-mount:/data"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "colon-form mounts are only supported on docker-local apps"
+
+  run /bin/bash -c "dokku scheduler:set $TEST_APP selected docker-local"
+  assert_success
+}


### PR DESCRIPTION
### Problem

Storage entries are global resources bound to one scheduler (`docker-local` or `k3s`), and every app runs under one effective scheduler. `dokku storage:mount <app> <entry>` never checked that the entry's scheduler matched the app's, which produced three failure modes:

1. **docker-local app with a k3s entry: silent no-op.** The mount was accepted and recorded, `storage:list` and `storage:report` kept showing it as active, but `TriggerDockerArgs` skipped the entry via `continue` at deploy time. The deploy succeeded and the container directory was left empty and unmounted. Nothing in between reported the divergence.

2. **k3s app with a docker-local entry: failure deferred to deploy.** The mount was accepted, and `ToProcessVolumes` rejected the pair only when the app was next deployed.

3. **Colon-form mount on a k3s app: accepted against documented behavior.** The docs state that the legacy `storage:mount <app> <host>:<container>` colon form is rejected on k3s apps, but `CommandMount` accepted it, synthesized a `legacy-<hash>` docker-local entry in the global registry, and the mismatch surfaced only at deploy time under the generated hash name.

### Solution

- **Validate at mount time in `CommandMount`.** Compare `entry.Scheduler` against `common.GetAppScheduler(appName)`, which resolves the same effective scheduler used at deploy (app selection, then global selection, then `docker-local`). A mismatch is rejected immediately with the entry name, both scheduler values, and the `--scheduler` flag to recreate the entry with. The check runs before any attachment is written, so a refused mount leaves no state behind.

- **Gate the colon form on docker-local apps.** When the app's effective scheduler is not `docker-local`, `CommandMount` returns an error before `mountLegacyColon` can synthesize a `legacy-<hash>` entry, and points the user at the named-entry form with the correct `--scheduler`.

- **Make the docker-local direction loud at deploy as defense in depth.** `TriggerDockerArgs` now returns an error when an attachment references a non-docker-local entry instead of silently skipping it. This only fires for stale state that predates the mount-time check (apps switched schedulers after mounting, or entries left behind by an install migrated from k3s to docker-local), and the failing trigger aborts the deploy or `dokku run`.

- **Tighten `ToProcessVolumes` in scheduler-k3s.** The check changed from rejecting only `scheduler=docker-local` to requiring `scheduler=k3s`. Entries with an empty or unknown scheduler value previously slipped through and were emitted as k3s PVC mounts; they are now rejected with the same actionable error.

- **Tests.** Go unit tests for `CommandMount`, `TriggerDockerArgs`, and `ToProcessVolumes` (happy path, both mismatch directions, unknown scheduler, nil pairs, and no attachment side effect on failure), plus bats tests in `tests/unit/storage-2.bats` covering both directions and the colon form on a k3s app.

### Note for upgraders

This is an intentional behavior change for pre-existing mismatched state: an app that already carries an attachment whose entry scheduler does not match the app's will now fail deploys and `dokku run` with a clear error instead of deploying without the volume. Pure docker-local hosts are unaffected, since k3s entries cannot exist there. The fix for affected apps is to remove the stale attachment with `dokku storage:unmount <app> <entry> --container-dir <path>` and recreate the entry with the matching scheduler.

Closes #8994