### PR TITLE
Add dokku-generic to community plugins

### DIFF
--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -120,6 +120,7 @@ The following plugins are available and provided by Dokku maintainers.  Please f
 | [Dokku Clone](https://github.com/crisward/dokku-clone)                                            | [crisward][]          | 0.4.0+                |
 | [Dokku Copy App Config Files](https://github.com/dokku-community/dokku-supply-config)             | [josegonzalez][]      | 0.4.0+                |
 | [Dokku Require](https://github.com/crisward/dokku-require)<sup>3</sup>                            | [crisward][]          | 0.4.0+                |
+| [Generic (any Docker image)](https://github.com/meteozond/dokku-generic)                          | [meteozond][]         | 0.35.0+               |
 | [Global Certificates](https://github.com/josegonzalez/dokku-global-cert)                          | [josegonzalez][]      | 0.5.0+                |
 | [Graduate (Environment Management)](https://github.com/glassechidna/dokku-graduate)               | [benjamin-dobell][]   | 0.4.0+                |
 | [Host post-build command hook](https://github.com/baikunz/dokku-post-deploy-script)               | [baikunz][]           | 0.4.0+                |
@@ -334,3 +335,4 @@ The following plugins are no longer maintained by their developers.
 [lazyatom]: https://github.com/lazyatom
 [ollej]: https://github.com/ollej
 [ignisda]: https://github.com/IgnisDa
+[meteozond]: https://github.com/meteozond


### PR DESCRIPTION
Adds a link to my new plugin — [dokku-generic](https://github.com/meteozond/dokku-generic).

It's a plugin that lets you deploy any Docker image as a Dokku service (env/mounts/expose/link like dokku-redis, but for arbitrary images). Compatibility verified in CI against Dokku 0.35.20 / 0.36.4 / 0.37.10 / 0.38.27.