### PR TITLE
Discard the build record git:sync starts when nothing is built

### DIFF
--- a/docs/advanced-usage/builds.md
+++ b/docs/advanced-usage/builds.md
@@ -25,6 +25,8 @@ Every build is identified by a sortable base36 ULID-style id (`DOKKU_BUILD_ID`) 
 
 Output is also tagged into syslog as `dokku-<build-id>` so `journalctl -t dokku-<build-id>` continues to work. The on-disk log file is the durable source of truth and is read for `builds:output` even when journald has rotated old entries away.
 
+A run that builds nothing leaves no record behind. `git:sync` has to fetch before it can tell whether there is anything to deploy, so it opens a record up front and discards it again when it turns out there is not - a `git:sync` with no `--build` flag, or a `--build-if-changes` poll that finds the remote unchanged. Without that, an app polled on a timer would accumulate `running` records that are later reaped as spurious failures, pushing real deploys out of the retention window.
+
 ### Record schema
 
 ```json

--- a/plugins/builds/.gitignore
+++ b/plugins/builds/.gitignore
@@ -3,6 +3,7 @@
 /triggers/*
 /triggers
 /builds-generate-id
+/builds-record-discard
 /builds-record-finalize
 /builds-record-start
 /install

--- a/plugins/builds/Makefile
+++ b/plugins/builds/Makefile
@@ -1,5 +1,5 @@
 SUBCOMMANDS = subcommands/cancel subcommands/info subcommands/list subcommands/output subcommands/prune subcommands/report subcommands/set
-TRIGGERS = triggers/builds-generate-id triggers/builds-record-finalize triggers/builds-record-start triggers/install triggers/post-app-rename-setup triggers/post-delete
+TRIGGERS = triggers/builds-generate-id triggers/builds-record-discard triggers/builds-record-finalize triggers/builds-record-start triggers/install triggers/post-app-rename-setup triggers/post-delete
 BUILD = commands subcommands triggers
 PLUGIN_NAME = builds
 

--- a/plugins/builds/builds.go
+++ b/plugins/builds/builds.go
@@ -436,6 +436,30 @@ func PruneAppBuilds(appName string) error {
 	return nil
 }
 
+// DiscardBuild removes a build record and its log outright. It exists for
+// callers that start a record and then discover there was nothing to build:
+// leaving such a record at status=running means it is later reaped as a
+// spurious failure, and counts against retention in the meantime.
+//
+// It is a no-op for a record that is missing or already terminal - discarding
+// a finalized build would delete real history.
+func DiscardBuild(appName, buildID string) error {
+	b, err := ReadBuild(appName, buildID)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	if b.Status.IsTerminal() {
+		return nil
+	}
+
+	removeBuildFiles(appName, buildID)
+	return nil
+}
+
 func removeBuildFiles(appName, buildID string) {
 	if err := os.Remove(RecordPath(appName, buildID)); err != nil && !os.IsNotExist(err) {
 		common.LogWarn(fmt.Sprintf("Could not remove build record %s/%s: %s", appName, buildID, err))

--- a/plugins/builds/builds_test.go
+++ b/plugins/builds/builds_test.go
@@ -553,6 +553,72 @@ func TestRecordStartFinalizeIdempotency(t *testing.T) {
 	}
 }
 
+func TestRecordDiscardRemovesRunningRecord(t *testing.T) {
+	setupTestRoot(t)
+	app := "discard"
+	id := GenerateBuildID()
+
+	if err := TriggerBuildsRecordStart(app, id, strconv.Itoa(os.Getpid()), string(BuildSourceGitSync)); err != nil {
+		t.Fatalf("record-start: %v", err)
+	}
+	if err := os.WriteFile(LogPathFor(app, id), []byte("fetch chatter\n"), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	if err := TriggerBuildsRecordDiscard(app, id); err != nil {
+		t.Fatalf("record-discard: %v", err)
+	}
+
+	if _, err := os.Stat(RecordPath(app, id)); !os.IsNotExist(err) {
+		t.Errorf("record still present after discard, stat err = %v", err)
+	}
+	if _, err := os.Stat(LogPathFor(app, id)); !os.IsNotExist(err) {
+		t.Errorf("log still present after discard, stat err = %v", err)
+	}
+}
+
+func TestRecordDiscardLeavesTerminalRecordsAlone(t *testing.T) {
+	setupTestRoot(t)
+	app := "discard-terminal"
+	id := GenerateBuildID()
+
+	if err := TriggerBuildsRecordStart(app, id, strconv.Itoa(os.Getpid()), string(BuildSourceGitSync)); err != nil {
+		t.Fatalf("record-start: %v", err)
+	}
+	if err := TriggerBuildsRecordFinalize(app, id, "0"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+
+	if err := TriggerBuildsRecordDiscard(app, id); err != nil {
+		t.Fatalf("record-discard: %v", err)
+	}
+
+	got, err := ReadBuild(app, id)
+	if err != nil {
+		t.Fatalf("read after discard: %v", err)
+	}
+	if got.Status != BuildStatusSucceeded {
+		t.Errorf("Status = %v, want succeeded (discard must not touch finalized history)", got.Status)
+	}
+}
+
+func TestRecordDiscardMissingRecordIsNoop(t *testing.T) {
+	setupTestRoot(t)
+	if err := TriggerBuildsRecordDiscard("discard-missing", GenerateBuildID()); err != nil {
+		t.Errorf("discard of missing record = %v, want nil", err)
+	}
+}
+
+func TestRecordDiscardValidatesArguments(t *testing.T) {
+	setupTestRoot(t)
+	if err := TriggerBuildsRecordDiscard("", "abc"); err == nil {
+		t.Error("discard with empty app = nil, want error")
+	}
+	if err := TriggerBuildsRecordDiscard("app", ""); err == nil {
+		t.Error("discard with empty build id = nil, want error")
+	}
+}
+
 func TestRecordStartUnknownSourceCoercedToUnknown(t *testing.T) {
 	setupTestRoot(t)
 	app := "src"

--- a/plugins/builds/src/triggers/triggers.go
+++ b/plugins/builds/src/triggers/triggers.go
@@ -19,6 +19,10 @@ func main() {
 	switch trigger {
 	case "builds-generate-id":
 		err = builds.TriggerBuildsGenerateID()
+	case "builds-record-discard":
+		appName := flag.Arg(0)
+		buildID := flag.Arg(1)
+		err = builds.TriggerBuildsRecordDiscard(appName, buildID)
 	case "builds-record-finalize":
 		appName := flag.Arg(0)
 		buildID := flag.Arg(1)

--- a/plugins/builds/triggers.go
+++ b/plugins/builds/triggers.go
@@ -96,6 +96,23 @@ func TriggerBuildsRecordStart(appName, buildID, pidStr, sourceStr string) error 
 	return WriteBuild(b)
 }
 
+// TriggerBuildsRecordDiscard drops a record that was started before the caller
+// knew whether it would build anything - the git:sync no-op paths, which fetch
+// first and only then discover there is nothing to deploy. Records that are
+// missing or already terminal are left alone.
+//
+// Args: <app> <build-id>
+func TriggerBuildsRecordDiscard(appName, buildID string) error {
+	if appName == "" {
+		return errors.New("builds-record-discard: missing app name")
+	}
+	if buildID == "" {
+		return errors.New("builds-record-discard: missing build id")
+	}
+
+	return DiscardBuild(appName, buildID)
+}
+
 // TriggerBuildsRecordFinalize writes the terminal status onto an existing
 // build record. It is idempotent: records that are already terminal (or have
 // been overwritten by an earlier finalize) are left untouched.

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -910,6 +910,20 @@ dokku_setup_build_capture() {
   exec &> >(tee -a "$LOG" >(logger -i -t "dokku-${DOKKU_BUILD_ID}"))
 }
 
+dokku_discard_build_capture() {
+  declare desc="drop the build record started by dokku_setup_build_capture when nothing ended up being built"
+  declare APP="$1"
+  if [[ -z "$APP" ]] || [[ -z "$DOKKU_BUILD_ID" ]]; then
+    return 0
+  fi
+
+  plugn trigger builds-record-discard "$APP" "$DOKKU_BUILD_ID" || true
+  # forget the id so a later finalize does not warn about the missing record.
+  # output stays redirected: the tee keeps the now-unlinked log open until the
+  # process exits, and stdout still reaches the operator.
+  unset DOKKU_BUILD_ID DOKKU_BUILD_LOG_FILE DOKKU_BUILD_SOURCE
+}
+
 acquire_app_deploy_lock() {
   declare desc="acquire advisory lock for use in deploys"
   local APP="$1"

--- a/plugins/git/internal-functions
+++ b/plugins/git/internal-functions
@@ -299,6 +299,7 @@ cmd-git-sync() {
   elif [[ "$FLAG" == "--build-if-changes" ]]; then
     if [[ "$CURRENT_REF" == "$UPDATED_REF" ]]; then
       dokku_log_verbose "Skipping build as no changes were detected"
+      dokku_discard_build_capture "$APP"
       return
     fi
 
@@ -314,6 +315,11 @@ cmd-git-sync() {
 
     plugn trigger receive-app "$APP" "$GIT_REF"
     plugn trigger deploy-source-set "$APP" "git-sync" "${GIT_REMOTE}#${GIT_REF}"
+  else
+    # nothing was built, so the record opened before the fetch has no build to
+    # describe. Left in place it stays at status=running, is later reaped as a
+    # spurious failure, and evicts real history from the retention window.
+    dokku_discard_build_capture "$APP"
   fi
 }
 

--- a/tests/unit/git_3.bats
+++ b/tests/unit/git_3.bats
@@ -395,6 +395,59 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output_contains "$SMOKE_TEST_APP_MASTER_SHA"
+
+  # the no-op tick must not add a record of its own, and must leave the
+  # succeeded record of the build above untouched
+  run /bin/bash -c "ls $DOKKU_LIB_ROOT/data/builds/$TEST_APP/*.json 2>/dev/null | wc -l"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "1"
+
+  run /bin/bash -c "dokku builds:list $TEST_APP --format json"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains '"status":"succeeded"'
+  assert_output_not_contains '"display_status":"abandoned"'
+}
+
+@test "(git) git:sync new [no build leaves no build record]" {
+  run /bin/bash -c "rm -rf $DOKKU_LIB_ROOT/data/builds/$TEST_APP"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  # a sync with no build flag builds nothing, so it should record nothing
+  run /bin/bash -c "dokku git:sync $TEST_APP https://github.com/dokku/smoke-test-app.git"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run /bin/bash -c "ls $DOKKU_LIB_ROOT/data/builds/$TEST_APP/*.json 2>/dev/null | wc -l"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "0"
+
+  # and neither should a --build-if-changes poll that finds no changes
+  run /bin/bash -c "dokku git:sync --build-if-changes $TEST_APP https://github.com/dokku/smoke-test-app.git"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "Skipping build as no changes were detected"
+
+  run /bin/bash -c "ls $DOKKU_LIB_ROOT/data/builds/$TEST_APP/*.json 2>/dev/null | wc -l"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "0"
+
+  run /bin/bash -c "ls $DOKKU_LIB_ROOT/data/builds/$TEST_APP/*.log 2>/dev/null | wc -l"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "0"
 }
 
 @test "(git) git:sync new [--build branch]" {


### PR DESCRIPTION
Fixes #9030.

### The bug

`cmd-git-sync` calls `dokku_setup_build_capture` before the clone/fetch — it has to, because it cannot know whether there is anything to deploy until it has fetched, and because a `--build` that fails during clone should still have its output captured. But both paths that then decline to build return without ever finalizing that record:

- `dokku git:sync <app> <remote>` with no build flag: `SHOULD_BUILD` stays `false` and the function falls off the end.
- `dokku git:sync --build-if-changes <app> <remote>` when `CURRENT_REF == UPDATED_REF`: the early `return`.

`builds-record-finalize` fires from exactly two places — the deploy path in `release_and_deploy` and `release_app_deploy_lock` — and neither is reached from either of those exits. The record sits at `status: running` with a dead PID forever.

On an app on a five-minute `--build-if-changes` timer, that is 288 leaked records a day, and it does three things:

1. **They accumulate unbounded while the app is idle.** `PruneAppBuilds` only runs from `builds-record-finalize`, so nothing prunes them in the meantime — and the growth is invisible from the CLI, because `builds:list` caps output at the retention count.
2. **The next real deploy rewrites them all as failures.** `ReapAbandonedBuilds` finalizes every dead-PID `running` record as `status: failed, exit_code: -1`, which is indistinguishable on disk from a build that really failed, so `builds:list <app> --status failed` stops selecting failures. Reaping also stamps `finished_at` at the moment of reaping, so a one-second no-op is recorded with a duration of minutes and reads like a real build that ran and failed.
3. **That same deploy's finalize then prunes the real history away.** `PruneAppBuilds` keeps the newest records by `started_at`, which after an idle stretch are the no-op ticks plus the build that just finished — so the previous successful deploy's record *and* its log are deleted. At a five-minute poll and the default retention of 20, the window in which you can still read why last night's deploy failed is about 100 minutes.

A quieter fourth effect: `reportBuildStatus` takes `builds[0]`, so `dokku builds:report <app>` on an idle app shows `Build status: abandoned` however long ago it last built successfully.

### The fix

A run that builds nothing should leave no build record. This adds a `builds-record-discard` trigger that removes a record and its log, and calls it from both no-op paths in `cmd-git-sync`.

The trigger is deliberately conservative: a record that is **missing** or **already terminal** is left alone, so it can never delete real history even if a caller is wrong about having built nothing. The bash side (`dokku_discard_build_capture`) also unsets `DOKKU_BUILD_ID` so a later finalize does not warn about the now-missing record; output stays redirected — the `tee` keeps the unlinked log open until the process exits, so nothing the operator sees changes.

I kept the capture where it is rather than moving it after the ref comparison, so that a `--build` sync still captures its clone/fetch output in the build log.

### What this does not cover

A `--build` whose *clone* fails still leaks a record identically — a wrong `deploy-branch` produces one. That path exits through `dokku_log_fail`, which calls `exit` rather than returning, and `fn-git-clone` installs its own `EXIT` trap for its temp dirs, which would clobber a finalizing trap set by the caller. Fixing that properly means changing how `dokku_log_fail` unwinds, which felt out of scope here; the existing reaper still catches it, which is at least truthful in kind if not in duration. Happy to follow up separately if you'd like it in this PR.

A distinct `nothing-to-build` status would be better still — it would keep `--status failed` meaning failed and leave a trace that the poll ran — but that is a new persisted status value to thread through the schema, the display path, the filters and the docs, so I went with discard as the smaller change. Glad to switch if you'd prefer the status.

### Testing

- `go test ./...` in `plugins/builds` — four new unit tests covering discard of a running record, refusal to touch a terminal record, the missing-record no-op, and argument validation.
- Two bats assertions in `tests/unit/git_3.bats`: a new test that a plain `git:sync` and a no-change `--build-if-changes` each leave zero `.json`/`.log` records, and an extension of the existing `[--build noarg]` test asserting the no-op tick that follows a real build neither adds a record nor leaves the real one showing as abandoned.
- `shellcheck` and `shfmt -l -bn -ci -i 2 -d` clean on both changed shell files.
- The bats suite itself I could not run — no Dokku host on the machine I wrote this on (the reproduction in #9030 was on a separate VM). CI will be the first real run of those two tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
